### PR TITLE
Use filepath.Join to manipulate a filepath.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -456,7 +456,7 @@ type serveCommandFileSystem struct {
 
 func (fs serveCommandFileSystem) Open(name string) (http.File, error) {
 	for _, d := range fs.dirs {
-		file, err := http.Dir(d + "/src").Open(name)
+		file, err := http.Dir(filepath.Join(d, "src")).Open(name)
 		if err == nil {
 			return file, nil
 		}


### PR DESCRIPTION
`http.Dir` expects a native filepath, so it's correct to use `filepath.Join` instead of hardcoding the filepath separator as '/'.

See https://godoc.org/net/http#Dir for details:

> While the FileSystem.Open method takes '/'-separated paths, a Dir's string value is a filename on the native file system, not a URL, so it is separated by filepath.Separator, which isn't necessarily '/'.