### PR TITLE
Treat GOPATH as a list of workspaces; use first workspace.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1,7 +1,11 @@
 package build
 
 import (
+	"bitbucket.org/kardianos/osext"
+	"code.google.com/p/go.exp/fsnotify"
 	"fmt"
+	"github.com/gopherjs/gopherjs/compiler"
+	"github.com/neelance/sourcemap"
 	"go/ast"
 	"go/build"
 	"go/parser"
@@ -13,11 +17,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
-	"bitbucket.org/kardianos/osext"
-	"code.google.com/p/go.exp/fsnotify"
-	"github.com/gopherjs/gopherjs/compiler"
-	"github.com/neelance/sourcemap"
 )
 
 type ImportCError struct{}
@@ -56,10 +55,7 @@ func Import(path string, mode build.ImportMode, archSuffix string) (*build.Packa
 	}
 	if _, err := os.Stat(pkg.PkgObj); os.IsNotExist(err) && strings.HasPrefix(pkg.PkgObj, build.Default.GOROOT) {
 		// fall back to GOPATH
-		// TODO: Instead of always using the first GOPATH workspace, perhaps one should be chosen more intelligently?
-		//       In this case, I think all GOPATH workspaces should be consulted, so one would need to iterate over
-		//       each one, until there's a match (or no matches at all).
-		firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0]
+		firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0] // TODO: Need to check inside all GOPATH workspaces.
 		gopathPkgObj := filepath.Join(firstGopathWorkspace, pkg.PkgObj[len(build.Default.GOROOT):])
 		if _, err := os.Stat(gopathPkgObj); err == nil {
 			pkg.PkgObj = gopathPkgObj

--- a/tool.go
+++ b/tool.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"code.google.com/p/go.tools/go/types"
 	"flag"
 	"fmt"
+	gbuild "github.com/gopherjs/gopherjs/build"
+	"github.com/gopherjs/gopherjs/compiler"
 	"go/ast"
 	"go/build"
 	"go/parser"
@@ -17,10 +20,6 @@ import (
 	"syscall"
 	"text/template"
 	"time"
-
-	"code.google.com/p/go.tools/go/types"
-	gbuild "github.com/gopherjs/gopherjs/build"
-	"github.com/gopherjs/gopherjs/compiler"
 )
 
 var currentDirectory string
@@ -137,9 +136,7 @@ func main() {
 			exitCode := handleError(func() error {
 				pkgs := installFlags.Args()
 				if len(pkgs) == 0 {
-					// TODO: Instead of always using the first GOPATH workspace, perhaps one should be chosen more intelligently?
-					//       In this case, the GOPATH workspace that contains the package source should be chosen.
-					firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0]
+					firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0] // TODO: The GOPATH workspace that contains the package source should be chosen.
 					srcDir, err := filepath.EvalSymlinks(filepath.Join(firstGopathWorkspace, "src"))
 					if err != nil {
 						return err
@@ -224,9 +221,7 @@ func main() {
 				}
 			}
 			if len(pkgs) == 0 {
-				// TODO: Instead of always using the first GOPATH workspace, perhaps one should be chosen more intelligently?
-				//       Not sure which GOPATH workspace should be chosen for this...
-				firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0]
+				firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0] // TODO: Not sure if always picking first GOPATH workspace here is the right thing.
 				srcDir, err := filepath.EvalSymlinks(filepath.Join(firstGopathWorkspace, "src"))
 				if err != nil {
 					return err


### PR DESCRIPTION
First cut at correct GOPATH handling as a list, rather than assuming it contains no more than 1 entry. It's unfinished and needs more work to correctly handle all scenarios with multiple GOPATH workspaces, but it's an improvement over the original version.
- Fixes #60.
- The behavior should be improved (fixes #60) if user has multiple GOPATH workspaces.
- The behavior should be unchanged if user has a single GOPATH workspace.
- Use `filepath.Join` instead of concatenating strings for path manipulation.
- Use `goimports` to gofmt the code, it separates 3rd party imports from standard library imports.

While this PR can be merged as is (since it fixes a real issue), I think it's better to use it as a starting point of discussion about how completely proper GOPATH handling can be achieved. I've left a few TODOs in the code comments that need to be addressed.
