### PR TITLE
Use CWD for temp files, and fall back to /tmp only for upstream tests.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -223,7 +223,10 @@ func main() {
 				return fmt.Errorf("gopherjs run: no go files listed")
 			}
 
-			tempfile, err := ioutil.TempFile("", filepath.Base(args[0])+".")
+			tempfile, err := ioutil.TempFile(currentDirectory, filepath.Base(args[0])+".")
+			if err != nil && strings.HasPrefix(currentDirectory, runtime.GOROOT()) {
+				tempfile, err = ioutil.TempFile("", filepath.Base(args[0])+".")
+			}
 			if err != nil {
 				return err
 			}
@@ -363,7 +366,7 @@ func main() {
 					return err
 				}
 
-				tempfile, err := ioutil.TempFile("", "test.")
+				tempfile, err := ioutil.TempFile(currentDirectory, "test.")
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This is an alternative to #334 to fix #303.  It uses the CWD for temp files, but falls back to using /tmp only for files found in the system GOROOT path, which should not be vulnerable to the security risks of running nodejs code in /tmp.

If there are ever other situations where we need to run tests in read-only directories, this will fail.  I don't know if such cases are likely ever to exist, but if they do, then #334 is probably the preferred solution.