### PR TITLE
Call JsFilesFromDir in the case of 'gopherjs test' as well.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -309,7 +309,7 @@ func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string)
 	}
 	pkg := &PackageData{Package: buildPkg}
 	pkg.ImportPath = "main"
-	jsFiles, err := jsFilesFromDir(pkg.Dir)
+	jsFiles, err := JsFilesFromDir(pkg.Dir)
 	if err != nil {
 		return err
 	}
@@ -366,7 +366,7 @@ func (s *Session) ImportPackage(path string) (*compiler.Archive, error) {
 	}
 	pkg := &PackageData{Package: buildPkg}
 
-	jsFiles, err := jsFilesFromDir(pkg.Dir)
+	jsFiles, err := JsFilesFromDir(pkg.Dir)
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func NewMappingCallback(m *sourcemap.Map, goroot, gopath string) func(generatedL
 	}
 }
 
-func jsFilesFromDir(dir string) ([]string, error) {
+func JsFilesFromDir(dir string) ([]string, error) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, err

--- a/tool.go
+++ b/tool.go
@@ -299,6 +299,11 @@ func main() {
 				tests := &testFuncs{Package: pkg}
 				collectTests := func(buildPkg *build.Package, testPkgName string, needVar *bool) error {
 					testPkg := &gbuild.PackageData{Package: buildPkg, IsTest: true}
+					jsFiles, err := gbuild.JsFilesFromDir(pkg.Dir)
+					if err != nil {
+						return err
+					}
+					testPkg.JsFiles = jsFiles
 					if err := s.BuildPackage(testPkg); err != nil {
 						return err
 					}


### PR DESCRIPTION
As luck would have it, #322 was an incomplete fix for #306.  Although it handled the case of 'gopherjs build', it didn't hand the case of 'gopherjs test', which this PR now handles.