### PR TITLE
Optimize bounds checking's ternary operator use

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -623,7 +623,7 @@ func rangeCheck(pattern string, constantIndex, array bool) string {
 	if !constantIndex {
 		check = "(%2f < 0 || " + check + ")"
 	}
-	return "(" + check + ` ? $throwRuntimeError("index out of range") : ` + pattern + ")"
+	return "(" + check + ` ? ($throwRuntimeError("index out of range"), undefined) : ` + pattern + ")"
 }
 
 func endsWithReturn(stmts []ast.Stmt) bool {


### PR DESCRIPTION
By supplying a value on both sides of the check, browsers are able to
always assume a value will exist (even if it is bypassed by the thrown
error), and optimize accordingly.