### PR TITLE
runtime, runtime/debug: Fix func signature, add missing stubs.

### DIFF
--- a/compiler/natives/runtime/debug/debug.go
+++ b/compiler/natives/runtime/debug/debug.go
@@ -2,6 +2,6 @@
 
 package debug
 
-func setGCPercent(int) int {
+func setGCPercent(int32) int32 {
 	return 100
 }

--- a/compiler/natives/runtime/runtime.go
+++ b/compiler/natives/runtime/runtime.go
@@ -147,9 +147,9 @@ type Func struct {
 	opaque struct{} // unexported field to disallow conversions
 }
 
-func (f *Func) Name() string {
-	return ""
-}
+func (_ *Func) Entry() uintptr                              { return 0 }
+func (_ *Func) FileLine(pc uintptr) (file string, line int) { return "", 0 }
+func (_ *Func) Name() string                                { return "" }
 
 func FuncForPC(pc uintptr) *Func {
 	return nil


### PR DESCRIPTION
- The signature for `setGCPercent(int) int` has changed between 1.3 and 1.4 to become `setGCPercent(int32) int32`.
  - 1.3: [src/pkg/runtime/debug/garbage.go#L25](https://github.com/golang/go/blob/release-branch.go1.3/src/pkg/runtime/debug/garbage.go#L25).
  - 1.4: [src/runtime/debug/stubs.go#L13](https://github.com/golang/go/blob/release-branch.go1.4/src/runtime/debug/stubs.go#L13).
- Add missing `Entry`, `FileLine` method stubs to `runtime.Func` struct. This allows valid Go code to compile.

For the new `runtime.Func` methods, I've copied your approach of returning zero values from the stub.

However, given that your `FuncForPC(pc uintptr) *Func` always returns `nil`, wouldn't it be more valid to simply do `panic()` instead, since the user should never have a non-`nil` `*runtime.Func` available to them, and calling methods of a `nil` `*runtime.Func` is not  valid? Although I suppose they could create an non-`nil` instance of `*runtime.Func` themselves somehow since it is exported...
