### PR TITLE
include *.inc.js in seperate scope to avoid package variable shadowing 

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -501,8 +501,9 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 		if err != nil {
 			return err
 		}
-		code = append(append([]byte("\t(function() {\n"), code...), []byte("\n\t}).call($global);\n")...)
+		pkg.Archive.IncJSCode = append(pkg.Archive.IncJSCode, []byte("\t(function() {\n")...)
 		pkg.Archive.IncJSCode = append(pkg.Archive.IncJSCode, code...)
+		pkg.Archive.IncJSCode = append(pkg.Archive.IncJSCode, []byte("\n\t}).call($global);\n")...)
 	}
 
 	if s.options.Verbose {

--- a/build/build.go
+++ b/build/build.go
@@ -496,17 +496,16 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 		return err
 	}
 
-	var jsDecls []*compiler.Decl
+	pkg.Archive.JSDecls = []*compiler.Decl{}
 	for _, jsFile := range pkg.JSFiles {
 		code, err := ioutil.ReadFile(filepath.Join(pkg.Dir, jsFile))
 		if err != nil {
 			return err
 		}
-		jsDecls = append(jsDecls, &compiler.Decl{
+		pkg.Archive.JSDecls = append(pkg.Archive.JSDecls, &compiler.Decl{
 			DeclCode: append(append([]byte("\t(function() {\n"), code...), []byte("\n\t}).call($global);\n")...),
 		})
 	}
-	pkg.Archive.Declarations = append(jsDecls, pkg.Archive.Declarations...)
 
 	if s.options.Verbose {
 		fmt.Println(pkg.ImportPath)

--- a/build/build.go
+++ b/build/build.go
@@ -496,15 +496,13 @@ func (s *Session) BuildPackage(pkg *PackageData) error {
 		return err
 	}
 
-	pkg.Archive.JSDecls = []*compiler.Decl{}
 	for _, jsFile := range pkg.JSFiles {
 		code, err := ioutil.ReadFile(filepath.Join(pkg.Dir, jsFile))
 		if err != nil {
 			return err
 		}
-		pkg.Archive.JSDecls = append(pkg.Archive.JSDecls, &compiler.Decl{
-			DeclCode: append(append([]byte("\t(function() {\n"), code...), []byte("\n\t}).call($global);\n")...),
-		})
+		code = append(append([]byte("\t(function() {\n"), code...), []byte("\n\t}).call($global);\n")...)
+		pkg.Archive.IncJSCode = append(pkg.Archive.IncJSCode, code...)
 	}
 
 	if s.options.Verbose {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -37,6 +37,7 @@ type Archive struct {
 	Imports      []string
 	ExportData   []byte
 	Declarations []*Decl
+	JSDecls      []*Decl
 	FileSet      []byte
 	Minified     bool
 
@@ -181,6 +182,11 @@ func WritePkgCode(pkg *Archive, dceSelection map[*Decl]struct{}, minify bool, w 
 		w.fileSet = token.NewFileSet()
 		if err := w.fileSet.Read(json.NewDecoder(bytes.NewReader(pkg.FileSet)).Decode); err != nil {
 			panic(err)
+		}
+	}
+	for _, d := range pkg.JSDecls {
+		if _, err := w.Write(d.DeclCode); err != nil {
+			return err
 		}
 	}
 	if _, err := w.Write(removeWhitespace([]byte(fmt.Sprintf("$packages[\"%s\"] = (function() {\n", pkg.ImportPath)), minify)); err != nil {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -37,7 +37,7 @@ type Archive struct {
 	Imports      []string
 	ExportData   []byte
 	Declarations []*Decl
-	JSDecls      []*Decl
+	IncJSCode    []byte
 	FileSet      []byte
 	Minified     bool
 
@@ -184,8 +184,8 @@ func WritePkgCode(pkg *Archive, dceSelection map[*Decl]struct{}, minify bool, w 
 			panic(err)
 		}
 	}
-	for _, d := range pkg.JSDecls {
-		if _, err := w.Write(d.DeclCode); err != nil {
+	if pkg.IncJSCode != nil {
+		if _, err := w.Write(pkg.IncJSCode); err != nil {
 			return err
 		}
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -184,10 +184,8 @@ func WritePkgCode(pkg *Archive, dceSelection map[*Decl]struct{}, minify bool, w 
 			panic(err)
 		}
 	}
-	if pkg.IncJSCode != nil {
-		if _, err := w.Write(pkg.IncJSCode); err != nil {
-			return err
-		}
+	if _, err := w.Write(pkg.IncJSCode); err != nil {
+		return err
 	}
 	if _, err := w.Write(removeWhitespace([]byte(fmt.Sprintf("$packages[\"%s\"] = (function() {\n", pkg.ImportPath)), minify)); err != nil {
 		return err


### PR DESCRIPTION
fix #351 

by adding field `compiler.Archive.JSDecls` to seperate included js code from the genereate js code and  then write the included js code just before gopherjs package declarations to avoid variable name shadowing.