### PR TITLE
gopherjs serve: Fix precedence of served files.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -458,12 +458,12 @@ type serveCommandFileSystem struct {
 }
 
 func (fs serveCommandFileSystem) Open(name string) (http.File, error) {
-	dir, _ := path.Split(name)
+	dir, file := path.Split(name)
 	base := path.Base(dir) // base is parent folder name, which becomes the output file name.
 
-	isPkg := strings.HasSuffix(name, "/"+base+".js")
-	isMap := strings.HasSuffix(name, "/"+base+".js.map")
-	isIndex := strings.HasSuffix(name, "/index.html")
+	isPkg := file == base+".js"
+	isMap := file == base+".js.map"
+	isIndex := file == "index.html"
 
 	if isPkg || isMap || isIndex {
 		// If we're going to be serving our special files, make sure there's a Go command in this folder.
@@ -517,9 +517,9 @@ func (fs serveCommandFileSystem) Open(name string) (http.File, error) {
 	}
 
 	for _, d := range fs.dirs {
-		file, err := http.Dir(filepath.Join(d, "src")).Open(name)
+		f, err := http.Dir(filepath.Join(d, "src")).Open(name)
 		if err == nil {
-			return file, nil
+			return f, nil
 		}
 	}
 


### PR DESCRIPTION
Previously, if there was already a {base}.js file on disk (possibly as a result of running `gopherjs build` in the past), it would take higher precedence than the freshly compiled {base}.js file. Fix that by rearranging the serving precedence logic as follows:

1. {base}.js && valid Go command in folder -> compiled {base}.js
2. {base}.js.map && valid Go command in folder -> compiled {base}.js.map
3. Look in all Go workspaces (GOPATH and GOROOT)
4. index.html && valid Go command in folder -> our own stub index.html

This way, if there's an index.html file on disk, it takes higher precedence, but not {base}.js and {base}.js.map files.

Needed for https://github.com/gopherjs/gopherjs.github.io/pull/25.