### PR TITLE
compiler: Verify version Go 1.6 strictly, tip not supported.

### DIFF
--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -1,3 +1,4 @@
+// +build !go1.7
 // +build go1.6
 
 package compiler


### PR DESCRIPTION
Be more strict in the version check, so it's clear which versions are supported. Only Go 1.6, 1.6.1, and 1.6.2, not older nor newer.

This should help communicate to people who try running GopherJS with tip and run into issues that it's because 1.6 strictly is required, rather than "1.6 and newer".

/cc @neelance I couldn't think of a reason not to this, but is there one? I've seen a few comments where people tried GopherJS with tip and it failed, so they had to use 1.6. I think we should be more explicit about that, especially now that 1.7 is getting nearer. The current `master` branch expects and supports 1.6 only, not newer. Thoughts?

Maybe we didn't have this sooner because it wasn't possible? `go1.7` build tag has only been added on March 7 in https://github.com/golang/go/commit/399f0f5fe8029e31e742e0341c7ddfd2097f3926.