### PR TITLE
Override os.Hostname()

### DIFF
--- a/compiler/natives/os/os.go
+++ b/compiler/natives/os/os.go
@@ -24,3 +24,27 @@ func init() {
 }
 
 func runtime_beforeExit() {}
+
+// Override the builtin os.Hostname(). The builtin Hostname() will result in
+// a non-working syscall on most (all?) platforms
+func Hostname() (string, error) {
+	// Browser
+	// The browser doesn't know anything about any hostname, so we use the host part of
+	// the current url.
+	if location := js.Global.Get("location"); location != js.Undefined {
+		if browserHostname := location.Get("hostname"); browserHostname != js.Undefined {
+			return browserHostname.String(), nil
+		}
+	}
+
+	// Node.js
+	// We call node's require("os").hostname() which should return current hostname
+	if require := js.Global.Get("require"); require != js.Undefined {
+		// "os" is in nodejs core, it should always exist
+		if nodeHostname := require.Invoke("os").Call("hostname"); nodeHostname != js.Undefined {
+			return nodeHostname.String(), nil
+		}
+	}
+
+	return "", ErrNotExist
+}


### PR DESCRIPTION
`os.Hostname()` doesn't work in compiled code because it will trigger a syscall.

This replacement tries to do the right thing. In a node.js environment it will call `require("os").hostname()`. In the browser it will use `window.location.hostname`, which is the closest thing we got.