### PR TITLE
$externalize fixes

### DIFF
--- a/compiler/prelude/jsmapping.go
+++ b/compiler/prelude/jsmapping.go
@@ -114,6 +114,9 @@ var $externalize = function(v, t) {
         return searchJsObject(v.$get(), t.elem);
       case $kindStruct:
         var f = t.fields[0];
+        if (f === undefined) {
+          return noJsObject;
+        }
         return searchJsObject(v[f.prop], f.typ);
       case $kindInterface:
         return searchJsObject(v.$val, v.constructor);

--- a/compiler/prelude/jsmapping.go
+++ b/compiler/prelude/jsmapping.go
@@ -132,7 +132,11 @@ var $externalize = function(v, t) {
       if (f.pkg !== "") { /* not exported */
         continue;
       }
-      o[f.name] = $externalize(v[f.prop], f.typ);
+      var name = f.name;
+      if (name === "") {
+        name = f.prop;
+      }
+      o[name] = $externalize(v[f.prop], f.typ);
     }
     return o;
   }


### PR DESCRIPTION
Found a couple of bugs in how $externalize converts structs to js objects.

First, when converting an anonymous field, it gives it a name of empty string. This is not ideal, and actually causes naming collisions if you have two or more anonymous fields.

The following playground link shows this off: -

<http://www.gopherjs.org/playground/#/paSROP9iN_>

The js console will show an object with two fields, the NotEmpty and the empty string struct, which will be C, which has overridden B.

The second occurs when you have an empty struct, searchJsObject doesn't handle the case where there are no fields to check.

This can be shown by just printing an empty struct{} to the log: -

http://www.gopherjs.org/playground/#/PfMcT_bbbz
