### PR TITLE
Add missing line spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you include an argument, it will be the root from which everything is served.
 - [GopherJS on Twitter](https://twitter.com/GopherJS)
 
 ### Getting started
+
 #### Interacting with the DOM
 The package `github.com/gopherjs/gopherjs/js` (see [documentation](https://godoc.org/github.com/gopherjs/gopherjs/js)) provides functions for interacting with native JavaScript APIs. For example the line
 


### PR DESCRIPTION
Insert a missing newline tells the markdown parser to generate a header instead of just '####'. See current gopherjs page for reference.