### PR TITLE
Add initial support for Go 1.5.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz | sudo tar -xz && sudo chmod a+w go/src/path/filepath
+    - cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.5beta1.linux-amd64.tar.gz | sudo tar -xz && sudo chmod a+w go/src/path/filepath
   post:
     - npm install --global node-gyp
     - cd node-syscall && node-gyp rebuild && mkdir -p ~/.node_libraries/ && cp build/Release/syscall.node ~/.node_libraries/syscall.node

--- a/compiler/natives/runtime/pprof/pprof.go
+++ b/compiler/natives/runtime/pprof/pprof.go
@@ -33,3 +33,6 @@ func WriteHeapProfile(w io.Writer) error {
 func Lookup(name string) *Profile {
 	return nil
 }
+
+func StartTrace(w io.Writer) error { return nil }
+func StopTrace()                   {}

--- a/compiler/natives/runtime/runtime.go
+++ b/compiler/natives/runtime/runtime.go
@@ -166,3 +166,7 @@ func Stack(buf []byte, all bool) int {
 func LockOSThread() {}
 
 func UnlockOSThread() {}
+
+func Version() string {
+	return theVersion
+}

--- a/compiler/natives/time/time.go
+++ b/compiler/natives/time/time.go
@@ -3,6 +3,7 @@
 package time
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -70,4 +71,8 @@ func stopTimer(t *runtimeTimer) bool {
 	wasActive := t.active
 	t.active = false
 	return wasActive
+}
+
+func loadLocation(name string) (*Location, error) {
+	return nil, errors.New("unknown time zone " + name)
 }


### PR DESCRIPTION
- Add time.loadLocation to natives.
- Add runtime.Version to natives.
- Add pprof.StartTrace, pprof.StopTrace to natives.

These are changes I had to make to GopherJS to get it to be able to compile a few simple and medium sized Go packages, using Go version `go1.5beta1`.

I'm not very familiar with how natives works, and why it seems some funcs are provided while others are missing (I'd love to learn more about it), so this may not be entirely correct, but I hope it's helpful as an initial start. After making these changes, everything seemed to work great so far.

This should not be merged into `master` branch until Go 1.5 final version is officially released. Making this PR for visibility, to run CI, and because I can't make a PR into a non-existing branch (`master` is the only choice).