### PR TITLE
Filter gopherjs warnings from test output.

### DIFF
--- a/tests/run.go
+++ b/tests/run.go
@@ -734,8 +734,8 @@ func (t *test) run() {
 					t.err = err
 					return
 				}
-				if strings.Replace(string(out), "\r\n", "\n", -1) != t.expectedOutput() {
-					t.err = fmt.Errorf("incorrect output\n%s", out)
+				if fo := filterOutput(out); fo != t.expectedOutput() {
+					t.err = fmt.Errorf("incorrect output\n%s", fo)
 				}
 			}
 		}
@@ -754,8 +754,8 @@ func (t *test) run() {
 			t.err = err
 			return
 		}
-		if strings.Replace(string(out), "\r\n", "\n", -1) != t.expectedOutput() {
-			t.err = fmt.Errorf("incorrect output\n%s", out)
+		if fo := filterOutput(out); fo != t.expectedOutput() {
+			t.err = fmt.Errorf("incorrect output\n%s", fo)
 		}
 
 	case "runoutput":
@@ -779,8 +779,8 @@ func (t *test) run() {
 			t.err = err
 			return
 		}
-		if string(out) != t.expectedOutput() {
-			t.err = fmt.Errorf("incorrect output\n%s", out)
+		if fo := filterOutput(out); fo != t.expectedOutput() {
+			t.err = fmt.Errorf("incorrect output\n%s", fo)
 		}
 
 	case "errorcheckoutput":
@@ -814,6 +814,13 @@ func (t *test) run() {
 		t.err = t.errorCheck(string(out), tfile, "tmp__.go")
 		return
 	}
+}
+
+func filterOutput(out []byte) string {
+	filteredOut := strings.Replace(string(out), "\r\n", "\n", -1)
+	re := regexp.MustCompile("(?m)^gopherjs: Source maps disabled.*?\n")
+	filteredOut = re.ReplaceAllString(filteredOut, "")
+	return filteredOut
 }
 
 var execCmd []string


### PR DESCRIPTION
For some reason, I'm unable to get nodejs to find the source-map-support module when running the test suite, which causes every one of the official go tests to fail with "invalid output":

    FAIL    fixedbugs/issue9006.go  0.326s
    # go run run.go -- fixedbugs/issue9110.go
    incorrect output
    gopherjs: Source maps disabled. Use Node.js 4.x with source-map-support module for nice stack traces.

As running tests with source maps doesn't seem especially valuable to me, this patch attempts to remedy the problem by filtering out this text from the output of the tests 