### PR TITLE
Add support for TestMain function in test mode

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -334,10 +334,6 @@ func main() {
 
 				tests := &testFuncs{Package: pkg.Package}
 				collectTests := func(testPkg *gbuild.PackageData, testPkgName string, needVar *bool) error {
-					_, err := s.BuildPackage(testPkg)
-					if err != nil {
-						return err
-					}
 					if testPkgName == "_test" {
 						for _, file := range pkg.TestGoFiles {
 							if err := tests.load(filepath.Join(pkg.Package.Dir, file), testPkgName, &tests.ImportTest, &tests.NeedTest); err != nil {
@@ -350,6 +346,10 @@ func main() {
 								return err
 							}
 						}
+					}
+					_, err := s.BuildPackage(testPkg)
+					if err != nil {
+						return err
 					}
 					return nil
 				}

--- a/tool.go
+++ b/tool.go
@@ -334,7 +334,7 @@ func main() {
 
 				tests := &testFuncs{Package: pkg.Package}
 				collectTests := func(testPkg *gbuild.PackageData, testPkgName string, needVar *bool) error {
-					archive, err := s.BuildPackage(testPkg)
+					_, err := s.BuildPackage(testPkg)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
This adds support for the `TestMain` function in test mode, described [here](https://godoc.org/testing#hdr-Main), and requested in issue #239.  Naturally, I took inspiration from the relevant official [go source](https://github.com/golang/go/blob/master/src/cmd/go/test.go).

I have tested it to the extent I know to. It's possible I may have missed some functionality. Any other suggestions or feedback is welcome.