### PR TITLE
Fix "shorthand redefinition" panic when running `gopherjs tool` command.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -448,7 +448,6 @@ func main() {
 	}
 	cmdTool.Flags().BoolP("e", "e", false, "")
 	cmdTool.Flags().BoolP("l", "l", false, "")
-	cmdTool.Flags().BoolP("m", "m", false, "")
 	cmdTool.Flags().StringP("o", "o", "", "")
 	cmdTool.Flags().StringP("D", "D", "", "")
 	cmdTool.Flags().StringP("I", "I", "", "")


### PR DESCRIPTION
Fixes #392.

/cc @neelance I have no idea if this `gopherjs tool` command is even supported, or what it's meant to do with all those flags. But this fixes the panic. 