### PR TITLE
Do not include _test.go files (of stdlib deps) when not building tests.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -90,9 +90,9 @@ func Import(path string, mode build.ImportMode, installSuffix string, buildTags 
 	return pkg, nil
 }
 
-// parse parses and returns all .go files for given pkg, including all transitive dependencies.
+// parse parses and returns all .go files of given pkg.
+// Standard Go library packages are augmented with files in compiler/natives folder.
 // isTest is true when package is being built for running tests.
-// Standard Go library files are augmented with files in compiler/natives folder.
 func parse(pkg *build.Package, isTest bool, fileSet *token.FileSet) ([]*ast.File, error) {
 	var files []*ast.File
 	replacedDeclNames := make(map[string]bool)

--- a/tool.go
+++ b/tool.go
@@ -297,7 +297,7 @@ func main() {
 				s := gbuild.NewSession(options)
 				tests := &testFuncs{Package: pkg}
 				collectTests := func(buildPkg *build.Package, testPkgName string, needVar *bool) error {
-					testPkg := &gbuild.PackageData{Package: buildPkg}
+					testPkg := &gbuild.PackageData{Package: buildPkg, IsTest: true}
 					if err := s.BuildPackage(testPkg); err != nil {
 						return err
 					}


### PR DESCRIPTION
Fixes #260.

Add `IsTest` bool to `PackageData` to specify if package is being build normally or for tests.

`parse` was made unexported. It was undocumented, and not used by any external packages. Unless there's a good reason to export it, it's better not to, as that keeps the API smaller and simpler, allows internal code to change more easily. For this fix, I changed signature of `parse` to accept an extra parameter.