### PR TITLE
doc: Update net/http notes.

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -107,7 +107,7 @@ On each commit, Circle CI automatically compiles all supported packages with Gop
 | -- multipart    | yes                   |                                   |
 | -- quotedprintable | yes                |                                   |
 | net             | no                    |                                   |
-| -- http         | partially             | emulated via Fetch/XMLHttpRequest APIs; node.js requires polyfill |
+| -- http         | partially             | client only, emulated via Fetch/XMLHttpRequest APIs;<br>node.js requires polyfill |
 | -- -- cgi       | no                    |                                   |
 | -- -- cookiejar | yes                   |                                   |
 | -- -- fcgi      | yes                   |                                   |

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -107,7 +107,7 @@ On each commit, Circle CI automatically compiles all supported packages with Gop
 | -- multipart    | yes                   |                                   |
 | -- quotedprintable | yes                |                                   |
 | net             | no                    |                                   |
-| -- http         | partially             | emulated via XMLHttpRequest       |
+| -- http         | partially             | emulated via Fetch/XMLHttpRequest APIs; node.js requires polyfill |
 | -- -- cgi       | no                    |                                   |
 | -- -- cookiejar | yes                   |                                   |
 | -- -- fcgi      | yes                   |                                   |


### PR DESCRIPTION
Followup to #454. Mention that Fetch API can be used.

Mention that only `net/http` client is supported, server is not.

Also mention that by default, without third party polyfill modules for XHR or Fetch APIs, node.js will not support net/http.