### PR TITLE
use top level this as global object

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -105,7 +105,7 @@ func WriteProgramCode(pkgs []*Archive, w *SourceMapFilter) error {
 		}
 	}
 
-	if _, err := w.Write([]byte("\"use strict\";\n(function() {\n\n")); err != nil {
+	if _, err := w.Write([]byte("\"use strict\";\n(function($top_level_this) {\n\n")); err != nil {
 		return err
 	}
 	if _, err := w.Write(removeWhitespace([]byte(prelude.Prelude), minify)); err != nil {
@@ -122,7 +122,7 @@ func WriteProgramCode(pkgs []*Archive, w *SourceMapFilter) error {
 		}
 	}
 
-	if _, err := w.Write([]byte("$packages[\"runtime\"].$init()();\n$go($packages[\"" + string(mainPkg.ImportPath) + "\"].$init, [], true);\n$flushConsole();\n\n})();\n")); err != nil {
+	if _, err := w.Write([]byte("$packages[\"runtime\"].$init()();\n$go($packages[\"" + string(mainPkg.ImportPath) + "\"].$init, [], true);\n$flushConsole();\n\n})(this);\n")); err != nil {
 		return err
 	}
 

--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -12,8 +12,10 @@ if (typeof window !== "undefined") { /* web page */
 } else if (typeof global !== "undefined") { /* Node.js */
   $global = global;
   $global.require = require;
+} else if (typeof $top_level_this !== "undefined") { /* Others (e.g. Nashorn) */
+  $global = $top_level_this;
 } else {
-  console.log("warning: no global object found");
+  throw new Error("warning: no global object found");
 }
 if (typeof module !== "undefined") {
   $module = module;


### PR DESCRIPTION
I want to use gopherjs for [JavaFX](http://docs.oracle.com/javase/8/javase-clienttechnologies.htm) with [Nashorn](http://www.oracle.com/technetwork/articles/java/jf14-nashorn-2126515.html) such as a following code.
[My article](http://qiita.com/tenntenn/items/e61822b265bc2b8f6c88)  explains this code.
(Sorry! This article is written in Japanese.)

* https://gist.github.com/tenntenn/f8c89022f7139a3c15bf

In Nashorn, we can get the global object from only `this` in top level.
But gopherjs cannot get top level `this`.
So I fix it.

Please review and merge my pull request.