### PR TITLE
fix for goroutine blocking bookkeeping

### DIFF
--- a/compiler/prelude/goroutines.go
+++ b/compiler/prelude/goroutines.go
@@ -120,7 +120,7 @@ var $go = function(fun, args, direct) {
       $curGoroutine = $goroutine;
       var r = fun.apply(undefined, args);
       if (r && r.$blk !== undefined) {
-        fun = function() { r.$blk(); };
+        fun = function() { return r.$blk(); };
         args = [];
         rescheduled = true;
         return;

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -297,8 +297,8 @@ func TestNumGoroutine(t *testing.T) {
 	c <- true
 	c <- true
 	c <- true
-	if g, w := runtime.NumGoroutine(), n+1; g != w {
-		t.Errorf("runtime.NumGoroutine(): Got %d, want %d.", g, w)
+	if got, want := runtime.NumGoroutine(), n+1; got != want {
+		t.Errorf("runtime.NumGoroutine(): Got %d, want %d.", got, want)
 	}
 	c <- true
 }

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"math"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -282,4 +283,22 @@ func zero() int {
 		recover()
 	}()
 	panic("")
+}
+
+func TestNumGoroutine(t *testing.T) {
+	n := runtime.NumGoroutine()
+	c := make(chan bool)
+	go func() {
+		<-c
+		<-c
+		<-c
+		<-c
+	}()
+	c <- true
+	c <- true
+	c <- true
+	if g, w := runtime.NumGoroutine(), n+1; g != w {
+		t.Errorf("runtime.NumGoroutine(): Got %d, want %d.", g, w)
+	}
+	c <- true
 }


### PR DESCRIPTION
I imagine this problem shows up elsewhere, but the clearest
demonstration I can find is in the behavior of runtime.NumGoroutine():
The second time a goroutine blocks, and every time thereafter, it
invokes the goroutine exiting logic. This causes runtime.NumGoroutine to
underreport the number of goroutines, because the exiting logic includes
decrementing that count. In my testing, runtime.NumGoroutine was often
negative.

The fix is pretty simple. When calling the `r.$blk` closure, return its
output, which may itself be another closure.