### PR TITLE
build: Update dependency import path.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -16,10 +16,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gopherjs/gopherjs/compiler"
 	"github.com/kardianos/osext"
 	"github.com/neelance/sourcemap"
-	"gopkg.in/fsnotify.v1"
 )
 
 type ImportCError struct {


### PR DESCRIPTION
The import path of this package has changed to github.com/fsnotify/fsnotify.

The old import path still works, but that was [an unplanned coincidence](https://github.com/fsnotify/fsnotify/issues/108#issuecomment-185815848). It is no longer officially supported.

See https://github.com/fsnotify/fsnotify/issues/118#issuecomment-185814855 and https://github.com/fsnotify/fsnotify/issues/108#issuecomment-185824561 for source. /cc @nathany

According to https://github.com/fsnotify/fsnotify#api-stability there are future API changes planned, but we can easily update our usage when that happens, so I don't think we need to vendor it at this time.