### PR TITLE
build: Detect vendored js package and return error.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -79,6 +79,11 @@ func importWithSrcDir(path string, srcDir string, mode build.ImportMode, install
 		return nil, err
 	}
 
+	// TODO: Resolve issue #415 and remove this temporary workaround.
+	if strings.HasSuffix(pkg.ImportPath, "/vendor/github.com/gopherjs/gopherjs/js") {
+		return nil, fmt.Errorf("vendoring github.com/gopherjs/gopherjs/js package is not supported, see https://github.com/gopherjs/gopherjs/issues/415")
+	}
+
 	switch path {
 	case "runtime":
 		pkg.GoFiles = []string{"error.go"}

--- a/compiler/typesutil/typesutil.go
+++ b/compiler/typesutil/typesutil.go
@@ -1,11 +1,19 @@
 package typesutil
 
 import (
+	"fmt"
 	"go/types"
+	"os"
 	"strings"
 )
 
 func IsJsPackage(pkg *types.Package) bool {
+	// TODO: Resolve issue #415 and remove this temporary workaround.
+	if pkg != nil && strings.HasSuffix(pkg.Path(), "/vendor/github.com/gopherjs/gopherjs/js") {
+		fmt.Fprintln(os.Stderr, "GopherJS: vendoring github.com/gopherjs/gopherjs/js package is not supported, see https://github.com/gopherjs/gopherjs/issues/415.")
+		os.Exit(1)
+	}
+
 	return pkg != nil && (pkg.Path() == "github.com/gopherjs/gopherjs/js" || strings.HasSuffix(pkg.Path(), "/vendor/github.com/gopherjs/gopherjs/js"))
 }
 

--- a/compiler/typesutil/typesutil.go
+++ b/compiler/typesutil/typesutil.go
@@ -1,19 +1,11 @@
 package typesutil
 
 import (
-	"fmt"
 	"go/types"
-	"os"
 	"strings"
 )
 
 func IsJsPackage(pkg *types.Package) bool {
-	// TODO: Resolve issue #415 and remove this temporary workaround.
-	if pkg != nil && strings.HasSuffix(pkg.Path(), "/vendor/github.com/gopherjs/gopherjs/js") {
-		fmt.Fprintln(os.Stderr, "GopherJS: vendoring github.com/gopherjs/gopherjs/js package is not supported, see https://github.com/gopherjs/gopherjs/issues/415.")
-		os.Exit(1)
-	}
-
 	return pkg != nil && (pkg.Path() == "github.com/gopherjs/gopherjs/js" || strings.HasSuffix(pkg.Path(), "/vendor/github.com/gopherjs/gopherjs/js"))
 }
 


### PR DESCRIPTION
This follows #538.

Vendoring `github.com/gopherjs/gopherjs/js` package is not supported, and can cause hard to understand runtime errors. Better catch it earlier and print a clear error message.

Helps #569.