### PR TITLE
compiler/natives/runtime: Add missing function body for ReadTrace.

### DIFF
--- a/compiler/natives/runtime/runtime.go
+++ b/compiler/natives/runtime/runtime.go
@@ -174,7 +174,7 @@ func Version() string {
 
 func StartTrace() error { return nil }
 func StopTrace()        {}
-func ReadTrace() []byte
+func ReadTrace() []byte { return nil }
 
 // We fake a cgo environment to catch errors. Therefor we have to implement this and always return 0
 func NumCgoCall() int64 {


### PR DESCRIPTION
Addresses https://github.com/gopherjs/gopherjs/commit/a6b5a2662eeefb2063c09e39baf4104828f3d589#commitcomment-16172129.

Needs review. (It's possible I'm misunderstanding what's going on and the missing func body is valid (in that case, a comment is likely worthwhile), but given the history the change, this seems unlikely.)