### PR TITLE
Use defer attribute in gopherjs serve default HTML.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -665,7 +665,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 
 	if isIndex {
 		// If there was no index.html file in any dirs, supply our own.
-		return newFakeFile("index.html", []byte(`<html><head><meta charset="utf-8"><script src="`+base+`.js"></script></head><body></body></html>`)), nil
+		return newFakeFile("index.html", []byte(`<html><head><meta charset="utf-8"><script defer src="`+base+`.js"></script></head><body></body></html>`)), nil
 	}
 
 	return nil, os.ErrNotExist


### PR DESCRIPTION
Note, because the implementation was trivial, this PR serves as both a proposal (up for discussion) and implementation in one.

---

The defer attribute specifies that the script is executed when the page has finished parsing.

This affects the default HTML served by gopherjs serve command when there
isn't an index.html provided. Advanced users who want custom behavior will be
specifying their own HTML anyway. For beginners or people looking to write
a quick snippet, having the script be deferred makes it easier to not worry about
the script running before the body is available. It allows writing:

```Go
var document = dom.GetWindow().Document().(dom.HTMLDocument)

func main() {
	body := document.Body()
	// ... use body right away
}
```

Instead of having to write:

```Go
var document = dom.GetWindow().Document().(dom.HTMLDocument)

func main() {
	switch readyState := document.ReadyState(); readyState {
	case "loading":
		document.AddEventListener("DOMContentLoaded", false, func(dom.Event) {
			go setup()
		})
	case "interactive", "complete":
		setup()
	default:
		panic(fmt.Errorf("internal error: unexpected document.ReadyState value: %v", readyState))
	}
}

func setup() {
	body := document.Body()
	// ... use body right away
}
```

Which is more user friendly.

References:

-	http://www.w3schools.com/tags/att_script_defer.asp
-	https://developer.mozilla.org/en/docs/Web/HTML/Element/script
-	http://caniuse.com/#feat=script-defer