### PR TITLE
Add wrappers for some JavaScript built-in functions. Plus tests.

### DIFF
--- a/jsbuiltin/jsbuiltin.go
+++ b/jsbuiltin/jsbuiltin.go
@@ -1,0 +1,31 @@
+package jsbuiltin
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// Wrappers for standard JS Builtin functions
+
+func DecodeURI(uri string) string {
+	return js.Global.Call("decodeURI", uri).String()
+}
+
+func EncodeURI(uri string) string {
+	return js.Global.Call("encodeURI", uri).String()
+}
+
+func EncodeURIComponent(uri string) string {
+	return js.Global.Call("encodeURIComponent", uri).String()
+}
+
+func DecodeURIComponent(uri string) string {
+	return js.Global.Call("decodeURIComponent", uri).String()
+}
+
+func IsFinite(value interface{}) bool {
+	return js.Global.Call("isFinite", value).Bool()
+}
+
+func IsNaN(value interface{}) bool {
+	return js.Global.Call("isNaN", value).Bool()
+}

--- a/jsbuiltin/jsbuiltin.go
+++ b/jsbuiltin/jsbuiltin.go
@@ -9,9 +9,16 @@ import (
 )
 
 // DecodeURI decodes a Uniform Resource Identifier (URI) previously created
-// by EncodeURI() or by a similar routine.
-func DecodeURI(uri string) string {
-	return js.Global.Call("decodeURI", uri).String()
+// by EncodeURI() or by a similar routine. If the underlying JavaScript
+// function throws an error, it is returned as an error.
+func DecodeURI(uri string) (raw string,err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(*js.Error)
+		}
+	}()
+	raw = js.Global.Call("decodeURI", uri).String()
+	return
 }
 
 // EncodeURI encodes a Uniform Resource Identifier (URI) by replacing each
@@ -32,9 +39,16 @@ func EncodeURIComponent(uri string) string {
 }
 
 // DecodeURIComponent decodes a Uniform Resource Identifier (URI) component
-// previously created by EncodeURIComponent() or by a similar routine
-func DecodeURIComponent(uri string) string {
-	return js.Global.Call("decodeURIComponent", uri).String()
+// previously created by EncodeURIComponent() or by a similar routine. If the
+// underlying JavaScript function throws an error, it is returned as an error.
+func DecodeURIComponent(uri string) (raw string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(*js.Error)
+		}
+	}()
+	raw = js.Global.Call("decodeURIComponent", uri).String()
+	return
 }
 
 // IsFinite determines whether the passed value is a finite number, and returns

--- a/jsbuiltin/jsbuiltin.go
+++ b/jsbuiltin/jsbuiltin.go
@@ -1,31 +1,50 @@
+// +build js
+
+// Package jsbuiltin provides minimal wrappers around some JavasScript
+// built-in functions.
 package jsbuiltin
 
 import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-// Wrappers for standard JS Builtin functions
-
+// DecodeURI decodes a Uniform Resource Identifier (URI) previously created
+// by EncodeURI() or by a similar routine.
 func DecodeURI(uri string) string {
 	return js.Global.Call("decodeURI", uri).String()
 }
 
+// EncodeURI encodes a Uniform Resource Identifier (URI) by replacing each
+// instance of certain characters by one, two, three, or four escape sequences
+// representing the UTF-8 encoding of the character (will only be four escape
+// sequences for characters composed of two "surrogate" characters).
 func EncodeURI(uri string) string {
 	return js.Global.Call("encodeURI", uri).String()
 }
 
+// EncodeURIComponents encodes a Uniform Resource Identifier (URI) component
+// by replacing each instance of certain characters by one, two, three, or
+// four escape sequences representing the UTF-8 encoding of the character
+// (will only be four escape sequences for characters composed of two
+// "surrogate" characters).
 func EncodeURIComponent(uri string) string {
 	return js.Global.Call("encodeURIComponent", uri).String()
 }
 
