### PR TITLE
README: Remove google group link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ If you include an argument, it will be the root from which everything is served.
 
 ### Community
 - [#gopherjs Channel on Gophers Slack](https://gophers.slack.com/messages/gopherjs/) (invites to Gophers Slack are available [here](http://blog.gopheracademy.com/gophers-slack-community/#how-can-i-be-invited-to-join:2facdc921b2310f18cb851c36fa92369))
-- [Google Group](https://groups.google.com/d/forum/gopherjs)
 - [Bindings to JavaScript APIs and libraries](https://github.com/gopherjs/gopherjs/wiki/bindings)
 - [GopherJS on Twitter](https://twitter.com/GopherJS)
 


### PR DESCRIPTION
The google group for GopherJS has been deprecated (it's read-only now). It has bad UI, and it was used very infrequently. Messages posted there were often not seen for weeks by anyone. It's better to have them posted elsewhere.

Please use the issue tracker and slack channel instead.