### PR TITLE
gopherjs serve: Allow specifying host and port via http flag.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -443,8 +443,8 @@ func main() {
 		if host, port, err := net.SplitHostPort(addr); err != nil {
 			fmt.Fprintf(os.Stderr, "invalid http flag value: %v\n", err)
 			os.Exit(2)
-		} else if host == "" || host == "0.0.0.0" { // ":port" or "0.0.0.0:port" form, all network interfaces.
-			fmt.Printf("serving on port %s on all interfaces, e.g., http://localhost:%s\n", port, port)
+		} else if host == "" || host == net.IPv4zero.String() { // ":port" or "0.0.0.0:port" form, any available addresses.
+			fmt.Printf("serving on port %s on any available addresses, e.g., http://localhost:%s\n", port, port)
 		} else { // "host:port" form, specific network interface.
 			fmt.Printf("serving at http://%s\n", addr)
 		}


### PR DESCRIPTION
Followup to #233.

Previously, gopherjs serve would print "serving at http://localhost:port" but actually bind at ":port". That means it was serving content at "localhost:port" and also any other interfaces.

This changes the `port` flag from an int (default 8080), to `http` parameter (default ":8080") that allows one to specify either just the port, or port and host to bind at. This "http" flag is common to many Go tools, including `godoc`.