### PR TITLE
Eliminate duplicate logical right shifts

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -376,6 +376,9 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 					if i >= 32 {
 						return c.formatExpr("0")
 					}
+					if op == ">>>" && isUnsigned(basic) {
+						return c.formatExpr("%e %s %s", e.X, op, strconv.FormatUint(i, 10))
+					}
 					return c.fixNumber(c.formatExpr("%e %s %s", e.X, op, strconv.FormatUint(i, 10)), basic)
 				}
 				if e.Op == token.SHR && !isUnsigned(basic) {


### PR DESCRIPTION
When doing an logical right shift, there's no need to append another
zero bit logical right shift to coerce to 32 bit unsigned.