### PR TITLE
Revert "fixed watcher deadlock"

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -575,11 +575,5 @@ func (s *Session) WaitForChange() {
 	case err := <-s.Watcher.Errors:
 		s.options.PrintError("watcher error: %s\n", err.Error())
 	}
-
-	go func() {
-		for range s.Watcher.Events {
-			// consume, else Close() may deadlock
-		}
-	}()
 	s.Watcher.Close()
 }


### PR DESCRIPTION
Reason: broke the build

This reverts commit 5d9184372fd34ea5838d61881effc07cd4100c2a.