### PR TITLE
use fsnotify.v0

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1,11 +1,7 @@
 package build
 
 import (
-	"bitbucket.org/kardianos/osext"
-	"code.google.com/p/go.exp/fsnotify"
 	"fmt"
-	"github.com/gopherjs/gopherjs/compiler"
-	"github.com/neelance/sourcemap"
 	"go/ast"
 	"go/build"
 	"go/parser"
@@ -17,6 +13,11 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"bitbucket.org/kardianos/osext"
+	"github.com/gopherjs/gopherjs/compiler"
+	"github.com/neelance/sourcemap"
+	"gopkg.in/fsnotify.v0"
 )
 
 type ImportCError struct{}


### PR DESCRIPTION
fsnotify is currently being maintained at:
https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.

(So I know when this is merged, ref: https://github.com/go-fsnotify/fsnotify/issues/35)
