### PR TITLE
Make error friendlier if GOPATH is not set

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -46,6 +46,11 @@ func init() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	gopaths := filepath.SplitList(build.Default.GOPATH)
+	if len(gopaths) == 0 {
+		fmt.Fprintf(os.Stderr, "$GOPATH not set. For more details see: go help gopath\n")
+		os.Exit(1)
+	}
 }
 
 func main() {


### PR DESCRIPTION
Currently, if GOPATH isn't set, a rather unfriendly stack trace is generated. Something like:

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/gopherjs/gopherjs/build.Import(0x61e420, 0x7, 0x0, 0x0, 0x0, 0x9067b0, 0x0, 0x0, 0xc8200cea90, 0x0, ...)
	/Users/rodarmor/src/tumlt-app/src/github.com/gopherjs/gopherjs/build/build.go:97 +0xdd9
```

This adds a check to init() to print a friendlier error message. I reused the error message that the go tool prints out.

Thanks for GopherJS, it's f'in sweet :)