### PR TITLE
build: Add test to verify that augmented packages don't import extras.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -135,10 +135,11 @@ func ImportDir(dir string, mode build.ImportMode) (*PackageData, error) {
 	return &PackageData{Package: pkg, JSFiles: jsFiles}, nil
 }
 
-// parse parses and returns all .go files of given pkg.
+// parseAndAugment parses and returns all .go files of given pkg.
 // Standard Go library packages are augmented with files in compiler/natives folder.
-// isTest is true when package is being built for running tests.
-func parse(pkg *build.Package, isTest bool, fileSet *token.FileSet) ([]*ast.File, error) {
+// If isTest is true and pkg.ImportPath has no _test suffix, package is built for running internal tests.
+// If isTest is true and pkg.ImportPath has _test suffix, package is built for running external tests.
+func parseAndAugment(pkg *build.Package, isTest bool, fileSet *token.FileSet) ([]*ast.File, error) {
 	var files []*ast.File
 	replacedDeclNames := make(map[string]bool)
 	funcName := func(d *ast.FuncDecl) string {
@@ -550,7 +551,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 	}
 
 	fileSet := token.NewFileSet()
-	files, err := parse(pkg.Package, pkg.IsTest, fileSet)
+	files, err := parseAndAugment(pkg.Package, pkg.IsTest, fileSet)
 	if err != nil {
 		return nil, err
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -139,6 +139,13 @@ func ImportDir(dir string, mode build.ImportMode) (*PackageData, error) {
 // Standard Go library packages are augmented with files in compiler/natives folder.
 // If isTest is true and pkg.ImportPath has no _test suffix, package is built for running internal tests.
 // If isTest is true and pkg.ImportPath has _test suffix, package is built for running external tests.
+//
+// The native packages are augmented by the contents of natives.FS in the following way.
+// The file names do not matter except the usual `_test` suffix. The files for
+// native overrides get added to the package (even if they have the same name
+// as an existing file from the standard library). For all identifiers that exist
+// in the original AND the overrides, the original identifier in the AST gets
+// replaced by `_`. New identifiers that don't exist in original package get added.
 func parseAndAugment(pkg *build.Package, isTest bool, fileSet *token.FileSet) ([]*ast.File, error) {
 	var files []*ast.File
 	replacedDeclNames := make(map[string]bool)

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -1,0 +1,169 @@
+package build
+
+import (
+	gobuild "go/build"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kisielk/gotool"
+	"github.com/shurcooL/go/importgraphutil"
+)
+
+// Natives augment the standard library with GopherJS-specific changes.
+// This test ensures that none of the standard library packages are modified
+// in a way that adds imports which the original upstream standard library package
+// does not already import. Doing that can increase generated output size or cause
+// other unexpected issues (since the cmd/go tool does not know about these extra imports),
+// so it's best to avoid it.
+//
+// It checks all standard library packages. Each package is considered as a normal
+// package, as a test package, and as an external test package.
+func TestNativesDontImportExtraPackages(t *testing.T) {
+	// Calculate the forward import graph for all standard library packages.
+	// It's needed for populateImportSet.
+	stdOnly := gobuild.Default
+	stdOnly.GOPATH = "" // We only care about standard library, so skip all GOPATH packages.
+	forward, _, err := importgraphutil.BuildNoTests(&stdOnly)
+	if err != nil {
+		t.Fatalf("importgraphutil.BuildNoTests: %v", err)
+	}
+
+	// populateImportSet takes a slice of imports, and populates set with those
+	// imports, as well as their transitive dependencies. That way, the set can
+	// be quickly queried to check if a package is in the import graph of imports.
+	//
+	// Note, this does not include transitive imports of test/xtest packages,
+	// which could cause some false positives. It currently doesn't, but if it does,
+	// then support for that should be added here.
+	populateImportSet := func(imports []string, set *map[string]struct{}) {
+		for _, p := range imports {
+			(*set)[p] = struct{}{}
+			switch p {
+			case "sync":
+				(*set)["github.com/gopherjs/gopherjs/nosync"] = struct{}{}
+			}
+			transitiveImports := forward.Search(p)
+			for p := range transitiveImports {
+				(*set)[p] = struct{}{}
+			}
+		}
+	}
+
+	// Check all standard library packages.
+	for _, pkg := range gotool.ImportPaths([]string{"std"}) {
+		// Normal package.
+		{
+			bpkg, err := gobuild.Import(pkg, "", gobuild.ImportComment)
+			if err != nil {
+				t.Fatalf("gobuild.Import: %v", err)
+			}
+			realImports := make(map[string]struct{})
+			populateImportSet(bpkg.Imports, &realImports)
+
+			fset := token.NewFileSet()
+			files, err := parse(bpkg, false, fset)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			for _, f := range files {
+				fileName := fset.File(f.Pos()).Name()
+				normalFile := !strings.HasSuffix(fileName, "_test.go")
+				if !normalFile {
+					continue
+				}
+				for _, imp := range f.Imports {
+					importPath, err := strconv.Unquote(imp.Path.Value)
+					if err != nil {
+						t.Fatalf("strconv.Unquote(%v): %v", imp.Path.Value, err)
+					}
+					if importPath == "github.com/gopherjs/gopherjs/js" {
+						continue
+					}
+					if _, ok := realImports[importPath]; !ok {
+						t.Errorf("augmented normal package %q imports %q in file %v, but real %q doesn't:\nrealImports = %q", bpkg.ImportPath, importPath, fileName, bpkg.ImportPath, toSlice(realImports))
+					}
+				}
+			}
+		}
+
+		// Test package.
+		{
+			bpkg, err := gobuild.Import(pkg, "", gobuild.ImportComment)
+			if err != nil {
+				t.Fatalf("gobuild.Import: %v", err)
+			}
+			realTestImports := make(map[string]struct{})
+			populateImportSet(bpkg.TestImports, &realTestImports)
+
+			fset := token.NewFileSet()
+			files, err := parse(bpkg, true, fset)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			for _, f := range files {
+				fileName, pkgName := fset.File(f.Pos()).Name(), f.Name.String()
+				testFile := strings.HasSuffix(fileName, "_test.go") && !strings.HasSuffix(pkgName, "_test")
+				if !testFile {
+					continue
+				}
+				for _, imp := range f.Imports {
+					importPath, err := strconv.Unquote(imp.Path.Value)
+					if err != nil {
+						t.Fatalf("strconv.Unquote(%v): %v", imp.Path.Value, err)
+					}
+					if importPath == "github.com/gopherjs/gopherjs/js" {
+						continue
+					}
+					if _, ok := realTestImports[importPath]; !ok {
+						t.Errorf("augmented test package %q imports %q in file %v, but real %q doesn't:\nrealTestImports = %q", bpkg.ImportPath, importPath, fileName, bpkg.ImportPath, toSlice(realTestImports))
+					}
+				}
+			}
+		}
+
+		// External test package.
+		{
+			bpkg, err := gobuild.Import(pkg, "", gobuild.ImportComment)
+			if err != nil {
+				t.Fatalf("gobuild.Import: %v", err)
+			}
+			realXTestImports := make(map[string]struct{})
+			populateImportSet(bpkg.XTestImports, &realXTestImports)
+
+			fset := token.NewFileSet()
+			files, err := parse(bpkg, true, fset)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			for _, f := range files {
+				fileName, pkgName := fset.File(f.Pos()).Name(), f.Name.String()
+				xTestFile := strings.HasSuffix(fileName, "_test.go") && strings.HasSuffix(pkgName, "_test")
+				if !xTestFile {
+					continue
+				}
+				for _, imp := range f.Imports {
+					importPath, err := strconv.Unquote(imp.Path.Value)
+					if err != nil {
+						t.Fatalf("strconv.Unquote(%v): %v", imp.Path.Value, err)
+					}
+					if importPath == "github.com/gopherjs/gopherjs/js" {
+						continue
+					}
+					if _, ok := realXTestImports[importPath]; !ok {
+						t.Errorf("augmented external test package %q imports %q in file %v, but real %q doesn't:\nrealXTestImports = %q", bpkg.ImportPath, importPath, fileName, bpkg.ImportPath, toSlice(realXTestImports))
+					}
+				}
+			}
+		}
+	}
+}
+
+func toSlice(m map[string]struct{}) []string {
+	s := make([]string, 0, len(m))
+	for v := range m {
+		s = append(s, v)
+	}
+	return s
+}

--- a/compiler/natives/doc.go
+++ b/compiler/natives/doc.go
@@ -1,4 +1,8 @@
 // Package natives provides native packages via a virtual filesystem.
+//
+// See documentation of parseAndAugment in github.com/gopherjs/gopherjs/build
+// for explanation of behavior used to augment the native packages using the files
+// in src subfolder.
 package natives
 
 //go:generate vfsgendev -source="github.com/gopherjs/gopherjs/compiler/natives".FS


### PR DESCRIPTION
Natives augment the standard library with GopherJS-specific changes. This test ensures that none of the standard library packages are modified in a way that adds imports which the original upstream standard library package does not already import. Doing that can increase generated output size or cause other unexpected issues (since the cmd/go tool does not know about these extra imports), so it's best to avoid it.

It checks all standard library packages. Each package is considered as a normal package, as a test package, and as an external test package.

Depends on #480 and #482 being merged. It catches both those issues, so the test will fail until those PRs are merged (and this branch is rebased).