### PR TITLE
WIP-388: Rewrite gopherjs tool.go to use cmd/go functionality.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -1,32 +1,23 @@
+// GopherJS is a tool for compiling Go source code to JavaScript.
 package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"go/ast"
 	"go/build"
-	"go/doc"
-	"go/parser"
 	"go/scanner"
-	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"text/template"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	gbuild "github.com/gopherjs/gopherjs/build"
 	"github.com/gopherjs/gopherjs/compiler"
@@ -36,27 +27,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var currentDirectory string
-
-func init() {
-	var err error
-	currentDirectory, err = os.Getwd()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	currentDirectory, err = filepath.EvalSymlinks(currentDirectory)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	gopaths := filepath.SplitList(build.Default.GOPATH)
-	if len(gopaths) == 0 {
-		fmt.Fprintf(os.Stderr, "$GOPATH not set. For more details see: go help gopath\n")
-		os.Exit(1)
-	}
-}
-
 func main() {
 	options := &gbuild.Options{CreateMapFile: true}
 	var pkgObj string
@@ -65,8 +35,6 @@ func main() {
 	flagVerbose := pflag.Lookup("verbose")
 	pflag.BoolVarP(&options.Quiet, "quiet", "q", false, "suppress non-fatal warnings")
 	flagQuiet := pflag.Lookup("quiet")
-	pflag.BoolVarP(&options.Watch, "watch", "w", false, "watch for changes to the source files")
-	flagWatch := pflag.Lookup("watch")
 	pflag.BoolVarP(&options.Minify, "minify", "m", false, "minify generated code")
 	flagMinify := pflag.Lookup("minify")
 	pflag.BoolVar(&options.Color, "color", terminal.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb", "colored output")
@@ -81,74 +49,28 @@ func main() {
 	cmdBuild.Flags().StringVarP(&pkgObj, "output", "o", "", "output file")
 	cmdBuild.Flags().AddFlag(flagVerbose)
 	cmdBuild.Flags().AddFlag(flagQuiet)
-	cmdBuild.Flags().AddFlag(flagWatch)
 	cmdBuild.Flags().AddFlag(flagMinify)
 	cmdBuild.Flags().AddFlag(flagColor)
 	cmdBuild.Flags().AddFlag(flagTags)
 	cmdBuild.Run = func(cmd *cobra.Command, args []string) {
 		options.BuildTags = strings.Fields(*tags)
-		for {
-			s := gbuild.NewSession(options)
 
-			exitCode := handleError(func() error {
-				if len(args) == 0 {
-					return s.BuildDir(currentDirectory, currentDirectory, pkgObj)
-				}
+		build.Default.GOARCH = "js"
+		cmdgo_buildContext = build.Default
 
-				if strings.HasSuffix(args[0], ".go") || strings.HasSuffix(args[0], ".inc.js") {
-					for _, arg := range args {
-						if !strings.HasSuffix(arg, ".go") && !strings.HasSuffix(arg, ".inc.js") {
-							return fmt.Errorf("named files must be .go or .inc.js files")
-						}
-					}
-					if pkgObj == "" {
-						basename := filepath.Base(args[0])
-						pkgObj = basename[:len(basename)-3] + ".js"
-					}
-					names := make([]string, len(args))
-					for i, name := range args {
-						name = filepath.ToSlash(name)
-						names[i] = name
-						if s.Watcher != nil {
-							s.Watcher.Add(name)
-						}
-					}
-					if err := s.BuildFiles(args, pkgObj, currentDirectory); err != nil {
-						return err
-					}
-					return nil
-				}
-
-				for _, pkgPath := range args {
-					pkgPath = filepath.ToSlash(pkgPath)
-					if s.Watcher != nil {
-						s.Watcher.Add(pkgPath)
-					}
-					pkg, err := gbuild.Import(pkgPath, 0, s.InstallSuffix(), options.BuildTags)
-					if err != nil {
-						return err
-					}
-					archive, err := s.BuildPackage(pkg)
-					if err != nil {
-						return err
-					}
-					if pkgObj == "" {
-						pkgObj = filepath.Base(args[0]) + ".js"
-					}
-					if pkg.IsCommand() && !pkg.UpToDate {
-						if err := s.WriteCommandPackage(archive, pkgObj); err != nil {
-							return err
-						}
-					}
-				}
-				return nil
-			}, options, nil)
-
-			if s.Watcher == nil {
-				os.Exit(exitCode)
-			}
-			s.WaitForChange()
+		os.Args = []string{"gopherjs", "build", "-compiler=gopherjs"}
+		if pkgObj != "" {
+			os.Args = append(os.Args, "-o", pkgObj)
 		}
+		if options.Verbose {
+			os.Args = append(os.Args, "-v")
+		}
+		if *tags != "" {
+			os.Args = append(os.Args, "-tags", *tags)
+		}
+		os.Args = append(os.Args, args...)
+
+		cmdgo_main()
 	}
 
 	cmdInstall := &cobra.Command{
@@ -157,70 +79,25 @@ func main() {
 	}
 	cmdInstall.Flags().AddFlag(flagVerbose)
 	cmdInstall.Flags().AddFlag(flagQuiet)
-	cmdInstall.Flags().AddFlag(flagWatch)
 	cmdInstall.Flags().AddFlag(flagMinify)
 	cmdInstall.Flags().AddFlag(flagColor)
 	cmdInstall.Flags().AddFlag(flagTags)
 	cmdInstall.Run = func(cmd *cobra.Command, args []string) {
 		options.BuildTags = strings.Fields(*tags)
-		for {
-			s := gbuild.NewSession(options)
 
-			exitCode := handleError(func() error {
-				pkgs := args
-				if len(pkgs) == 0 {
-					firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0] // TODO: The GOPATH workspace that contains the package source should be chosen.
-					srcDir, err := filepath.EvalSymlinks(filepath.Join(firstGopathWorkspace, "src"))
-					if err != nil {
-						return err
-					}
-					if !strings.HasPrefix(currentDirectory, srcDir) {
-						return fmt.Errorf("gopherjs install: no install location for directory %s outside GOPATH", currentDirectory)
-					}
-					pkgPath, err := filepath.Rel(srcDir, currentDirectory)
-					if err != nil {
-						return err
-					}
-					pkgs = []string{pkgPath}
-				}
-				if cmd.Name() == "get" {
-					goGet := exec.Command("go", append([]string{"get", "-d", "-tags=js"}, pkgs...)...)
-					goGet.Stdout = os.Stdout
-					goGet.Stderr = os.Stderr
-					if err := goGet.Run(); err != nil {
-						return err
-					}
-				}
-				for _, pkgPath := range pkgs {
-					pkgPath = filepath.ToSlash(pkgPath)
+		build.Default.GOARCH = "js"
+		cmdgo_buildContext = build.Default
 
-					pkg, err := gbuild.Import(pkgPath, 0, s.InstallSuffix(), options.BuildTags)
-					if s.Watcher != nil && pkg != nil { // add watch even on error
-						s.Watcher.Add(pkg.Dir)
-					}
-					if err != nil {
-						return err
-					}
-
-					archive, err := s.BuildPackage(pkg)
-					if err != nil {
-						return err
-					}
-
-					if pkg.IsCommand() && !pkg.UpToDate {
-						if err := s.WriteCommandPackage(archive, pkg.PkgObj); err != nil {
-							return err
-						}
-					}
-				}
-				return nil
-			}, options, nil)
-
-			if s.Watcher == nil {
-				os.Exit(exitCode)
-			}
-			s.WaitForChange()
+		os.Args = []string{"gopherjs", "install", "-compiler=gopherjs"}
+		if options.Verbose {
+			os.Args = append(os.Args, "-v")
 		}
+		if *tags != "" {
+			os.Args = append(os.Args, "-tags", *tags)
+		}
+		os.Args = append(os.Args, args...)
+
+		cmdgo_main()
 	}
 
 	cmdGet := &cobra.Command{
@@ -229,50 +106,45 @@ func main() {
 	}
 	cmdGet.Flags().AddFlag(flagVerbose)
 	cmdGet.Flags().AddFlag(flagQuiet)
-	cmdGet.Flags().AddFlag(flagWatch)
 	cmdGet.Flags().AddFlag(flagMinify)
 	cmdGet.Flags().AddFlag(flagColor)
 	cmdGet.Flags().AddFlag(flagTags)
-	cmdGet.Run = cmdInstall.Run
+	cmdGet.Run = func(_ *cobra.Command, args []string) {
+		options.BuildTags = strings.Fields(*tags)
+
+		build.Default.GOARCH = "js"
+		cmdgo_buildContext = build.Default
+
+		os.Args = []string{"gopherjs", "get", "-compiler=gopherjs"}
+		if options.Verbose {
+			os.Args = append(os.Args, "-v")
+		}
+		if *tags != "" {
+			os.Args = append(os.Args, "-tags", *tags)
+		}
+		os.Args = append(os.Args, args...)
+
+		cmdgo_main()
+	}
 
 	cmdRun := &cobra.Command{
 		Use:   "run [gofiles...] [arguments...]",
 		Short: "compile and run Go program",
 	}
+	cmdRun.Flags().AddFlag(flagVerbose)
 	cmdRun.Run = func(cmd *cobra.Command, args []string) {
-		os.Exit(handleError(func() error {
-			lastSourceArg := 0
-			for {
-				if lastSourceArg == len(args) || !(strings.HasSuffix(args[lastSourceArg], ".go") || strings.HasSuffix(args[lastSourceArg], ".inc.js")) {
-					break
-				}
-				lastSourceArg++
-			}
-			if lastSourceArg == 0 {
-				return fmt.Errorf("gopherjs run: no go files listed")
-			}
+		options.BuildTags = strings.Fields(*tags)
 
-			tempfile, err := ioutil.TempFile(currentDirectory, filepath.Base(args[0])+".")
-			if err != nil && strings.HasPrefix(currentDirectory, runtime.GOROOT()) {
-				tempfile, err = ioutil.TempFile("", filepath.Base(args[0])+".")
-			}
-			if err != nil {
-				return err
-			}
-			defer func() {
-				tempfile.Close()
-				os.Remove(tempfile.Name())
-				os.Remove(tempfile.Name() + ".map")
-			}()
-			s := gbuild.NewSession(options)
-			if err := s.BuildFiles(args[:lastSourceArg], tempfile.Name(), currentDirectory); err != nil {
-				return err
-			}
-			if err := runNode(tempfile.Name(), args[lastSourceArg:], "", options.Quiet); err != nil {
-				return err
-			}
-			return nil
-		}, options, nil))
+		build.Default.GOARCH = "js"
+		cmdgo_buildContext = build.Default
+
+		os.Args = []string{"gopherjs", "run", "-compiler=gopherjs", "-exec=node"}
+		if options.Verbose {
+			os.Args = append(os.Args, "-v")
+		}
+		os.Args = append(os.Args, args...)
+
+		cmdgo_main()
 	}
 
 	cmdTest := &cobra.Command{
@@ -287,180 +159,38 @@ func main() {
 	outputFilename := cmdTest.Flags().StringP("output", "o", "", "Compile the test binary to the named file. The test still runs (unless -c is specified).")
 	cmdTest.Flags().AddFlag(flagMinify)
 	cmdTest.Flags().AddFlag(flagColor)
-	cmdTest.Run = func(cmd *cobra.Command, args []string) {
-		os.Exit(handleError(func() error {
-			pkgs := make([]*gbuild.PackageData, len(args))
-			for i, pkgPath := range args {
-				pkgPath = filepath.ToSlash(pkgPath)
-				var err error
-				pkgs[i], err = gbuild.Import(pkgPath, 0, "", nil)
-				if err != nil {
-					return err
-				}
-			}
-			if len(pkgs) == 0 {
-				firstGopathWorkspace := filepath.SplitList(build.Default.GOPATH)[0]
-				srcDir, err := filepath.EvalSymlinks(filepath.Join(firstGopathWorkspace, "src"))
-				if err != nil {
-					return err
-				}
-				var pkg *gbuild.PackageData
-				if strings.HasPrefix(currentDirectory, srcDir) {
-					pkgPath, err := filepath.Rel(srcDir, currentDirectory)
-					if err != nil {
-						return err
-					}
-					if pkg, err = gbuild.Import(pkgPath, 0, "", nil); err != nil {
-						return err
-					}
-				}
-				if pkg == nil {
-					if pkg, err = gbuild.ImportDir(currentDirectory, 0); err != nil {
-						return err
-					}
-					pkg.ImportPath = "_" + currentDirectory
-				}
-				pkgs = []*gbuild.PackageData{pkg}
-			}
+	cmdTest.Flags().AddFlag(flagTags)
+	cmdTest.Run = func(_ *cobra.Command, args []string) {
+		options.BuildTags = strings.Fields(*tags)
 
-			var exitErr error
-			for _, pkg := range pkgs {
-				if len(pkg.TestGoFiles) == 0 && len(pkg.XTestGoFiles) == 0 {
-					fmt.Printf("?   \t%s\t[no test files]\n", pkg.ImportPath)
-					continue
-				}
-				s := gbuild.NewSession(options)
+		build.Default.GOARCH = "js"
+		cmdgo_buildContext = build.Default
 
-				tests := &testFuncs{Package: pkg.Package}
-				collectTests := func(testPkg *gbuild.PackageData, testPkgName string, needVar *bool) error {
-					if testPkgName == "_test" {
-						for _, file := range pkg.TestGoFiles {
-							if err := tests.load(filepath.Join(pkg.Package.Dir, file), testPkgName, &tests.ImportTest, &tests.NeedTest); err != nil {
-								return err
-							}
-						}
-					} else {
-						for _, file := range pkg.XTestGoFiles {
-							if err := tests.load(filepath.Join(pkg.Package.Dir, file), "_xtest", &tests.ImportXtest, &tests.NeedXtest); err != nil {
-								return err
-							}
-						}
-					}
-					_, err := s.BuildPackage(testPkg)
-					if err != nil {
-						return err
-					}
-					return nil
-				}
+		os.Args = []string{"gopherjs", "test", "-compiler=gopherjs", "-exec=node"}
+		if *bench != "" {
+			os.Args = append(os.Args, "-bench", *bench)
+		}
+		if *run != "" {
+			os.Args = append(os.Args, "-run", *run)
+		}
+		if *short {
+			os.Args = append(os.Args, "-short")
+		}
+		if *verbose {
+			os.Args = append(os.Args, "-v")
+		}
+		if *compileOnly {
+			os.Args = append(os.Args, "-c")
+		}
+		if *outputFilename != "" {
+			os.Args = append(os.Args, "-o", *outputFilename)
+		}
+		if *tags != "" {
+			os.Args = append(os.Args, "-tags", *tags)
+		}
+		os.Args = append(os.Args, args...)
 
-				if err := collectTests(&gbuild.PackageData{
-					Package: &build.Package{
-						ImportPath: pkg.ImportPath,
-						Dir:        pkg.Dir,
-						GoFiles:    append(pkg.GoFiles, pkg.TestGoFiles...),
-						Imports:    append(pkg.Imports, pkg.TestImports...),
-					},
-					IsTest:  true,
-					JSFiles: pkg.JSFiles,
-				}, "_test", &tests.NeedTest); err != nil {
-					return err
-				}
-
-				if err := collectTests(&gbuild.PackageData{
-					Package: &build.Package{
-						ImportPath: pkg.ImportPath + "_test",
-						Dir:        pkg.Dir,
-						GoFiles:    pkg.XTestGoFiles,
-						Imports:    pkg.XTestImports,
-					},
-					IsTest: true,
-				}, "_xtest", &tests.NeedXtest); err != nil {
-					return err
-				}
-
-				buf := bytes.NewBuffer(nil)
-				if err := testmainTmpl.Execute(buf, tests); err != nil {
-					return err
-				}
-
-				fset := token.NewFileSet()
-				mainFile, err := parser.ParseFile(fset, "_testmain.go", buf, 0)
-				if err != nil {
-					return err
-				}
-
-				importContext := &compiler.ImportContext{
-					Packages: s.Types,
-					Import: func(path string) (*compiler.Archive, error) {
-						if path == pkg.ImportPath || path == pkg.ImportPath+"_test" {
-							return s.Archives[path], nil
-						}
-						return s.BuildImportPath(path)
-					},
-				}
-				mainPkgArchive, err := compiler.Compile("main", []*ast.File{mainFile}, fset, importContext, options.Minify)
-				if err != nil {
-					return err
-				}
-
-				if *compileOnly && *outputFilename == "" {
-					*outputFilename = pkg.Package.Name + "_test.js"
-				}
-
-				var outfile *os.File
-				if *outputFilename != "" {
-					outfile, err = os.Create(*outputFilename)
-					if err != nil {
-						return err
-					}
-				} else {
-					outfile, err = ioutil.TempFile(currentDirectory, "test.")
-					if err != nil {
-						return err
-					}
-				}
-				defer func() {
-					outfile.Close()
-					if *outputFilename == "" {
-						os.Remove(outfile.Name())
-						os.Remove(outfile.Name() + ".map")
-					}
-				}()
-
-				if err := s.WriteCommandPackage(mainPkgArchive, outfile.Name()); err != nil {
-					return err
-				}
-
-				if *compileOnly {
-					continue
-				}
-
-				var args []string
-				if *bench != "" {
-					args = append(args, "-test.bench", *bench)
-				}
-				if *run != "" {
-					args = append(args, "-test.run", *run)
-				}
-				if *short {
-					args = append(args, "-test.short")
-				}
-				if *verbose {
-					args = append(args, "-test.v")
-				}
-				status := "ok  "
-				start := time.Now()
-				if err := runNode(outfile.Name(), args, pkg.Dir, options.Quiet); err != nil {
-					if _, ok := err.(*exec.ExitError); !ok {
-						return err
-					}
-					exitErr = err
-					status = "FAIL"
-				}
-				fmt.Printf("%s\t%s\t%.3fs\n", status, pkg.ImportPath, time.Now().Sub(start).Seconds())
-			}
-			return exitErr
-		}, options, nil))
+		cmdgo_main()
 	}
 
 	cmdServe := &cobra.Command{
@@ -689,10 +419,19 @@ func handleError(f func() error, options *gbuild.Options, browserErrors *bytes.B
 	}
 }
 
+// printError prints err to Stderr with options. If browserErrors is non-nil, errors are also written for presentation in browser.
+func printError(err error, options *gbuild.Options, browserErrors *bytes.Buffer) {
+	e := sprintError(err)
+	options.PrintError("%s\n", e)
+	if browserErrors != nil {
+		fmt.Fprintln(browserErrors, `console.error("`+template.JSEscapeString(e)+`");`)
+	}
+}
+
 // sprintError returns an annotated error string without trailing newline.
 func sprintError(err error) string {
 	makeRel := func(name string) string {
-		if relname, err := filepath.Rel(currentDirectory, name); err == nil {
+		if relname, err := filepath.Rel(cmdgo_cwd, name); err == nil {
 			return relname
 		}
 		return name
@@ -708,202 +447,3 @@ func sprintError(err error) string {
 		return fmt.Sprintf("%s", e)
 	}
 }
-
-// printError prints err to Stderr with options. If browserErrors is non-nil, errors are also written for presentation in browser.
-func printError(err error, options *gbuild.Options, browserErrors *bytes.Buffer) {
-	e := sprintError(err)
-	options.PrintError("%s\n", e)
-	if browserErrors != nil {
-		fmt.Fprintln(browserErrors, `console.error("`+template.JSEscapeString(e)+`");`)
-	}
-}
-
-func runNode(script string, args []string, dir string, quiet bool) error {
-	var allArgs []string
-	if b, _ := strconv.ParseBool(os.Getenv("SOURCE_MAP_SUPPORT")); os.Getenv("SOURCE_MAP_SUPPORT") == "" || b {
-		allArgs = []string{"--require", "source-map-support/register"}
-		if err := exec.Command("node", "--require", "source-map-support/register", "--eval", "").Run(); err != nil {
-			if !quiet {
-				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Use Node.js 4.x with source-map-support module for nice stack traces.")
-			}
-			allArgs = []string{}
-		}
-	}
-
-	if runtime.GOOS != "windows" {
-		allArgs = append(allArgs, "--stack_size=10000", script)
-	}
-
-	allArgs = append(allArgs, args...)
-
-	node := exec.Command("node", allArgs...)
-	node.Dir = dir
-	node.Stdin = os.Stdin
-	node.Stdout = os.Stdout
-	node.Stderr = os.Stderr
-	err := node.Run()
-	if _, ok := err.(*exec.ExitError); err != nil && !ok {
-		err = fmt.Errorf("could not run Node.js: %s", err.Error())
-	}
-	return err
-}
-
-type testFuncs struct {
-	Tests       []testFunc
-	Benchmarks  []testFunc
-	Examples    []testFunc
-	TestMain    *testFunc
-	Package     *build.Package
-	ImportTest  bool
-	NeedTest    bool
-	ImportXtest bool
-	NeedXtest   bool
-}
-
-type testFunc struct {
-	Package string // imported package name (_test or _xtest)
-	Name    string // function name
-	Output  string // output, for examples
-}
-
-var testFileSet = token.NewFileSet()
-
-func (t *testFuncs) load(filename, pkg string, doImport, seen *bool) error {
-	f, err := parser.ParseFile(testFileSet, filename, nil, parser.ParseComments)
-	if err != nil {
-		return err
-	}
-	for _, d := range f.Decls {
-		n, ok := d.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if n.Recv != nil {
-			continue
-		}
-		name := n.Name.String()
-		switch {
-		case isTestMain(n):
-			if t.TestMain != nil {
-				return errors.New("multiple definitions of TestMain")
-			}
-			t.TestMain = &testFunc{pkg, name, ""}
-			*doImport, *seen = true, true
-		case isTest(name, "Test"):
-			t.Tests = append(t.Tests, testFunc{pkg, name, ""})
-			*doImport, *seen = true, true
-		case isTest(name, "Benchmark"):
-			t.Benchmarks = append(t.Benchmarks, testFunc{pkg, name, ""})
-			*doImport, *seen = true, true
-		}
-	}
-	// TODO: Support examples, populate t.Examples here.
-	//       Blocking on https://github.com/gopherjs/gopherjs/issues/381 being resolved.
-	return nil
-}
-
-type byOrder []*doc.Example
-
-func (x byOrder) Len() int           { return len(x) }
-func (x byOrder) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
-func (x byOrder) Less(i, j int) bool { return x[i].Order < x[j].Order }
-
-// isTestMain tells whether fn is a TestMain(m *testing.M) function.
-func isTestMain(fn *ast.FuncDecl) bool {
-	if fn.Name.String() != "TestMain" ||
-		fn.Type.Results != nil && len(fn.Type.Results.List) > 0 ||
-		fn.Type.Params == nil ||
-		len(fn.Type.Params.List) != 1 ||
-		len(fn.Type.Params.List[0].Names) > 1 {
-		return false
-	}
-	ptr, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
-	if !ok {
-		return false
-	}
-	// We can't easily check that the type is *testing.M
-	// because we don't know how testing has been imported,
-	// but at least check that it's *M or *something.M.
-	if name, ok := ptr.X.(*ast.Ident); ok && name.Name == "M" {
-		return true
-	}
-	if sel, ok := ptr.X.(*ast.SelectorExpr); ok && sel.Sel.Name == "M" {
-		return true
-	}
-	return false
-}
-
-// isTest tells whether name looks like a test (or benchmark, according to prefix).
-// It is a Test (say) if there is a character after Test that is not a lower-case letter.
-// We don't want TesticularCancer.
-func isTest(name, prefix string) bool {
-	if !strings.HasPrefix(name, prefix) {
-		return false
-	}
-	if len(name) == len(prefix) { // "Test" is ok
-		return true
-	}
-	rune, _ := utf8.DecodeRuneInString(name[len(prefix):])
-	return !unicode.IsLower(rune)
-}
-
-var testmainTmpl = template.Must(template.New("main").Parse(`
-package main
-
-import (
-{{if not .TestMain}}
-	"os"
-{{end}}
-	"regexp"
-	"testing"
-
-{{if .ImportTest}}
-	{{if .NeedTest}}_test{{else}}_{{end}} {{.Package.ImportPath | printf "%q"}}
-{{end}}
-{{if .ImportXtest}}
-	{{if .NeedXtest}}_xtest{{else}}_{{end}} {{.Package.ImportPath | printf "%s_test" | printf "%q"}}
-{{end}}
-)
-
-var tests = []testing.InternalTest{
-{{range .Tests}}
-	{"{{.Name}}", {{.Package}}.{{.Name}}},
-{{end}}
-}
-
-var benchmarks = []testing.InternalBenchmark{
-{{range .Benchmarks}}
-	{"{{.Name}}", {{.Package}}.{{.Name}}},
-{{end}}
-}
-
-var examples = []testing.InternalExample{
-{{range .Examples}}
-	{"{{.Name}}", {{.Package}}.{{.Name}}, {{.Output | printf "%q"}}},
-{{end}}
-}
-
-var matchPat string
-var matchRe *regexp.Regexp
-
-func matchString(pat, str string) (result bool, err error) {
-	if matchRe == nil || matchPat != pat {
-		matchPat = pat
-		matchRe, err = regexp.Compile(matchPat)
-		if err != nil {
-			return
-		}
-	}
-	return matchRe.MatchString(str), nil
-}
-
-func main() {
-	m := testing.MainStart(matchString, tests, benchmarks, examples)
-{{with .TestMain}}
-	{{.Package}}.{{.Name}}(m)
-{{else}}
-	os.Exit(m.Run())
-{{end}}
-}
-
-`))


### PR DESCRIPTION
DO NOT MERGE. This is a PR for review only, it's not in a mergable state because not all components are present. I want to break review of the final PR into smaller pieces, to make it more diffs smaller and manageable.

This change rewrites tool.go to use the functionality of cmd/go with GopherJS compiler support added, which will be bundled here.

Changes:

- -watch flag is removed. Supporting it is possible, but difficult at this time and it's hard to test it. It may be brought back later, or maybe it'll be decided that it's out of scope, and another tool can help with watching. With gopherjs serve command available, the need for -watch flag is greatly reduced.

This is a mostly mechanical change, done by hand, so there's a chance for typos or other screw ups, forgetting flags, etc. This is what I want this review to catch.

Helps #388.