+// DecodeURIComponent decodes a Uniform Resource Identifier (URI) component
+// previously created by EncodeURIComponent() or by a similar routine
 func DecodeURIComponent(uri string) string {
 	return js.Global.Call("decodeURIComponent", uri).String()
 }
 
+// IsFinite determines whether the passed value is a finite number, and returns
+// true if it is. If needed, the parameter is first converted to a number.
 func IsFinite(value interface{}) bool {
 	return js.Global.Call("isFinite", value).Bool()
 }
 
+// IsNaN determines whether a value is NaN (Not-a-Number) or not. A return
+// value of true indicates the input value is considered NaN by JavaScript.
 func IsNaN(value interface{}) bool {
 	return js.Global.Call("isNaN", value).Bool()
 }

--- a/jsbuiltin/jsbuiltin_test.go
+++ b/jsbuiltin/jsbuiltin_test.go
@@ -2,7 +2,6 @@ package jsbuiltin
 
 import (
 	"testing"
-//	"github.com/gopherjs/gopherjs/jsbuiltin"
 )
 
 
@@ -19,15 +18,40 @@ func TestEncodeURI(t *testing.T) {
 	}
 }
 
+type testData struct {
+	URL				string
+	ExpectedURL		string
+	ExpectedError	string
+}
+
 func TestDecodeURI(t *testing.T) {
-	data := map[string]string{
-		"http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.": "http://foo.com/?msg=Привет мир.",
-		"http://user:host@foo.com/": "http://user:host@foo.com/",
+	data := []testData{
+		testData{
+			"http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.", "http://foo.com/?msg=Привет мир.", "",
+		},
+		testData{
+			"http://user:host@foo.com/", "http://user:host@foo.com/", "",
+		},
+		testData{
+			"http://foo.com/?invalidutf8=%80", "", "JavaScript error: URI malformed",
+		},
 	}
-	for url,expected := range data {
-		result := DecodeURI(url)
-		if result != expected {
-			t.Fatalf("DecodeURI(%s) returned '%s', not '%s'", url, result, expected)
+	for _,test := range data {
+		result,err := DecodeURI(test.URL)
+		if len(test.ExpectedError) > 0 {
+			if err == nil {
+				t.Fatalf("DecodeURI(%s) should have resulted in an error", test.URL)
+			}
+			if err.Error() != test.ExpectedError {
+				t.Fatalf("DecodeURI(%s) should have resulted in error '%s', got '%s'", test.ExpectedError, err)
+			}
+		} else {
+			if err != nil && err.Error() != test.ExpectedError {
+				t.Fatal("DecodeURI() resulted in an error: %s", err)
+			}
+			if result != test.ExpectedURL {
+				t.Fatalf("DecodeURI(%s) returned '%s', not '%s'", test.URL, result, test.ExpectedURL)
+			}
 		}
 	}
 }
@@ -46,14 +70,33 @@ func TestEncodeURIComponentn(t *testing.T) {
 }
 
 func TestDecodeURIComponentn(t *testing.T) {
-	data := map[string]string{
-		"%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.": "Привет мир.",
-		"bar": "bar",
+	data := []testData{
+		testData{
+			"%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.", "Привет мир.", "",
+		},
+		testData{
+			"bar", "bar", "",
+		},
+		testData{
+			"%80", "", "JavaScript error: URI malformed",
+		},
 	}
-	for url,expected := range data {
-		result := DecodeURIComponent(url)
-		if result != expected {
-			t.Fatalf("DecodeURIComponent(%s) returned '%s', not '%s'", url, result, expected)
+	for _,test := range data {
+		result,err := DecodeURIComponent(test.URL)
+		if len(test.ExpectedError) > 0 {
+			if err == nil {
+				t.Fatalf("DecodeURIComponent(%s) should have resulted in an error", test.URL)
+			}
+			if err.Error() != test.ExpectedError {
+				t.Fatalf("DecodeURIComponent(%s) should have resulted in error '%s', got '%s'", test.ExpectedError, err)
+			}
+		} else {
+			if err != nil && err.Error() != test.ExpectedError {
+				t.Fatal("DecodeURIComponent() resulted in an error: %s", err)
+			}
+			if result != test.ExpectedURL {
+				t.Fatalf("DecodeURIComponent(%s) returned '%s', not '%s'", test.URL, result, test.ExpectedURL)
+			}
 		}
 	}
 }

--- a/jsbuiltin/jsbuiltin_test.go
+++ b/jsbuiltin/jsbuiltin_test.go
@@ -1,0 +1,95 @@
+package jsbuiltin
+
+import (
+	"testing"
+//	"github.com/gopherjs/gopherjs/jsbuiltin"
+)
+
+
+func TestEncodeURI(t *testing.T) {
+	data := map[string]string{
+		"http://foo.com/?msg=Привет мир.": "http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.",
+		"http://user:host@foo.com/": "http://user:host@foo.com/",
+	}
+	for url,expected := range data {
+		result := EncodeURI(url)
+		if result != expected {
+			t.Fatalf("EncodeURI(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+func TestDecodeURI(t *testing.T) {
+	data := map[string]string{
+		"http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.": "http://foo.com/?msg=Привет мир.",
+		"http://user:host@foo.com/": "http://user:host@foo.com/",
+	}
+	for url,expected := range data {
+		result := DecodeURI(url)
+		if result != expected {
+			t.Fatalf("DecodeURI(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+func TestEncodeURIComponentn(t *testing.T) {
+	data := map[string]string{
+		"Привет мир.": "%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.",
+		"bar": "bar",
+	}
+	for url,expected := range data {
+		result := EncodeURIComponent(url)
+		if result != expected {
+			t.Fatalf("EncodeURIComponent(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+func TestDecodeURIComponentn(t *testing.T) {
+	data := map[string]string{
+		"%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.": "Привет мир.",
+		"bar": "bar",
+	}
+	for url,expected := range data {
+		result := DecodeURIComponent(url)
+		if result != expected {
+			t.Fatalf("DecodeURIComponent(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+func TestIsFinite(t *testing.T) {
+	data := map[interface{}]bool {
+		123:			true,
+		-1.23:			true,
+		5-2:			true,
+		0:				true,
+		"123":			true,
+		"Hello":		false,
+		"2005/12/12":	false,
+	}
+	for value,expected := range data {
+		result := IsFinite(value)
+		if result != expected {
+			t.Fatalf("IsFinite(%s) returned %t, not %t", value, result, expected)
+		}
+	}
+}
+
+func TestIsNaN(t *testing.T) {
+	data := map[interface{}]bool {
+		123:			false,
+		-1.23:			false,
+		5-2:			false,
+		0:				false,
+		"123":			false,
+		"Hello":		true,
+		"2005/12/12":	true,
+	}
+	for value,expected := range data {
+		result := IsNaN(value)
+		if result != expected {
+			t.Fatalf("IsNaN(%s) returned %t, not %t", value, result, expected)
+		}
+	}
+}


### PR DESCRIPTION
I'm submitting this PR for comment in relation to issue #294 .

Note that I did not wrap the following built in functions:

* **escape()** and **unescape()**: These were deprecated circa 2000.
* **eval()**:  I'm not sure if it would ever be a good idea to eval() JS code from within Go. Maybe, maybe not... but it's not obvious so I'm leaving it out for now.
* **Number()**: This requires handling a bunch of corner cases which don't exist in a strictly typed language such as Go. The impedance mismatch between JS and Go seems too high to be meaningful to wrap this, plus, the parse*() functions handle most of the meaningful use cases anyway. Anyone with a legitimate need to use `Number()` probably need to write their own wrapper to handle the variations that matter to them.
* **parseInt()** and **parseFloat()**: These are already wrapped as *js.Object methods. It probably makes sense to wrap them as global functions, too, but how should NaN be handled? The object method (I'm guessing) returns an uninitialized number (i.e. 0), which doesn't seem right.  Returning, for example, either `int,error` or `int,bool` (a la type reflection), seem to make sense to me. Returning an error seems more idiomatic, but would require adding a dependency on 'errors' (would this be bad?)
