### PR TITLE
mock call to probeWindowsIPStack()

### DIFF
--- a/compiler/natives/net/net.go
+++ b/compiler/natives/net/net.go
@@ -32,6 +32,10 @@ func probeIPv6Stack() (supportsIPv6, supportsIPv4map bool) {
 	return false, false
 }
 
+func probeWindowsIPStack() (supportsVistaIP bool) {
+	return false
+}
+
 func maxListenerBacklog() int {
 	return syscall.SOMAXCONN
 }


### PR DESCRIPTION
In Go's "net" package, some syscalls are invoked during initialisation. Since the JS runtime that GopherJS targets cannot make syscalls, these need to be mocked out with empty functions to prevent runtime errors.

To mock out a standard Go function so that the GopherJS compiler will provide a substitute function at compile time, you simply add the extra functions to : 
gopherjs/compiler/natives/package-name/filename.go

... and the compiler will then inject these "native" alternatives in the generated JS code. This makes it very simple to find where GopherJS is using overrides, and see exactly whats going on.

In the case of the "net" package, there are already some mocks for syscalls, such as probeIPv4Stack() and sysInit()

However, the "net" package init in Windows is different, and it calls probeWindowsIPStack() as a syscall. End result is that code that is generated on a Windows machine will fail at runtime if "net" is imported.

This pull request simply adds the probeWindowsIPStack empty function inline with the other IPStack probe functions.

Closes issue 424
https://github.com/gopherjs/gopherjs/issues/424