### PR TITLE
README: Document that using vendored GopherJS is currently not supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GopherJS - A compiler from Go to JavaScript
 GopherJS compiles Go code ([golang.org](https://golang.org/)) to pure JavaScript code. Its main purpose is to give you the opportunity to write front-end code in Go which will still run in all browsers. Give GopherJS a try on the [GopherJS Playground](http://gopherjs.github.io/playground/).
 
 ### What is supported?
-Nearly everything, including Goroutines ([compatibility table](https://github.com/gopherjs/gopherjs/blob/master/doc/packages.md)). Performance is quite good in most cases, see [HTML5 game engine benchmark](https://ajhager.github.io/engi/demos/botmark.html). Cgo is not supported.
+Nearly everything, including Goroutines ([compatibility table](https://github.com/gopherjs/gopherjs/blob/master/doc/packages.md)). Performance is quite good in most cases, see [HTML5 game engine benchmark](https://ajhager.github.io/engi/demos/botmark.html). Cgo is not supported. Using a vendored copy of GopherJS is currently not supported, see [#415](https://github.com/gopherjs/gopherjs/issues/415).
 
 ### Installation and Usage
 Get or update GopherJS and dependencies with:


### PR DESCRIPTION
GopherJS itself supports vendoring, but vendoring _it_ into your project is currently not supported. Issue #415 tracks the progress on fixing that.

Helps #415.
Updates #537.

/cc @jraedisch and @myitcv FYI.