### PR TITLE
Use new golang.org/x/... import paths.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"strings"
 
-	"code.google.com/p/go.tools/go/gcimporter"
-	"code.google.com/p/go.tools/go/types"
 	"github.com/gopherjs/gopherjs/compiler/prelude"
+	"golang.org/x/tools/go/gcimporter"
+	"golang.org/x/tools/go/types"
 )
 
 var sizes32 = &types.StdSizes{WordSize: 4, MaxAlign: 8}

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/types"
 )
 
 type expression struct {

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/go.tools/go/types"
 	"github.com/gopherjs/gopherjs/gcexporter"
+	"golang.org/x/tools/go/types"
 )
 
 type funcContext struct {

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/types"
 )
 
 type This struct {

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/types"
 )
 
 func (c *funcContext) Write(b []byte) (int, error) {

--- a/gcexporter/gcexporter.go
+++ b/gcexporter/gcexporter.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"unicode"
 
-	"code.google.com/p/go.tools/go/exact"
-	"code.google.com/p/go.tools/go/types"
+	"golang.org/x/tools/go/exact"
+	"golang.org/x/tools/go/types"
 )
 
 type exporter struct {

--- a/tool.go
+++ b/tool.go
@@ -17,12 +17,12 @@ import (
 	"text/template"
 	"time"
 
-	"code.google.com/p/go.crypto/ssh/terminal"
-	"code.google.com/p/go.tools/go/types"
 	gbuild "github.com/gopherjs/gopherjs/build"
 	"github.com/gopherjs/gopherjs/compiler"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/tools/go/types"
 )
 
 var currentDirectory string


### PR DESCRIPTION
See http://golang.org/s/go14subrepo.

Fixes the following compile errors after one updates to latest `code.google.com/p/...` packages (that use the new `golang.org/x/...` import paths internally):

```
# github.com/gopherjs/gopherjs/gcexporter
../../gopherjs/gopherjs/gcexporter/gcexporter.go:70: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".BoolVal:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:73: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".Uint64Val:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:77: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".Int64Val:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:91: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".Float64Val:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:94: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".Real:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:95: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".Imag:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
../../gopherjs/gopherjs/gcexporter/gcexporter.go:98: cannot use o.Val() (type "golang.org/x/tools/go/exact".Value) as type "code.google.com/p/go.tools/go/exact".Value in argument to "code.google.com/p/go.tools/go/exact".StringVal:
    "golang.org/x/tools/go/exact".Value does not implement "code.google.com/p/go.tools/go/exact".Value (wrong type for Kind method)
        have Kind() "golang.org/x/tools/go/exact".Kind
        want Kind() "code.google.com/p/go.tools/go/exact".Kind
```
