### PR TITLE
compiler/natives/src/net/http: Stay with ignored stream cancel error.

### DIFF
--- a/compiler/natives/src/net/http/fetch.go
+++ b/compiler/natives/src/net/http/fetch.go
@@ -49,20 +49,9 @@ func (r *streamReader) Read(p []byte) (n int, err error) {
 }
 
 func (r *streamReader) Close() error {
-	// TOOD: Cannot do this because it's a blocking call, and Close() is often called
-	//       via `defer resp.Body.Close()`, but GopherJS currently has an issue with supporting that.
-	//       See https://github.com/gopherjs/gopherjs/issues/381 and https://github.com/gopherjs/gopherjs/issues/426.
-	/*ch := make(chan error)
-	r.stream.Call("cancel").Call("then",
-		func(result *js.Object) {
-			if result != js.Undefined {
-				ch <- errors.New(result.String()) // TODO: Verify this works, it probably doesn't and should be rewritten as result.Get("message").String() or something.
-				return
-			}
-			ch <- nil
-		},
-	)
-	return <-ch*/
+	// This ignores any error returned from cancel method. So far, I did not encounter any concrete
+	// situation where reporting the error is meaningful. Most users ignore error from resp.Body.Close().
+	// If there's a need to report error here, it can be implemented and tested when that need comes up.
 	r.stream.Call("cancel")
 	return nil
 }


### PR DESCRIPTION
Previously, it was not possible to call stream.cancel and block until a response was available, because of a bug in GopherJS that prevented blocking func calls from being deferred.

That bug has since been resolved in 50101461d59f26b13c876f57aab314ce55387671, so it's possible to do that now.

However, I found no compelling reason to do so at this time. I prefer not to implement this without a concrete reason and a way of testing that it works correctly, so simply update the comment and remove commented out code.

If a need comes up in the future, it can be implemented and tested then.

Do not regenerate because this change is a noop.

### References

- https://fetch.spec.whatwg.org/
- https://streams.spec.whatwg.org/#readable-stream-cancel