### PR TITLE
candidate for improving the source maps

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -8,6 +8,7 @@ import (
 	"go/scanner"
 	"go/token"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -536,6 +537,7 @@ func (s *Session) WriteCommandPackage(pkg *PackageData, pkgObj string) error {
 			}
 			pos := fileSet.Position(originalPos)
 			file := pos.Filename
+
 			switch hasGopathPrefix, prefixLen := hasGopathPrefix(file, s.options.GOPATH); {
 			case hasGopathPrefix:
 				file = filepath.ToSlash(filepath.Join("/gopath", file[prefixLen:]))
@@ -543,6 +545,9 @@ func (s *Session) WriteCommandPackage(pkg *PackageData, pkgObj string) error {
 				file = filepath.ToSlash(filepath.Join("/goroot", file[len(s.options.GOROOT):]))
 			default:
 				file = filepath.Base(file)
+			}
+			if !strings.HasPrefix(file, "/goroot") && !strings.HasPrefix(file, "/gopath") {
+				log.Printf("warning: can't find %s in gopath (sourcemaps may be inaccurate)", file)
 			}
 			m.AddMapping(&sourcemap.Mapping{GeneratedLine: generatedLine, GeneratedColumn: generatedColumn, OriginalFile: file, OriginalLine: pos.Line, OriginalColumn: pos.Column})
 		}
@@ -560,7 +565,7 @@ func (s *Session) WriteCommandPackage(pkg *PackageData, pkgObj string) error {
 func hasGopathPrefix(file, gopath string) (hasGopathPrefix bool, prefixLen int) {
 	gopathWorkspaces := filepath.SplitList(gopath)
 	for _, gopathWorkspace := range gopathWorkspaces {
-		if strings.HasPrefix(file, gopathWorkspace) {
+		if _, err := os.Stat(filepath.Join(gopathWorkspace, file)); err != nil {
 			return true, len(gopathWorkspace)
 		}
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -566,7 +566,7 @@ func hasGopathPrefix(file, gopath string) (hasGopathPrefix bool, prefixLen int) 
 	gopathWorkspaces := filepath.SplitList(gopath)
 	for _, gopathWorkspace := range gopathWorkspaces {
 		if _, err := os.Stat(filepath.Join(gopathWorkspace, file)); err != nil {
-			return true, len(gopathWorkspace)
+			return true, len(filepath.Clean(gopathWorkspace))
 		}
 	}
 	return false, 0


### PR DESCRIPTION
@neelance I'm not sure if you prefer this method of determining the gopath.    There are a couple of cases this avoids: 1) if your /tmp/ is actually something /private/tmp (which it is on OS X) and 2) if you have relative (..) parts to your GOPATH.  

I also added a warning if this detects the problematic case, I don't know if you care about that.
