### PR TITLE
Fix Error prototype for PhantomJS environments

### DIFF
--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -16,6 +16,20 @@ if (typeof window !== "undefined") { /* web page */
   $global = this;
 }
 
+// Fix Error prototype for PhantomJS
+if (typeof phantom !== "undefined") {
+	var OriginalErrorPrototype = Error.prototype;
+	var OriginalError = Error;
+	$global.Error = function(m) {
+		try {
+			throw new OriginalError(m);
+		} catch (e) {
+			return e;
+		}
+	};
+	$global.Error.prototype = OriginalErrorPrototype;
+}
+
 if ($global === undefined || $global.Array === undefined) {
   throw new Error("no global object found");
 }


### PR DESCRIPTION
The JavaScript interpreter built into PhantomJS is apparently rather ancient, and has some oddities.  Of note for this PR, `throw new Error()` creates an Error object with a stack trace, but `new Error()`simply creates a string.  This is important in a few places where GopherJS needs to generate a JS stack trace, such as [here](https://github.com/gopherjs/gopherjs/blob/master/compiler/natives/runtime/runtime.go#L48), which caused a runtime crash prior to this PR.  I will follow on this work with proper parsing error stack traces from PhantomJS.

This PR works around this short-coming by doing a `throw` in the Error object constructor.

There may be a better way to do this (my JS-foo is weak).

There is also likely a better place, organizationally speaking, at least, to do this. I'm open for suggestions, if the concept is deemed appropriate.
