### PR TITLE
Fix func, map, slice, and array values as map keys

### DIFF
--- a/compiler/prelude/types.go
+++ b/compiler/prelude/types.go
@@ -370,6 +370,7 @@ var $newType = function(size, kind, string, name, pkg, constructor) {
   typ.methods = [];
   typ.methodSetCache = null;
   typ.comparable = true;
+  typ.keyFor = typ.keyFor || $identity;
   return typ;
 };
 


### PR DESCRIPTION
This reverts part of 8b46201 to to fix #323 

Some other solution may be preferred, in which case this PR can simply be closed.