### PR TITLE
Don't panic  if import returns without package

### DIFF
--- a/compiler/package.go
+++ b/compiler/package.go
@@ -113,6 +113,9 @@ func (pi packageImporter) Import(path string) (*types.Package, error) {
 		}
 		return nil, err
 	}
+	if a == nil {
+		return nil, fmt.Errorf("cannot find %q", path)
+	}
 
 	return a.types, nil
 }


### PR DESCRIPTION
gopherjs build panic'ed when couldn't find some imports. With this fix, it nicely prints the missing package.