### PR TITLE
compiler: fix runtime exceptions with blocking deferred functions

### DIFF
--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -282,7 +282,13 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			}
 			results = c.resultNames
 		}
-		c.Printf("return%s;", c.translateResults(results))
+		rVal := c.translateResults(results)
+		if c.Flattened[s] {
+			resumeCase := c.caseCounter
+			c.caseCounter++
+			c.Printf("/* */ $s = %[1]d; case %[1]d:", resumeCase)
+		}
+		c.Printf("return%s;", rVal)
 
 	case *ast.DeferStmt:
 		isBuiltin := false

--- a/tests/deferblock_test.go
+++ b/tests/deferblock_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"testing"
+	"time"
+)
+
+func inner(ch chan struct{}, b bool) ([]byte, error) {
+	// ensure gopherjs thinks that this inner function can block
+	if b {
+		<-ch
+	}
+	return []byte{}, nil
+}
+
+// this function's call to inner never blocks, but the deferred
+// statement does.
+func outer(ch chan struct{}, b bool) ([]byte, error) {
+	defer func() {
+		<-ch
+	}()
+
+	return inner(ch, b)
+}
+
+func TestBlockingInDefer(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Error("run time panic: %v", x)
+		}
+	}()
+
+	ch := make(chan struct{})
+	b := false
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		ch <- struct{}{}
+	}()
+
+	outer(ch, b)
+}


### PR DESCRIPTION
This issue arises when re-winding the stack to complete a blocking function call inside a deferred function.  More specifically it occurs in functions that call blocking functions both with the defer keyword and in return statements.  A trivial example is given in [tests/deferblock_test.go](tests/deferblock_test.go), `ioutil.ReadFile` is an example of such a function from the stdlib.

All the test cases pass for me, and I've added a new file containing a test for this.  Let me know if there is any better way to test this.