### PR TITLE
README: Suggest working with Go packages by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get or update GopherJS and dependencies with:
 go get -u github.com/gopherjs/gopherjs
 ```
 
-Now you can use  `gopherjs build [files]` or `gopherjs install [package]` which behave similar to the `go` tool. For `main` packages, these commands create a `.js` file and `.js.map` source map in the current directory or in `$GOPATH/bin`. The generated JavaScript file can be used as usual in a website. Use `gopherjs help [command]` to get a list of possible command line flags, e.g. for minification and automatically watching for changes.
+Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherjs install [package]` which behave similar to the `go` tool. For `main` packages, these commands create a `.js` file and `.js.map` source map in the current directory or in `$GOPATH/bin`. The generated JavaScript file can be used as usual in a website. Use `gopherjs help [command]` to get a list of possible command line flags, e.g. for minification and automatically watching for changes.
 
 If you want to use `gopherjs run` or `gopherjs test` to run the generated code locally, install Node.js 4.x and the module `source-map-support`:
 


### PR DESCRIPTION
When writing Go code that is something more than just a very short snippet, it helps to organize code as a Go package. It may contain 1 or more .go files in a directory.

`go build` is primarily used with Go packages, as in `go build import/path`. We should suggest the same use of `gopherjs build`. That will make it easier for users to get started and grow their code, because they'll be able to split into multiple .go files without having to update their build step.

#### Note

It's still possible to use `gopherjs build` with a list of files, just like `go build` can be used in the same way. But I don't think we should be recommending that as the primary usage mode. Users that still want this can discover it via `gopherjs help build`.