### PR TITLE
Add --quiet commandline option to suppress non-fatal warnings in output

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -260,6 +260,7 @@ type Options struct {
 	GOROOT        string
 	GOPATH        string
 	Verbose       bool
+	Quiet         bool
 	Watch         bool
 	CreateMapFile bool
 	Minify        bool

--- a/tests/run.go
+++ b/tests/run.go
@@ -749,7 +749,7 @@ func (t *test) run() {
 	case "run":
 		useTmp = false
 		// GOPHERJS.
-		out, err := runcmd(append([]string{"gopherjs", "run", t.goFileName()}, args...)...)
+		out, err := runcmd(append([]string{"gopherjs", "run", "-q", t.goFileName()}, args...)...)
 		if err != nil {
 			t.err = err
 			return


### PR DESCRIPTION
And use the -q flag when running official Go tests, to avoid test failures for "invalid output" when gopherjs emits warnings about not loading the source-map-support module:

    FAIL    fixedbugs/issue9006.go  0.326s
    # go run run.go -- fixedbugs/issue9110.go
    incorrect output
    gopherjs: Source maps disabled. Use Node.js 4.x with source-map-support module for nice stack traces.
