### PR TITLE
Add --tags flag support to serve command.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -436,6 +436,7 @@ func main() {
 	var port int
 	cmdServe.Flags().IntVarP(&port, "port", "p", 8080, "HTTP port")
 	cmdServe.Run = func(cmd *cobra.Command, args []string) {
+		options.BuildTags = strings.Fields(*tags)
 		dirs := append(filepath.SplitList(build.Default.GOPATH), build.Default.GOROOT)
 		sourceFiles := http.FileServer(serveCommandFileSystem{options: options, dirs: dirs, sourceMaps: make(map[string][]byte)})
 		fmt.Printf("serving at http://localhost:%d\n", port)


### PR DESCRIPTION
Currently, only build and install commands make use of the tags flag to set custom build tags. Add this functionality to serve command, so it's possible to use custom build tags with serve.

Note that the tags flag was already added to the serve command, it was just unused:

```Go
cmdServe.Flags().AddFlag(flagTags)
```