### PR TITLE
Exits with non-success exit code upon root command failure

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -530,7 +530,7 @@ func main() {
 	rootCmd.AddCommand(cmdBuild, cmdGet, cmdInstall, cmdRun, cmdTest, cmdServe, cmdVersion)
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(-1)
+		os.Exit(2)
 	}
 }
 

--- a/tool.go
+++ b/tool.go
@@ -528,7 +528,10 @@ func main() {
 		Long: "GopherJS is a tool for compiling Go source code to JavaScript.",
 	}
 	rootCmd.AddCommand(cmdBuild, cmdGet, cmdInstall, cmdRun, cmdTest, cmdServe, cmdVersion)
-	rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(-1)
+	}
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted


### PR DESCRIPTION
This PR improves the usability of gopherjs in shell scripts by ensuring that a failure due to unknown command line flags results in a non-success exit code.