### PR TITLE
Fix build (provide correct args to types.NewSignature).

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -231,7 +231,7 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 
 		case token.ARROW:
 			call := &ast.CallExpr{
-				Fun:  c.newIdent("$recv", types.NewSignature(nil, nil, types.NewTuple(types.NewVar(0, nil, "", t)), types.NewTuple(types.NewVar(0, nil, "", exprType), types.NewVar(0, nil, "", types.Typ[types.Bool])), false)),
+				Fun:  c.newIdent("$recv", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", t)), types.NewTuple(types.NewVar(0, nil, "", exprType), types.NewVar(0, nil, "", types.Typ[types.Bool])), false)),
 				Args: []ast.Expr{e.X},
 			}
 			c.Blocking[call] = true

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -169,7 +169,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 	}
 	sort.Strings(importedPaths)
 	for _, impPath := range importedPaths {
-		id := c.newIdent(fmt.Sprintf(`%s.$init`, c.p.pkgVars[impPath]), types.NewSignature(nil, nil, nil, nil, false))
+		id := c.newIdent(fmt.Sprintf(`%s.$init`, c.p.pkgVars[impPath]), types.NewSignature(nil, nil, nil, false))
 		call := &ast.CallExpr{Fun: id}
 		c.Blocking[call] = true
 		c.Flattened[call] = true
@@ -312,7 +312,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 				d.DceObjectFilter = ""
 			case "init":
 				d.InitCode = c.CatchOutput(1, func() {
-					id := c.newIdent("", types.NewSignature(nil, nil, nil, nil, false))
+					id := c.newIdent("", types.NewSignature(nil, nil, nil, false))
 					c.p.Uses[id] = o
 					call := &ast.CallExpr{Fun: id}
 					if len(c.p.FuncDeclInfos[o].Blocking) != 0 {
@@ -345,7 +345,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 		if mainFunc == nil {
 			return nil, fmt.Errorf("missing main function")
 		}
-		id := c.newIdent("", types.NewSignature(nil, nil, nil, nil, false))
+		id := c.newIdent("", types.NewSignature(nil, nil, nil, false))
 		c.p.Uses[id] = mainFunc
 		call := &ast.CallExpr{Fun: id}
 		if len(c.p.FuncDeclInfos[mainFunc].Blocking) != 0 {

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -441,7 +441,7 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 	case *ast.SendStmt:
 		chanType := c.p.Types[s.Chan].Type.Underlying().(*types.Chan)
 		call := &ast.CallExpr{
-			Fun:  c.newIdent("$send", types.NewSignature(nil, nil, types.NewTuple(types.NewVar(0, nil, "", chanType), types.NewVar(0, nil, "", chanType.Elem())), nil, false)),
+			Fun:  c.newIdent("$send", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", chanType), types.NewVar(0, nil, "", chanType.Elem())), nil, false)),
 			Args: []ast.Expr{s.Chan, s.Value},
 		}
 		c.Blocking[call] = true
@@ -477,7 +477,7 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		}
 
 		selectCall := c.setType(&ast.CallExpr{
-			Fun:  c.newIdent("$select", types.NewSignature(nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.NewInterface(nil, nil))), types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)),
+			Fun:  c.newIdent("$select", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", types.NewInterface(nil, nil))), types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)),
 			Args: []ast.Expr{c.newIdent(fmt.Sprintf("[%s]", strings.Join(channels, ", ")), types.NewInterface(nil, nil))},
 		}, types.Typ[types.Int])
 		c.Blocking[selectCall] = !hasDefault


### PR DESCRIPTION
Signature for `types.NewSignature` has changed in golang/tools@44761a8f84d6444f74938c73:

```diff
-func NewSignature(scope *Scope, recv *Var, params, results *Tuple, variadic bool) *Signature {
+func NewSignature(recv *Var, params, results *Tuple, variadic bool) *Signature {
```

See commits https://github.com/golang/tools/commit/f389b292089a2cf43f61f6ff6717250d14437be4 and https://github.com/golang/tools/commit/e5c3ebe4c75c7f8d84a92853cff976756a24faf9 for similar changes.