### PR TITLE
compiler/natives/src/net/http: Implement http.RoundTripper on Fetch API.

### DIFF
--- a/compiler/natives/src/net/http/fetch.go
+++ b/compiler/natives/src/net/http/fetch.go
@@ -1,0 +1,126 @@
+// +build js
+
+package http
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// streamReader implements a wrapper for ReadableStreamDefaultReader of https://streams.spec.whatwg.org/.
+type streamReader struct {
+	pending []byte
+	reader  *js.Object
+}
+
+func (r streamReader) Read(p []byte) (n int, err error) {
+	if len(r.pending) == 0 {
+		var (
+			bCh   = make(chan []byte)
+			errCh = make(chan error)
+		)
+		r.reader.Call("read").Call("then",
+			func(result *js.Object) {
+				if result.Get("done").Bool() {
+					errCh <- io.EOF
+					return
+				}
+				bCh <- result.Get("value").Interface().([]byte)
+			},
+			func(reason *js.Object) {
+				// Assumes it's a DOMException.
+				errCh <- errors.New(reason.Get("message").String())
+			},
+		)
+		select {
+		case b := <-bCh:
+			r.pending = b
+		case err := <-errCh:
+			return 0, err
+		}
+	}
+	n = copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+func (streamReader) Close() error {
+	// TODO: Implement. Use r.reader.cancel(reason) maybe?
+	return errors.New("not yet implemented")
+}
+
+// fetchTransport is a RoundTripper that is implemented using Fetch API. It supports streaming
+// response bodies.
+type fetchTransport struct{}
+
+func (t *fetchTransport) RoundTrip(req *Request) (*Response, error) {
+	headers := js.Global.Get("Headers").New()
+	for key, values := range req.Header {
+		for _, value := range values {
+			headers.Call("set", key, value)
+		}
+	}
+	respPromise := js.Global.Get("fetch").Invoke(req.URL.String(), map[string]interface{}{
+		"method":  req.Method,
+		"headers": headers,
+	})
+
+	var (
+		respCh = make(chan *Response)
+		errCh  = make(chan error)
+	)
+	respPromise.Call("then",
+		func(result *js.Object) {
+			// TODO: Decide which of these two to use. The latter is more reliable,
+			//       but likely uses up slightly more performance. It seems some browsers either
+			//       don't set statusText, or set it to something weird. For example, Chrome 50 (latest stable)
+			//       doesn't set it. Latest Safari does set it to something like "HTTP 2.0 200" instead of the
+			//       expected "OK". Firefox set it to the expected "OK. Not sure what's the future of statusText
+			//       property, maybe it's deprecated and we shouldn't use it? It does not seem to be deprecated
+			//       from a quick look at the docs, so maybe use it and hope the implementations are fixed soon?
+			//statusText := result.Get("statusText").String()
+			statusText := StatusText(result.Get("status").Int())
+
+			// TODO: Make this better.
+			header := Header{}
+			result.Get("headers").Call("forEach", func(value, key *js.Object) {
+				header[CanonicalHeaderKey(key.String())] = []string{value.String()} // TODO: Support multiple values.
+			})
+
+			// TODO: With streaming responses, this cannot be set.
+			//       But it doesn't seem to be set even for non-streaming responses. In other words,
+			//       this code is currently completely unexercised/untested. Need to test it. Probably
+			//       by writing a http.Handler that explicitly sets Content-Type header? Figure this out.
+			contentLength := int64(-1)
+			if cl, err := strconv.ParseInt(result.Get("headers").Call("get", "content-length").String(), 10, 64); err == nil {
+				contentLength = cl
+			}
+
+			respCh <- &Response{
+				Status:        result.Get("status").String() + " " + statusText,
+				StatusCode:    result.Get("status").Int(),
+				Header:        header,
+				ContentLength: contentLength,
+				Body:          &streamReader{reader: result.Get("body").Call("getReader")},
+				Request:       req,
+			}
+		},
+		func(reason *js.Object) {
+			// TODO: Better error.
+			errCh <- errors.New("net/http: Fetch failed")
+		},
+	)
+	select {
+	case resp := <-respCh:
+		return resp, nil
+	case err := <-errCh:
+		return nil, err
+	}
+}
+
+// TODO: Implement?
+/*func (t *fetchTransport) CancelRequest(req *Request) {
+}*/

--- a/compiler/natives/src/net/http/fetch.go
+++ b/compiler/natives/src/net/http/fetch.go
@@ -81,7 +81,6 @@ func (t *fetchTransport) RoundTrip(req *Request) (*Response, error) {
 	opt := map[string]interface{}{
 		"method":  req.Method,
 		"headers": headers,
-		//"redirect": "manual", // Can't use this because it results in an opaque-redirect filtered response, which appears to be unfit for the purpose of completing the redirect.
 	}
 	if req.Body != nil {
 		// TODO: Find out if request body can be streamed into the fetch request rather than in advance here.
@@ -108,22 +107,10 @@ func (t *fetchTransport) RoundTrip(req *Request) (*Response, error) {
 				header[ck] = append(header[ck], value.String())
 			})
 
-			// TODO: With streaming responses, this cannot be set.
-			//       But it doesn't seem to be set even for non-streaming responses. In other words,
-			//       this code is currently completely unexercised/untested. Need to test it. Probably
-			//       by writing a http.Handler that explicitly sets Content-Type header? Figure this out.
 			contentLength := int64(-1)
 			if cl, err := strconv.ParseInt(header.Get("Content-Length"), 10, 64); err == nil {
 				contentLength = cl
 			}
-
-			// TODO: Sort this out.
-			/*var body io.ReadCloser
-			if b := result.Get("body"); b != nil {
-				body = &streamReader{stream: b.Call("getReader")}
-			} else {
-				body = noBody
-			}*/
 
 			respCh <- &Response{
 				Status:        result.Get("status").String() + " " + StatusText(result.Get("status").Int()),
@@ -148,6 +135,3 @@ func (t *fetchTransport) RoundTrip(req *Request) (*Response, error) {
 		return nil, errors.New("net/http: request canceled")
 	}
 }
-
-// TODO: Consider implementing here if importing those 2 packages is expensive.
-//var noBody io.ReadCloser = ioutil.NopCloser(bytes.NewReader(nil))

--- a/compiler/natives/src/net/http/http.go
+++ b/compiler/natives/src/net/http/http.go
@@ -90,8 +90,10 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 		var err error
 		body, err = ioutil.ReadAll(req.Body)
 		if err != nil {
+			req.Body.Close() // RoundTrip must always close the body, including on errors.
 			return nil, err
 		}
+		req.Body.Close()
 	}
 	xhr.Call("send", body)
 

--- a/compiler/natives/src/net/http/http.go
+++ b/compiler/natives/src/net/http/http.go
@@ -15,8 +15,7 @@ import (
 
 var DefaultTransport = func() RoundTripper {
 	switch {
-	case js.Global.Get("fetch") != js.Undefined && js.Global.Get("ReadableStream") != js.Undefined:
-		// ReadableStream is used as a check for support of streaming response bodies, see https://fetch.spec.whatwg.org/#streams.
+	case js.Global.Get("fetch") != js.Undefined && js.Global.Get("ReadableStream") != js.Undefined: // ReadableStream is used as a check for support of streaming response bodies, see https://fetch.spec.whatwg.org/#streams.
 		return &fetchTransport{}
 	case js.Global.Get("XMLHttpRequest") != js.Undefined:
 		return &XHRTransport{}

--- a/compiler/natives/src/net/http/http.go
+++ b/compiler/natives/src/net/http/http.go
@@ -14,13 +14,15 @@ import (
 )
 
 var DefaultTransport = func() RoundTripper {
-	if fetchAPI, streamsAPI := js.Global.Get("fetch"), js.Global.Get("ReadableStream"); fetchAPI != js.Undefined && streamsAPI != js.Undefined {
+	switch {
+	case js.Global.Get("fetch") != js.Undefined && js.Global.Get("ReadableStream") != js.Undefined:
+		// ReadableStream is used as a check for support of streaming response bodies, see https://fetch.spec.whatwg.org/#streams.
 		return &fetchTransport{}
-	}
-	if xhrAPI := js.Global.Get("XMLHttpRequest"); xhrAPI != js.Undefined {
+	case js.Global.Get("XMLHttpRequest") != js.Undefined:
 		return &XHRTransport{}
+	default:
+		return noTransport{}
 	}
-	return noTransport{}
 }()
 
 // noTransport is used when neither Fetch API nor XMLHttpRequest API are available. It always fails.


### PR DESCRIPTION
This is a WIP PR in order to get initial review comments, to communicate and avoid duplicate efforts. Known TODOs are listed in code.

The motivation to use Fetch API is because it's lower level, and allows implementing an http.RoundTripper more efficiently (less conversions between strings and []byte). It also supports streaming body responses efficiently.

References:

- https://fetch.spec.whatwg.org/
- https://streams.spec.whatwg.org/
- http://caniuse.com/#search=Fetch

Tested in stable channel of Chrome, latest Safari, Firefox (developer edition).

Dynamically determine which of XHR, Fetch APIs are available and gracefully fallback to the best available API.

Here's a quick demo, using a local instance of https://http2.golang.org/reqinfo and https://http2.golang.org/clockstream endpoints. I've asked @bradfitz if it's possible to enable CORS on http2.golang.org itself, and if so, you could try this out in a playground.

```Go
func streamingDemo() error {
	resp, err := http.Get("https://localhost:4430/clockstream")
	if err != nil {
		return err
	}
	defer resp.Body.Close()
	_, err = io.Copy(os.Stdout, resp.Body)
	return err
}
```

### Results

(It's a video, click it to view.)

[![image](https://cloud.githubusercontent.com/assets/1924134/15110331/0e3848ac-1595-11e6-8f1b-5ae70a85e644.png)](http://virtivia.com:27080/15kvcw9ib4f2u.mov)