### PR TITLE
Include *.inc.js files in `gopherjs build` mode.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -309,15 +309,11 @@ func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string)
 	}
 	pkg := &PackageData{Package: buildPkg}
 	pkg.ImportPath = "main"
-	files, err := ioutil.ReadDir(pkg.Dir)
+	jsFiles, err := jsFilesFromDir(pkg.Dir)
 	if err != nil {
 		return err
 	}
-	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".inc.js") && file.Name()[0] != '_' {
-			pkg.JsFiles = append(pkg.JsFiles, file.Name())
-		}
-	}
+	pkg.JsFiles = jsFiles
 	if err := s.BuildPackage(pkg); err != nil {
 		return err
 	}
@@ -370,15 +366,11 @@ func (s *Session) ImportPackage(path string) (*compiler.Archive, error) {
 	}
 	pkg := &PackageData{Package: buildPkg}
 
-	files, err := ioutil.ReadDir(pkg.Dir)
+	jsFiles, err := jsFilesFromDir(pkg.Dir)
 	if err != nil {
 		return nil, err
 	}
-	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".inc.js") && file.Name()[0] != '_' {
-			pkg.JsFiles = append(pkg.JsFiles, file.Name())
-		}
-	}
+	pkg.JsFiles = jsFiles
 
 	if err := s.BuildPackage(pkg); err != nil {
 		return nil, err
@@ -581,6 +573,20 @@ func NewMappingCallback(m *sourcemap.Map, goroot, gopath string) func(generatedL
 		}
 		m.AddMapping(&sourcemap.Mapping{GeneratedLine: generatedLine, GeneratedColumn: generatedColumn, OriginalFile: file, OriginalLine: originalPos.Line, OriginalColumn: originalPos.Column})
 	}
+}
+
+func jsFilesFromDir(dir string) ([]string, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var jsFiles []string
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".inc.js") && file.Name()[0] != '_' {
+			jsFiles = append(jsFiles, file.Name())
+		}
+	}
+	return jsFiles, nil
 }
 
 // hasGopathPrefix returns true and the length of the matched GOPATH workspace,

--- a/build/build.go
+++ b/build/build.go
@@ -309,6 +309,15 @@ func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string)
 	}
 	pkg := &PackageData{Package: buildPkg}
 	pkg.ImportPath = "main"
+	files, err := ioutil.ReadDir(pkg.Dir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".inc.js") && file.Name()[0] != '_' {
+			pkg.JsFiles = append(pkg.JsFiles, file.Name())
+		}
+	}
 	if err := s.BuildPackage(pkg); err != nil {
 		return err
 	}


### PR DESCRIPTION
This simply copies the same functionality from ImportPackage(). Perhaps it
should be factored into a common function.

This appears to solve bug #306, but causes some test failures, which I will investigate later.