### PR TITLE
Have more helpful unexpected panic messages.

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -527,8 +527,9 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 				c.p.dependencies[sel.Obj()] = true
 			}
 			return c.formatExpr(`$methodExpr(%s, "%s")`, c.typeName(sel.Recv()), sel.Obj().(*types.Func).Name())
+		default:
+			panic(fmt.Sprintf("unexpected sel.Kind(): %T", sel.Kind()))
 		}
-		panic("")
 
 	case *ast.CallExpr:
 		plainFun := astutil.RemoveParens(e.Fun)
@@ -682,7 +683,7 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 				return c.translateCall(e, sig, c.translateExpr(f))
 
 			default:
-				panic("")
+				panic(fmt.Sprintf("unexpected sel.Kind(): %T", sel.Kind()))
 			}
 		default:
 			return c.translateCall(e, sig, c.translateExpr(plainFun))


### PR DESCRIPTION
This would've been more helpful to have when #256 was originally reported, before it was fixed in 427a88ec9ab6ff7fcb5a27f5ec752e193e809e04 (and a few subsequent commits). But I've already written it on my branch where I looked into what it'd take to fix #256, so might as well contribute it.

It makes the code more consistent (all other panics have a meaningful message associated), and it might come in handy in 10 years when a new [selection kind](https://godoc.org/golang.org/x/tools/go/types#SelectionKind) is added.

Another note. My original code used `panic(fmt.Errorf(...))` style, but I changed it to `panic(fmt.Sprintf(...))` style for consistency with existing code. But I still think using `panic(fmt.Errorf(...))` is slightly nicer.