### PR TITLE
gopherjs serve: Allow specifying host and port via http flag, handle port 0.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -446,7 +446,7 @@ func main() {
 			os.Exit(1)
 		}
 		if tcpAddr := ln.Addr().(*net.TCPAddr); tcpAddr.IP.Equal(net.IPv4zero) || tcpAddr.IP.Equal(net.IPv6zero) { // Any available addresses.
-			fmt.Printf("serving on port %d on any available addresses, e.g., http://localhost:%d\n", tcpAddr.Port, tcpAddr.Port)
+			fmt.Printf("serving at http://localhost:%d and on port %d of any available addresses\n", tcpAddr.Port, tcpAddr.Port)
 		} else { // Specific address.
 			fmt.Printf("serving at http://%s\n", tcpAddr)
 		}

--- a/tool.go
+++ b/tool.go
@@ -443,8 +443,8 @@ func main() {
 		if host, port, err := net.SplitHostPort(addr); err != nil {
 			fmt.Fprintf(os.Stderr, "invalid http flag value: %v\n", err)
 			os.Exit(2)
-		} else if host == "" || host == "0.0.0.0" { // ":port" or "0.0.0.0:port" form, all network interfaces.
-			fmt.Printf("serving on port %s on all interfaces, e.g., http://localhost:%s\n", port, port)
+		} else if host == "" || host == net.IPv4zero.String() { // ":port" or "0.0.0.0:port" form, any available addresses.
+			fmt.Printf("serving on port %s on any available addresses, e.g., http://localhost:%s\n", port, port)
 		} else { // "host:port" form, specific network interface.
 			fmt.Printf("serving at http://%s\n", addr)
 		}


### PR DESCRIPTION
When specified port was 0, that means for listen to "pick any available port", the output did not state which port was chosen. By printing the listener's `Addr()`, we print the actual address (host and port) being served.

Also improve handling of printing correct "serving at ..." messages when dealing with IPv6.

Resolves #265.

Closes #264 because it includes all of its commits, so if this PR is merged, that one becomes redundant. Alternatively, that one can be merged first, and this one can be rebased on top. I just made it in advance.