### PR TITLE
Fix fixedbugs/bug180.go and fixedbugs/issue12133.go compiler panics.

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1164,7 +1164,7 @@ func (c *funcContext) fixNumber(value *expression, basic *types.Basic) *expressi
 		return c.formatParenExpr("%s << 16 >> 16", value)
 	case types.Uint16:
 		return c.formatParenExpr("%s << 16 >>> 16", value)
-	case types.Int32, types.Int:
+	case types.Int32, types.Int, types.UntypedInt:
 		return c.formatParenExpr("%s >> 0", value)
 	case types.Uint32, types.Uint, types.Uintptr:
 		return c.formatParenExpr("%s >>> 0", value)
@@ -1173,7 +1173,7 @@ func (c *funcContext) fixNumber(value *expression, basic *types.Basic) *expressi
 	case types.Float64:
 		return value
 	default:
-		panic(int(basic.Kind()))
+		panic(fmt.Sprintf("fixNumber: unhandled basic.Kind(): %s", basic.String()))
 	}
 }
 

--- a/tests/run.go
+++ b/tests/run.go
@@ -45,17 +45,6 @@ import (
 //
 var knownFails = map[string]failReason{
 	// GopherJS compiler panics.
-	"fixedbugs/bug180.go": {category: compilerPanic, desc: `
-panic: 20
-
-goroutine 1 [running]:
-github.com/gopherjs/gopherjs/compiler.(*funcContext).fixNumber(0xc820164210, 0xc82000f360, 0x9088a0, 0xc820018ea0)
-	github.com/gopherjs/gopherjs/compiler/expressions.go:1176 +0x235
-`},
-	"fixedbugs/issue12133.go": {category: compilerPanic, desc: `
-github.com/gopherjs/gopherjs/compiler.(*funcContext).fixNumber(0xc82027c840, 0xc82004c820, 0x9088a0, 0xc82004c6c0)
-	github.com/gopherjs/gopherjs/compiler/expressions.go:1176 +0x235
-`},
 	"fixedbugs/issue5793.go": {category: compilerPanic, desc: `
 panic: runtime error: index out of range
 


### PR DESCRIPTION
Fixes #297.

Handle `types.UntypedInt` value of `types.BasicKind` in `fixNumber`. Treat it like `types.Int` and `types.Int32`.

Update error message to be more readable.