### PR TITLE
compiler/natives: Update filter API.

### DIFF
--- a/compiler/natives/fs.go
+++ b/compiler/natives/fs.go
@@ -21,9 +21,9 @@ func importPathToDir(importPath string) string {
 }
 
 // FS is a virtual filesystem that contains native packages.
-var FS = filter.New(
+var FS = filter.Keep(
 	http.Dir(importPathToDir("github.com/gopherjs/gopherjs/compiler/natives")),
 	func(path string, fi os.FileInfo) bool {
-		return path != "/" && path != "/src" && !strings.HasPrefix(path, "/src/")
+		return path == "/" || path == "/src" || strings.HasPrefix(path, "/src/")
 	},
 )


### PR DESCRIPTION
DO NOT MERGE until shurcooL/httpfs#4 is merged, since this change depends on that.

Rewrite filter in terms of `Keep` rather than `Skip` to make the logic simpler and more readable.

#### Test Plan

Tested locally with shurcooL/httpfs#4 merged (locally, not yet pushed upstream).