### PR TITLE
Introduce a workaround for a XMLHttpRequest bug in Firefox.

### DIFF
--- a/compiler/natives/net/http/http.go
+++ b/compiler/natives/net/http/http.go
@@ -25,7 +25,6 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 		return nil, errors.New("net/http: XMLHttpRequest not available")
 	}
 	xhr := xhrConstructor.New()
-	xhr.Set("responseType", "arraybuffer")
 
 	if t.inflight == nil {
 		t.inflight = map[*Request]*js.Object{}
@@ -69,6 +68,7 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 	})
 
 	xhr.Call("open", req.Method, req.URL.String())
+	xhr.Set("responseType", "arraybuffer")
 	for key, values := range req.Header {
 		for _, value := range values {
 			xhr.Call("setRequestHeader", key, value)


### PR DESCRIPTION
There is a bug on Firefox that causes all requests sent via the net/http package (using the underlying XMLHttpRequest) to fail with the error message: `InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable`. The bug is caused when you try to access the responseType attribute of an XMLHttpRequest before it is open. Since I don't know when Firefox is going to fix this bug, I am proposing this simple workaround. All I did was move the line that set the responseType to be after the call to open.

The bug is described here: https://bugzilla.mozilla.org/show_bug.cgi?id=1110761. I have tested on OS X 10.10.2 and the latest version of Firefox. My fork also still works on the latest versions of Chrome and Safari.

See https://github.com/albrow/firefox-http-fail for steps to reproduce the bug.

UPDATE: According to the bug report this happens on all platforms. I updated the title to reflect that.