### PR TITLE
handle non-boolean case clauses in switch statement with empty tag

### DIFF
--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -78,6 +78,17 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 					Y:  cond,
 				})
 			}
+		} else {
+			translateCond = func(cond ast.Expr) *expression {
+				if c.p.Info.TypeOf(cond).Underlying() == types.Typ[types.Bool] {
+					return c.translateExpr(cond)
+				}
+				return c.translateExpr(&ast.BinaryExpr{
+					X:  c.newIdent("true", types.Typ[types.Bool]),
+					Op: token.EQL,
+					Y:  cond,
+				})
+			}
 		}
 		c.translateBranchingStmt(s.Body.List, true, translateCond, nil, label, c.Flattened[s])
 

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -283,3 +283,12 @@ func zero() int {
 	}()
 	panic("")
 }
+
+func TestSwitchEmptyTag(t *testing.T) {
+	var i interface{} = 0
+	switch {
+	case i:
+		t.Fail()
+	default:
+	}
+}


### PR DESCRIPTION
Fixes #204

For switch statements with no tag, we effectively just cast each case
expression to a bool. But a case expression can have type interface{},
and casting the javascript equivalent to a bool always returns true. To
fix that, this commit converts such an expression X to the expression
"true == x" before translation to javascript.