### PR TITLE
Explicit values in $divComplex

### DIFF
--- a/compiler/prelude/numeric.go
+++ b/compiler/prelude/numeric.go
@@ -139,24 +139,24 @@ var $div64 = function(x, y, returnRemainder) {
 };
 
 var $divComplex = function(n, d) {
-  var ninf = n.$real === 1/0 || n.$real === -1/0 || n.$imag === 1/0 || n.$imag === -1/0;
-  var dinf = d.$real === 1/0 || d.$real === -1/0 || d.$imag === 1/0 || d.$imag === -1/0;
+  var ninf = n.$real === Infinity || n.$real === -Infinity || n.$imag === Infinity || n.$imag === -Infinity;
+  var dinf = d.$real === Infinity || d.$real === -Infinity || d.$imag === Infinity || d.$imag === -Infinity;
   var nnan = !ninf && (n.$real !== n.$real || n.$imag !== n.$imag);
   var dnan = !dinf && (d.$real !== d.$real || d.$imag !== d.$imag);
   if(nnan || dnan) {
-    return new n.constructor(0/0, 0/0);
+    return new n.constructor(NaN, NaN);
   }
   if (ninf && !dinf) {
-    return new n.constructor(1/0, 1/0);
+    return new n.constructor(Infinity, Infinity);
   }
   if (!ninf && dinf) {
     return new n.constructor(0, 0);
   }
   if (d.$real === 0 && d.$imag === 0) {
     if (n.$real === 0 && n.$imag === 0) {
-      return new n.constructor(0/0, 0/0);
+      return new n.constructor(NaN, NaN);
     }
-    return new n.constructor(1/0, 1/0);
+    return new n.constructor(Infinity, Infinity);
   }
   var a = Math.abs(d.$real);
   var b = Math.abs(d.$imag);


### PR DESCRIPTION
`$divComplex` for now uses implicit `Infinity` and `NaN` values (with divisions by zero and zero divided by zero). This improves the code readability by making these expressions explicit.