### PR TITLE
Include *.inc.js files consistently

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -309,11 +309,6 @@ func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string)
 	}
 	pkg := &PackageData{Package: buildPkg}
 	pkg.ImportPath = "main"
-	jsFiles, err := jsFilesFromDir(pkg.Dir)
-	if err != nil {
-		return err
-	}
-	pkg.JSFiles = jsFiles
 	if err := s.BuildPackage(pkg); err != nil {
 		return err
 	}
@@ -337,7 +332,6 @@ func (s *Session) BuildFiles(filenames []string, pkgObj string, packagePath stri
 
 	for _, file := range filenames {
 		if strings.HasSuffix(file, ".inc.js") {
-			pkg.JSFiles = append(pkg.JSFiles, file)
 			continue
 		}
 		pkg.GoFiles = append(pkg.GoFiles, file)
@@ -366,12 +360,6 @@ func (s *Session) ImportPackage(path string) (*compiler.Archive, error) {
 	}
 	pkg := &PackageData{Package: buildPkg}
 
-	jsFiles, err := jsFilesFromDir(pkg.Dir)
-	if err != nil {
-		return nil, err
-	}
-	pkg.JSFiles = jsFiles
-
 	if err := s.BuildPackage(pkg); err != nil {
 		return nil, err
 	}
@@ -383,6 +371,12 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 	if pkg.ImportPath == "unsafe" {
 		return nil
 	}
+
+	jsFiles, err := jsFilesFromDir(pkg.Dir)
+	if err != nil {
+		return err
+	}
+	pkg.JSFiles = jsFiles
 
 	if pkg.PkgObj != "" {
 		var fileInfo os.FileInfo

--- a/build/build.go
+++ b/build/build.go
@@ -248,7 +248,7 @@ func (o *Options) PrintSuccess(format string, a ...interface{}) {
 
 type PackageData struct {
 	*build.Package
-	JsFiles    []string
+	JSFiles    []string
 	IsTest     bool // IsTest is true if the package is being built for running tests.
 	SrcModTime time.Time
 	UpToDate   bool
@@ -313,7 +313,7 @@ func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string)
 	if err != nil {
 		return err
 	}
-	pkg.JsFiles = jsFiles
+	pkg.JSFiles = jsFiles
 	if err := s.BuildPackage(pkg); err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func (s *Session) BuildFiles(filenames []string, pkgObj string, packagePath stri
 
 	for _, file := range filenames {
 		if strings.HasSuffix(file, ".inc.js") {
-			pkg.JsFiles = append(pkg.JsFiles, file)
+			pkg.JSFiles = append(pkg.JSFiles, file)
 			continue
 		}
 		pkg.GoFiles = append(pkg.GoFiles, file)
@@ -370,7 +370,7 @@ func (s *Session) ImportPackage(path string) (*compiler.Archive, error) {
 	if err != nil {
 		return nil, err
 	}
-	pkg.JsFiles = jsFiles
+	pkg.JSFiles = jsFiles
 
 	if err := s.BuildPackage(pkg); err != nil {
 		return nil, err
@@ -425,7 +425,7 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 			}
 		}
 
-		for _, name := range append(pkg.GoFiles, pkg.JsFiles...) {
+		for _, name := range append(pkg.GoFiles, pkg.JSFiles...) {
 			fileInfo, err := os.Stat(filepath.Join(pkg.Dir, name))
 			if err != nil {
 				return err
@@ -470,7 +470,7 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 	}
 
 	var jsDecls []*compiler.Decl
-	for _, jsFile := range pkg.JsFiles {
+	for _, jsFile := range pkg.JSFiles {
 		code, err := ioutil.ReadFile(filepath.Join(pkg.Dir, jsFile))
 		if err != nil {
 			return err


### PR DESCRIPTION
An alternative proposal to finish fixing #306, in response to comments on #328.

Moving the call to `jsFilesFromDir()` into `Import()` doesn't work with the current code layout, as `Import()` doesn't know anything about the `gbuild.Package` data structure, only the official Go `build.Package` structure.  So I instead moved it to `BuildPackage()`.

The only (potential) drawback to this, is that it means we include `*.inc.js` files completely consistently for all call methods.  The one place where this causes a change of behavior is when calling `gopherjs build <files>`.  Under the old behavior, executing `gopherjs build foo.go` would *not* include foo.inc.js in the final output. Under the new behavior, it will.  If the old behavior is important to preserve*, something more clever needs to be done (which I'm willing to tackle myself, too, if it's deemed important).

*The only way I can imagine the old behavior being useful is for testing... someone might want to choose which JS file(s), among many, to include at build time. But I don't know if that was actually the intention, or if this "feature" was unintentional.  