### PR TITLE
Use go/types in Go 1.5 standard library.

### DIFF
--- a/compiler/analysis/bool.go
+++ b/compiler/analysis/bool.go
@@ -2,16 +2,15 @@ package analysis
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/token"
-
-	"golang.org/x/tools/go/exact"
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func BoolValue(expr ast.Expr, info *types.Info) (bool, bool) {
 	v := info.Types[expr].Value
-	if v != nil && v.Kind() == exact.Bool {
-		return exact.BoolVal(v), true
+	if v != nil && v.Kind() == constant.Bool {
+		return constant.BoolVal(v), true
 	}
 	switch e := expr.(type) {
 	case *ast.BinaryExpr:

--- a/compiler/analysis/escape.go
+++ b/compiler/analysis/escape.go
@@ -3,8 +3,7 @@ package analysis
 import (
 	"go/ast"
 	"go/token"
-
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func EscapingObjects(n ast.Node, info *types.Info) map[*types.Var]bool {

--- a/compiler/analysis/info.go
+++ b/compiler/analysis/info.go
@@ -3,11 +3,10 @@ package analysis
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 
 	"github.com/gopherjs/gopherjs/compiler/astutil"
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
-
-	"golang.org/x/tools/go/types"
 )
 
 type continueStmt struct {

--- a/compiler/analysis/sideeffect.go
+++ b/compiler/analysis/sideeffect.go
@@ -3,8 +3,7 @@ package analysis
 import (
 	"go/ast"
 	"go/token"
-
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func HasSideEffect(n ast.Node, info *types.Info) bool {

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -2,8 +2,7 @@ package astutil
 
 import (
 	"go/ast"
-
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func RemoveParens(e ast.Expr) ast.Expr {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/token"
+	"go/types"
 	"io"
 	"strings"
 
 	"github.com/gopherjs/gopherjs/compiler/prelude"
 	"golang.org/x/tools/go/importer"
-	"golang.org/x/tools/go/types"
 )
 
 var sizes32 = &types.StdSizes{WordSize: 4, MaxAlign: 8}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/gopherjs/gopherjs/compiler/prelude"
-	"golang.org/x/tools/go/importer"
+	"github.com/gopherjs/gopherjs/third_party/importer"
 )
 
 var sizes32 = &types.StdSizes{WordSize: 4, MaxAlign: 8}

--- a/compiler/filter/incdecstmt.go
+++ b/compiler/filter/incdecstmt.go
@@ -2,12 +2,11 @@ package filter
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/token"
+	"go/types"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
-
-	"golang.org/x/tools/go/exact"
-	"golang.org/x/tools/go/types"
 )
 
 func IncDecStmt(stmt ast.Stmt, info *analysis.Info) ast.Stmt {
@@ -30,7 +29,7 @@ func IncDecStmt(stmt ast.Stmt, info *analysis.Info) ast.Stmt {
 		}
 
 		one := &ast.BasicLit{Kind: token.INT}
-		info.Types[one] = types.TypeAndValue{Type: t, Value: exact.MakeInt64(1)}
+		info.Types[one] = types.TypeAndValue{Type: t, Value: constant.MakeInt64(1)}
 
 		return &ast.AssignStmt{
 			Lhs: []ast.Expr{s.X},

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
-	"golang.org/x/tools/go/importer"
+	"github.com/gopherjs/gopherjs/third_party/importer"
 	"golang.org/x/tools/go/types/typeutil"
 )
 

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 	"strings"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
 	"golang.org/x/tools/go/importer"
-	"golang.org/x/tools/go/types"
 	"golang.org/x/tools/go/types/typeutil"
 )
 

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -3,16 +3,15 @@ package compiler
 import (
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/token"
+	"go/types"
 	"strings"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
 	"github.com/gopherjs/gopherjs/compiler/astutil"
 	"github.com/gopherjs/gopherjs/compiler/filter"
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
-
-	"golang.org/x/tools/go/exact"
-	"golang.org/x/tools/go/types"
 )
 
 type this struct {
@@ -71,7 +70,7 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		tag := s.Tag
 		if tag == nil {
 			tag = ast.NewIdent("true")
-			c.p.Types[tag] = types.TypeAndValue{Type: types.Typ[types.Bool], Value: exact.MakeBool(true)}
+			c.p.Types[tag] = types.TypeAndValue{Type: types.Typ[types.Bool], Value: constant.MakeBool(true)}
 		}
 
 		if c.p.Types[tag].Value == nil {
@@ -455,7 +454,7 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 				panic(fmt.Sprintf("unhandled: %T", comm))
 			}
 			indexLit := &ast.BasicLit{Kind: token.INT}
-			c.p.Types[indexLit] = types.TypeAndValue{Type: types.Typ[types.Int], Value: exact.MakeInt64(int64(i))}
+			c.p.Types[indexLit] = types.TypeAndValue{Type: types.Typ[types.Int], Value: constant.MakeInt64(int64(i))}
 			caseClauses = append(caseClauses, &ast.CaseClause{
 				List: []ast.Expr{indexLit},
 				Body: clause.Body,

--- a/compiler/typesutil/typesutil.go
+++ b/compiler/typesutil/typesutil.go
@@ -1,6 +1,6 @@
 package typesutil
 
-import "golang.org/x/tools/go/types"
+import "go/types"
 
 func IsJsPackage(pkg *types.Package) bool {
 	return pkg != nil && pkg.Path() == "github.com/gopherjs/gopherjs/js"

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -5,7 +5,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/token"
+	"go/types"
 	"net/url"
 	"sort"
 	"strconv"
@@ -13,9 +15,6 @@ import (
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
-
-	"golang.org/x/tools/go/exact"
-	"golang.org/x/tools/go/types"
 )
 
 func (c *funcContext) Write(b []byte) (int, error) {
@@ -173,11 +172,11 @@ func (c *funcContext) zeroValue(ty types.Type) ast.Expr {
 	case *types.Basic:
 		switch {
 		case isBoolean(t):
-			return c.newConst(ty, exact.MakeBool(false))
+			return c.newConst(ty, constant.MakeBool(false))
 		case isNumeric(t):
-			return c.newConst(ty, exact.MakeInt64(0))
+			return c.newConst(ty, constant.MakeInt64(0))
 		case isString(t):
-			return c.newConst(ty, exact.MakeString(""))
+			return c.newConst(ty, constant.MakeString(""))
 		case t.Kind() == types.UnsafePointer:
 			// fall through to "nil"
 		case t.Kind() == types.UntypedNil:
@@ -197,7 +196,7 @@ func (c *funcContext) zeroValue(ty types.Type) ast.Expr {
 	return id
 }
 
-func (c *funcContext) newConst(t types.Type, value exact.Value) ast.Expr {
+func (c *funcContext) newConst(t types.Type, value constant.Value) ast.Expr {
 	id := &ast.Ident{}
 	c.p.Types[id] = types.TypeAndValue{Type: t, Value: value}
 	return id

--- a/third_party/importer/export.go
+++ b/third_party/importer/export.go
@@ -1,0 +1,461 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package importer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strings"
+)
+
+// debugging support
+const (
+	debug = false // emit debugging data
+	trace = false // print emitted data
+)
+
+// format returns a byte indicating the low-level encoding/decoding format
+// (debug vs product).
+func format() byte {
+	if debug {
+		return 'd'
+	}
+	return 'p'
+}
+
+// ExportData serializes the interface (exported package objects)
+// of package pkg and returns the corresponding data. The export
+// format is described elsewhere (TODO).
+func ExportData(pkg *types.Package) []byte {
+	p := exporter{
+		data:     append([]byte(magic), format()),
+		pkgIndex: make(map[*types.Package]int),
+		typIndex: make(map[types.Type]int),
+	}
+
+	// populate typIndex with predeclared types
+	for _, t := range predeclared {
+		p.typIndex[t] = len(p.typIndex)
+	}
+
+	if trace {
+		p.tracef("export %s\n", pkg.Name())
+		defer p.tracef("\n")
+	}
+
+	p.string(version)
+
+	p.pkg(pkg)
+
+	// collect exported objects from package scope
+	var list []types.Object
+	scope := pkg.Scope()
+	for _, name := range scope.Names() {
+		if exported(name) {
+			list = append(list, scope.Lookup(name))
+		}
+	}
+
+	// write objects
+	p.int(len(list))
+	for _, obj := range list {
+		p.obj(obj)
+	}
+
+	return p.data
+}
+
+type exporter struct {
+	data     []byte
+	pkgIndex map[*types.Package]int
+	typIndex map[types.Type]int
+
+	// tracing support
+	indent string
+}
+
+func (p *exporter) pkg(pkg *types.Package) {
+	if trace {
+		p.tracef("package { ")
+		defer p.tracef("} ")
+	}
+
+	if pkg == nil {
+		panic("unexpected nil pkg")
+	}
+
+	// if the package was seen before, write its index (>= 0)
+	if i, ok := p.pkgIndex[pkg]; ok {
+		p.int(i)
+		return
+	}
+	p.pkgIndex[pkg] = len(p.pkgIndex)
+
+	// otherwise, write the package tag (< 0) and package data
+	p.int(packageTag)
+	p.string(pkg.Name())
+	p.string(pkg.Path())
+}
+
+func (p *exporter) obj(obj types.Object) {
+	if trace {
+		p.tracef("object %s {\n", obj.Name())
+		defer p.tracef("}\n")
+	}
+
+	switch obj := obj.(type) {
+	case *types.Const:
+		p.int(constTag)
+		p.string(obj.Name())
+		p.typ(obj.Type())
+		p.value(obj.Val())
+	case *types.TypeName:
+		p.int(typeTag)
+		// name is written by corresponding named type
+		p.typ(obj.Type().(*types.Named))
+	case *types.Var:
+		p.int(varTag)
+		p.string(obj.Name())
+		p.typ(obj.Type())
+	case *types.Func:
+		p.int(funcTag)
+		p.string(obj.Name())
+		p.typ(obj.Type())
+	default:
+		panic(fmt.Sprintf("unexpected object type %T", obj))
+	}
+}
+
+func (p *exporter) value(x constant.Value) {
+	if trace {
+		p.tracef("value { ")
+		defer p.tracef("} ")
+	}
+
+	switch kind := x.Kind(); kind {
+	case constant.Bool:
+		tag := falseTag
+		if constant.BoolVal(x) {
+			tag = trueTag
+		}
+		p.int(tag)
+	case constant.Int:
+		if i, ok := constant.Int64Val(x); ok {
+			p.int(int64Tag)
+			p.int64(i)
+			return
+		}
+		p.int(floatTag)
+		p.float(x)
+	case constant.Float:
+		p.int(fractionTag)
+		p.fraction(x)
+	case constant.Complex:
+		p.int(complexTag)
+		p.fraction(constant.Real(x))
+		p.fraction(constant.Imag(x))
+	case constant.String:
+		p.int(stringTag)
+		p.string(constant.StringVal(x))
+	default:
+		panic(fmt.Sprintf("unexpected value kind %d", kind))
+	}
+}
+
+func (p *exporter) float(x constant.Value) {
+	sign := constant.Sign(x)
+	p.int(sign)
+	if sign == 0 {
+		return
+	}
+
+	p.ufloat(x)
+}
+
+func (p *exporter) fraction(x constant.Value) {
+	sign := constant.Sign(x)
+	p.int(sign)
+	if sign == 0 {
+		return
+	}
+
+	p.ufloat(constant.Num(x))
+	p.ufloat(constant.Denom(x))
+}
+
+// ufloat writes abs(x) in form of a binary exponent
+// followed by its mantissa bytes; x must be != 0.
+func (p *exporter) ufloat(x constant.Value) {
+	mant := constant.Bytes(x)
+	exp8 := -1
+	for i, b := range mant {
+		if b != 0 {
+			exp8 = i
+			break
+		}
+	}
+	if exp8 < 0 {
+		panic(fmt.Sprintf("%s has no mantissa", x))
+	}
+	p.int(exp8 * 8)
+	p.bytes(mant[exp8:])
+}
+
+func (p *exporter) typ(typ types.Type) {
+	if trace {
+		p.tracef("type {\n")
+		defer p.tracef("}\n")
+	}
+
+	// if the type was seen before, write its index (>= 0)
+	if i, ok := p.typIndex[typ]; ok {
+		p.int(i)
+		return
+	}
+	p.typIndex[typ] = len(p.typIndex)
+
+	// otherwise, write the type tag (< 0) and type data
+	switch t := typ.(type) {
+	case *types.Array:
+		p.int(arrayTag)
+		p.int64(t.Len())
+		p.typ(t.Elem())
+
+	case *types.Slice:
+		p.int(sliceTag)
+		p.typ(t.Elem())
+
+	case *types.Struct:
+		p.int(structTag)
+		n := t.NumFields()
+		p.int(n)
+		for i := 0; i < n; i++ {
+			p.field(t.Field(i))
+			p.string(t.Tag(i))
+		}
+
+	case *types.Pointer:
+		p.int(pointerTag)
+		p.typ(t.Elem())
+
+	case *types.Signature:
+		p.int(signatureTag)
+		p.signature(t)
+
+	case *types.Interface:
+		p.int(interfaceTag)
+
+		// write embedded interfaces
+		m := t.NumEmbeddeds()
+		p.int(m)
+		for i := 0; i < m; i++ {
+			p.typ(t.Embedded(i))
+		}
+
+		// write methods
+		n := t.NumExplicitMethods()
+		p.int(n)
+		for i := 0; i < n; i++ {
+			m := t.ExplicitMethod(i)
+			p.qualifiedName(m.Pkg(), m.Name())
+			p.typ(m.Type())
+		}
+
+	case *types.Map:
+		p.int(mapTag)
+		p.typ(t.Key())
+		p.typ(t.Elem())
+
+	case *types.Chan:
+		p.int(chanTag)
+		p.int(int(t.Dir()))
+		p.typ(t.Elem())
+
+	case *types.Named:
+		p.int(namedTag)
+
+		// write type object
+		obj := t.Obj()
+		p.string(obj.Name())
+		p.pkg(obj.Pkg())
+
+		// write underlying type
+		p.typ(t.Underlying())
+
+		// write associated methods
+		n := t.NumMethods()
+		p.int(n)
+		for i := 0; i < n; i++ {
+			m := t.Method(i)
+			p.string(m.Name())
+			p.typ(m.Type())
+		}
+
+	default:
+		panic("unreachable")
+	}
+}
+
+func (p *exporter) field(f *types.Var) {
+	// anonymous fields have "" name
+	name := ""
+	if !f.Anonymous() {
+		name = f.Name()
+	}
+
+	// qualifiedName will always emit the field package for
+	// anonymous fields because "" is not an exported name.
+	p.qualifiedName(f.Pkg(), name)
+	p.typ(f.Type())
+}
+
+func (p *exporter) qualifiedName(pkg *types.Package, name string) {
+	p.string(name)
+	// exported names don't need package
+	if !exported(name) {
+		if pkg == nil {
+			panic(fmt.Sprintf("nil package for unexported qualified name %s", name))
+		}
+		p.pkg(pkg)
+	}
+}
+
+func (p *exporter) signature(sig *types.Signature) {
+	// We need the receiver information (T vs *T)
+	// for methods associated with named types.
+	// We do not record interface receiver types in the
+	// export data because 1) the importer can derive them
+	// from the interface type and 2) they create cycles
+	// in the type graph.
+	if recv := sig.Recv(); recv != nil {
+		if _, ok := recv.Type().Underlying().(*types.Interface); !ok {
+			// 1-element tuple
+			p.int(1)
+			p.param(recv)
+		} else {
+			// 0-element tuple
+			p.int(0)
+		}
+	} else {
+		// 0-element tuple
+		p.int(0)
+	}
+	p.tuple(sig.Params())
+	p.tuple(sig.Results())
+	if sig.Variadic() {
+		p.int(1)
+	} else {
+		p.int(0)
+	}
+}
+
+func (p *exporter) param(v *types.Var) {
+	p.string(v.Name())
+	p.typ(v.Type())
+}
+
+func (p *exporter) tuple(t *types.Tuple) {
+	n := t.Len()
+	p.int(n)
+	for i := 0; i < n; i++ {
+		p.param(t.At(i))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// encoders
+
+func (p *exporter) string(s string) {
+	p.bytes([]byte(s)) // (could be inlined if extra allocation matters)
+}
+
+func (p *exporter) int(x int) {
+	p.int64(int64(x))
+}
+
+func (p *exporter) int64(x int64) {
+	if debug {
+		p.marker('i')
+	}
+
+	if trace {
+		p.tracef("%d ", x)
+	}
+
+	p.rawInt64(x)
+}
+
+func (p *exporter) bytes(b []byte) {
+	if debug {
+		p.marker('b')
+	}
+
+	if trace {
+		p.tracef("%q ", b)
+	}
+
+	p.rawInt64(int64(len(b)))
+	if len(b) > 0 {
+		p.data = append(p.data, b...)
+	}
+}
+
+// marker emits a marker byte and position information which makes
+// it easy for a reader to detect if it is "out of sync". Used for
+// debug format only.
+func (p *exporter) marker(m byte) {
+	if debug {
+		p.data = append(p.data, m)
+		p.rawInt64(int64(len(p.data)))
+	}
+}
+
+// rawInt64 should only be used by low-level encoders
+func (p *exporter) rawInt64(x int64) {
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutVarint(tmp[:], x)
+	p.data = append(p.data, tmp[:n]...)
+}
+
+// utility functions
+
+func (p *exporter) tracef(format string, args ...interface{}) {
+	// rewrite format string to take care of indentation
+	const indent = ".  "
+	if strings.IndexAny(format, "{}\n") >= 0 {
+		var buf bytes.Buffer
+		for i := 0; i < len(format); i++ {
+			// no need to deal with runes
+			ch := format[i]
+			switch ch {
+			case '{':
+				p.indent += indent
+			case '}':
+				p.indent = p.indent[:len(p.indent)-len(indent)]
+				if i+1 < len(format) && format[i+1] == '\n' {
+					buf.WriteByte('\n')
+					buf.WriteString(p.indent)
+					buf.WriteString("} ")
+					i++
+					continue
+				}
+			}
+			buf.WriteByte(ch)
+			if ch == '\n' {
+				buf.WriteString(p.indent)
+			}
+		}
+		format = buf.String()
+	}
+	fmt.Printf(format, args...)
+}
+
+func exported(name string) bool {
+	return ast.IsExported(name)
+}

--- a/third_party/importer/import.go
+++ b/third_party/importer/import.go
@@ -1,0 +1,455 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This implementation is loosely based on the algorithm described
+// in: "On the linearization of graphs and writing symbol files",
+// by R. Griesemer, Technical Report 156, ETH Zürich, 1991.
+
+// package importer implements an exporter and importer for Go export data.
+package importer
+
+import (
+	"encoding/binary"
+	"fmt"
+	"go/constant"
+	"go/token"
+	"go/types"
+)
+
+// ImportData imports a package from the serialized package data
+// and returns the number of bytes consumed and a reference to the package.
+// If data is obviously malformed, an error is returned but in
+// general it is not recommended to call ImportData on untrusted
+// data.
+func ImportData(imports map[string]*types.Package, data []byte) (int, *types.Package, error) {
+	datalen := len(data)
+
+	// check magic string
+	var s string
+	if len(data) >= len(magic) {
+		s = string(data[:len(magic)])
+		data = data[len(magic):]
+	}
+	if s != magic {
+		return 0, nil, fmt.Errorf("incorrect magic string: got %q; want %q", s, magic)
+	}
+
+	// check low-level encoding format
+	var m byte = 'm' // missing format
+	if len(data) > 0 {
+		m = data[0]
+		data = data[1:]
+	}
+	if m != format() {
+		return 0, nil, fmt.Errorf("incorrect low-level encoding format: got %c; want %c", m, format())
+	}
+
+	p := importer{
+		data:    data,
+		datalen: datalen,
+		imports: imports,
+	}
+
+	// populate typList with predeclared types
+	for _, t := range predeclared {
+		p.typList = append(p.typList, t)
+	}
+
+	if v := p.string(); v != version {
+		return 0, nil, fmt.Errorf("unknown version: got %s; want %s", v, version)
+	}
+
+	pkg := p.pkg()
+	if debug && p.pkgList[0] != pkg {
+		panic("imported packaged not found in pkgList[0]")
+	}
+
+	// read objects
+	n := p.int()
+	for i := 0; i < n; i++ {
+		p.obj(pkg)
+	}
+
+	// complete interfaces
+	for _, typ := range p.typList {
+		if it, ok := typ.(*types.Interface); ok {
+			it.Complete()
+		}
+	}
+
+	// package was imported completely and without errors
+	pkg.MarkComplete()
+
+	return p.consumed(), pkg, nil
+}
+
+type importer struct {
+	data    []byte
+	datalen int
+	imports map[string]*types.Package
+	pkgList []*types.Package
+	typList []types.Type
+}
+
+func (p *importer) pkg() *types.Package {
+	// if the package was seen before, i is its index (>= 0)
+	i := p.int()
+	if i >= 0 {
+		return p.pkgList[i]
+	}
+
+	// otherwise, i is the package tag (< 0)
+	if i != packageTag {
+		panic(fmt.Sprintf("unexpected package tag %d", i))
+	}
+
+	// read package data
+	name := p.string()
+	path := p.string()
+
+	// if the package was imported before, use that one; otherwise create a new one
+	pkg := p.imports[path]
+	if pkg == nil {
+		pkg = types.NewPackage(path, name)
+		p.imports[path] = pkg
+	}
+	p.pkgList = append(p.pkgList, pkg)
+
+	return pkg
+}
+
+func (p *importer) obj(pkg *types.Package) {
+	var obj types.Object
+	switch tag := p.int(); tag {
+	case constTag:
+		obj = types.NewConst(token.NoPos, pkg, p.string(), p.typ(), p.value())
+	case typeTag:
+		// type object is added to scope via respective named type
+		_ = p.typ().(*types.Named)
+		return
+	case varTag:
+		obj = types.NewVar(token.NoPos, pkg, p.string(), p.typ())
+	case funcTag:
+		obj = types.NewFunc(token.NoPos, pkg, p.string(), p.typ().(*types.Signature))
+	default:
+		panic(fmt.Sprintf("unexpected object tag %d", tag))
+	}
+
+	if alt := pkg.Scope().Insert(obj); alt != nil {
+		panic(fmt.Sprintf("%s already declared", alt.Name()))
+	}
+}
+
+func (p *importer) value() constant.Value {
+	switch kind := constant.Kind(p.int()); kind {
+	case falseTag:
+		return constant.MakeBool(false)
+	case trueTag:
+		return constant.MakeBool(true)
+	case int64Tag:
+		return constant.MakeInt64(p.int64())
+	case floatTag:
+		return p.float()
+	case fractionTag:
+		return p.fraction()
+	case complexTag:
+		re := p.fraction()
+		im := p.fraction()
+		return constant.BinaryOp(re, token.ADD, constant.MakeImag(im))
+	case stringTag:
+		return constant.MakeString(p.string())
+	default:
+		panic(fmt.Sprintf("unexpected value kind %d", kind))
+	}
+}
+
+func (p *importer) float() constant.Value {
+	sign := p.int()
+	if sign == 0 {
+		return constant.MakeInt64(0)
+	}
+
+	x := p.ufloat()
+	if sign < 0 {
+		x = constant.UnaryOp(token.SUB, x, 0)
+	}
+	return x
+}
+
+func (p *importer) fraction() constant.Value {
+	sign := p.int()
+	if sign == 0 {
+		return constant.MakeInt64(0)
+	}
+
+	x := constant.BinaryOp(p.ufloat(), token.QUO, p.ufloat())
+	if sign < 0 {
+		x = constant.UnaryOp(token.SUB, x, 0)
+	}
+	return x
+}
+
+func (p *importer) ufloat() constant.Value {
+	exp := p.int()
+	x := constant.MakeFromBytes(p.bytes())
+	switch {
+	case exp < 0:
+		d := constant.Shift(constant.MakeInt64(1), token.SHL, uint(-exp))
+		x = constant.BinaryOp(x, token.QUO, d)
+	case exp > 0:
+		x = constant.Shift(x, token.SHL, uint(exp))
+	}
+	return x
+}
+
+func (p *importer) record(t types.Type) {
+	p.typList = append(p.typList, t)
+}
+
+func (p *importer) typ() types.Type {
+	// if the type was seen before, i is its index (>= 0)
+	i := p.int()
+	if i >= 0 {
+		return p.typList[i]
+	}
+
+	// otherwise, i is the type tag (< 0)
+	switch i {
+	case arrayTag:
+		t := new(types.Array)
+		p.record(t)
+
+		n := p.int64()
+		*t = *types.NewArray(p.typ(), n)
+		return t
+
+	case sliceTag:
+		t := new(types.Slice)
+		p.record(t)
+
+		*t = *types.NewSlice(p.typ())
+		return t
+
+	case structTag:
+		t := new(types.Struct)
+		p.record(t)
+
+		n := p.int()
+		fields := make([]*types.Var, n)
+		tags := make([]string, n)
+		for i := range fields {
+			fields[i] = p.field()
+			tags[i] = p.string()
+		}
+		*t = *types.NewStruct(fields, tags)
+		return t
+
+	case pointerTag:
+		t := new(types.Pointer)
+		p.record(t)
+
+		*t = *types.NewPointer(p.typ())
+		return t
+
+	case signatureTag:
+		t := new(types.Signature)
+		p.record(t)
+
+		*t = *p.signature()
+		return t
+
+	case interfaceTag:
+		// Create a dummy entry in the type list. This is safe because we
+		// cannot expect the interface type to appear in a cycle, as any
+		// such cycle must contain a named type which would have been
+		// first defined earlier.
+		n := len(p.typList)
+		p.record(nil)
+
+		// read embedded interfaces
+		embeddeds := make([]*types.Named, p.int())
+		for i := range embeddeds {
+			embeddeds[i] = p.typ().(*types.Named)
+		}
+
+		// read methods
+		methods := make([]*types.Func, p.int())
+		for i := range methods {
+			pkg, name := p.qualifiedName()
+			methods[i] = types.NewFunc(token.NoPos, pkg, name, p.typ().(*types.Signature))
+		}
+
+		t := types.NewInterface(methods, embeddeds)
+		p.typList[n] = t
+		return t
+
+	case mapTag:
+		t := new(types.Map)
+		p.record(t)
+
+		*t = *types.NewMap(p.typ(), p.typ())
+		return t
+
+	case chanTag:
+		t := new(types.Chan)
+		p.record(t)
+
+		*t = *types.NewChan(types.ChanDir(p.int()), p.typ())
+		return t
+
+	case namedTag:
+		// read type object
+		name := p.string()
+		pkg := p.pkg()
+		scope := pkg.Scope()
+		obj := scope.Lookup(name)
+
+		// if the object doesn't exist yet, create and insert it
+		if obj == nil {
+			obj = types.NewTypeName(token.NoPos, pkg, name, nil)
+			scope.Insert(obj)
+		}
+
+		// associate new named type with obj if it doesn't exist yet
+		t0 := types.NewNamed(obj.(*types.TypeName), nil, nil)
+
+		// but record the existing type, if any
+		t := obj.Type().(*types.Named)
+		p.record(t)
+
+		// read underlying type
+		t0.SetUnderlying(p.typ())
+
+		// read associated methods
+		for i, n := 0, p.int(); i < n; i++ {
+			t0.AddMethod(types.NewFunc(token.NoPos, pkg, p.string(), p.typ().(*types.Signature)))
+		}
+
+		return t
+
+	default:
+		panic(fmt.Sprintf("unexpected type tag %d", i))
+	}
+}
+
+func deref(typ types.Type) types.Type {
+	if p, _ := typ.(*types.Pointer); p != nil {
+		return p.Elem()
+	}
+	return typ
+}
+
+func (p *importer) field() *types.Var {
+	pkg, name := p.qualifiedName()
+	typ := p.typ()
+
+	anonymous := false
+	if name == "" {
+		// anonymous field - typ must be T or *T and T must be a type name
+		switch typ := deref(typ).(type) {
+		case *types.Basic: // basic types are named types
+			pkg = nil
+			name = typ.Name()
+		case *types.Named:
+			obj := typ.Obj()
+			name = obj.Name()
+			// correct the field package for anonymous fields
+			if exported(name) {
+				pkg = p.pkgList[0]
+			}
+		default:
+			panic("anonymous field expected")
+		}
+		anonymous = true
+	}
+
+	return types.NewField(token.NoPos, pkg, name, typ, anonymous)
+}
+
+func (p *importer) qualifiedName() (*types.Package, string) {
+	name := p.string()
+	pkg := p.pkgList[0] // exported names assume current package
+	if !exported(name) {
+		pkg = p.pkg()
+	}
+	return pkg, name
+}
+
+func (p *importer) signature() *types.Signature {
+	var recv *types.Var
+	if p.int() != 0 {
+		recv = p.param()
+	}
+	return types.NewSignature(recv, p.tuple(), p.tuple(), p.int() != 0)
+}
+
+func (p *importer) param() *types.Var {
+	return types.NewVar(token.NoPos, nil, p.string(), p.typ())
+}
+
+func (p *importer) tuple() *types.Tuple {
+	vars := make([]*types.Var, p.int())
+	for i := range vars {
+		vars[i] = p.param()
+	}
+	return types.NewTuple(vars...)
+}
+
+// ----------------------------------------------------------------------------
+// decoders
+
+func (p *importer) string() string {
+	return string(p.bytes())
+}
+
+func (p *importer) int() int {
+	return int(p.int64())
+}
+
+func (p *importer) int64() int64 {
+	if debug {
+		p.marker('i')
+	}
+
+	return p.rawInt64()
+}
+
+// Note: bytes() returns the respective byte slice w/o copy.
+func (p *importer) bytes() []byte {
+	if debug {
+		p.marker('b')
+	}
+
+	var b []byte
+	if n := int(p.rawInt64()); n > 0 {
+		b = p.data[:n]
+		p.data = p.data[n:]
+	}
+	return b
+}
+
+func (p *importer) marker(want byte) {
+	if debug {
+		if got := p.data[0]; got != want {
+			panic(fmt.Sprintf("incorrect marker: got %c; want %c (pos = %d)", got, want, p.consumed()))
+		}
+		p.data = p.data[1:]
+
+		pos := p.consumed()
+		if n := int(p.rawInt64()); n != pos {
+			panic(fmt.Sprintf("incorrect position: got %d; want %d", n, pos))
+		}
+	}
+}
+
+// rawInt64 should only be used by low-level decoders
+func (p *importer) rawInt64() int64 {
+	i, n := binary.Varint(p.data)
+	p.data = p.data[n:]
+	return i
+}
+
+func (p *importer) consumed() int {
+	return p.datalen - len(p.data)
+}

--- a/third_party/importer/predefined.go
+++ b/third_party/importer/predefined.go
@@ -1,0 +1,84 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package importer
+
+import "go/types"
+
+const (
+	magic   = "\n$$ exports $$\n"
+	version = "v0"
+)
+
+// Tags. Must be < 0.
+const (
+	// Packages
+	packageTag = -(iota + 1)
+
+	// Objects
+	constTag
+	typeTag
+	varTag
+	funcTag
+
+	// Types
+	arrayTag
+	sliceTag
+	structTag
+	pointerTag
+	signatureTag
+	interfaceTag
+	mapTag
+	chanTag
+	namedTag
+
+	// Values
+	falseTag
+	trueTag
+	int64Tag
+	floatTag
+	fractionTag
+	complexTag
+	stringTag
+)
+
+var predeclared = []types.Type{
+	// basic types
+	types.Typ[types.Bool],
+	types.Typ[types.Int],
+	types.Typ[types.Int8],
+	types.Typ[types.Int16],
+	types.Typ[types.Int32],
+	types.Typ[types.Int64],
+	types.Typ[types.Uint],
+	types.Typ[types.Uint8],
+	types.Typ[types.Uint16],
+	types.Typ[types.Uint32],
+	types.Typ[types.Uint64],
+	types.Typ[types.Uintptr],
+	types.Typ[types.Float32],
+	types.Typ[types.Float64],
+	types.Typ[types.Complex64],
+	types.Typ[types.Complex128],
+	types.Typ[types.String],
+
+	// untyped types
+	types.Typ[types.UntypedBool],
+	types.Typ[types.UntypedInt],
+	types.Typ[types.UntypedRune],
+	types.Typ[types.UntypedFloat],
+	types.Typ[types.UntypedComplex],
+	types.Typ[types.UntypedString],
+	types.Typ[types.UntypedNil],
+
+	// package unsafe
+	types.Typ[types.UnsafePointer],
+
+	// aliases
+	types.Universe.Lookup("byte").Type(),
+	types.Universe.Lookup("rune").Type(),
+
+	// error
+	types.Universe.Lookup("error").Type(),
+}

--- a/tool.go
+++ b/tool.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
+	"go/types"
 	"io"
 	"io/ioutil"
 	"net"
@@ -29,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/tools/go/types"
 )
 
 var currentDirectory string


### PR DESCRIPTION
Do not merge, this PR is a work in progress. It's created for initial review and to avoid potential duplicate work.

With the release of Go 1.5, go/types and some related packages have moved from golang.org/x/tools subrepo to standard library. We can start using them. This PR is about making that so.

There are currently 3 commits, first one is clean and ready, the other two are WIP and need some work.

We need to use golang.org/x/tools/go/importer and x/tools/go/types/typeutil, which continue to live in golang.org/x/tools but have not yet been updated to import the new go/types. Instead, they still import the old golang.org/x/tools/go/types. Despite being identical, those packages have different import paths, and as a result the types they define cannot be used interchangeably.

For now, vendor those packages and modify them to use the new go/types package. Hopefully that change will be done upstream soon (see https://github.com/golang/tools/commit/12c48ced94a7752f71687ef145a83a59e for a first similar change) and vendoring/modifying them will becoming unnecessary.

**Update:** This PR is now updated and needs to be merged soon in order to resolve #373.

Resolves #373.