### PR TITLE
Handle GOARCH env var similarly to cmd/go.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -66,8 +67,8 @@ func Import(path string, mode build.ImportMode, installSuffix string, buildTags 
 
 func importWithSrcDir(path string, srcDir string, mode build.ImportMode, installSuffix string, buildTags []string) (*PackageData, error) {
 	buildContext := NewBuildContext(installSuffix, buildTags)
-	if path == "runtime" || path == "syscall" {
-		buildContext.GOARCH = build.Default.GOARCH
+	if path == "syscall" { // syscall needs to use a typical GOARCH like amd64 to pick up definitions for _Socklen, BpfInsn, IFNAMSIZ, Timeval, BpfStat, SYS_FCNTL, Flock_t, etc.
+		buildContext.GOARCH = runtime.GOARCH
 		buildContext.InstallSuffix = "js"
 		if installSuffix != "" {
 			buildContext.InstallSuffix += "_" + installSuffix

--- a/tests/run.go
+++ b/tests/run.go
@@ -620,7 +620,9 @@ func (t *test) run() {
 		os.Setenv("GOOS", runtime.GOOS)
 	}
 	if os.Getenv("GOARCH") == "" {
-		os.Setenv("GOARCH", runtime.GOARCH)
+		//os.Setenv("GOARCH", runtime.GOARCH)
+		// GOPHERJS.
+		os.Setenv("GOARCH", "js") // We're running this script natively, but the tests are executed with js architecture.
 	}
 
 	useTmp := true

--- a/tool.go
+++ b/tool.go
@@ -91,7 +91,7 @@ func main() {
 	cmdBuild.Flags().AddFlag(flagTags)
 	cmdBuild.Flags().AddFlag(flagLocalMap)
 	cmdBuild.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -176,7 +176,7 @@ func main() {
 	cmdInstall.Flags().AddFlag(flagTags)
 	cmdInstall.Flags().AddFlag(flagLocalMap)
 	cmdInstall.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -246,7 +246,7 @@ func main() {
 		Short: "display documentation for the requested, package, method or symbol",
 	}
 	cmdDoc.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -282,7 +282,7 @@ func main() {
 		Short: "compile and run Go program",
 	}
 	cmdRun.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -337,7 +337,7 @@ func main() {
 	cmdTest.Flags().AddFlag(flagTags)
 	cmdTest.Flags().AddFlag(flagLocalMap)
 	cmdTest.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -533,7 +533,7 @@ func main() {
 	var addr string
 	cmdServe.Flags().StringVarP(&addr, "http", "", ":8080", "HTTP bind address to serve")
 	cmdServe.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyAndUnsetGOARCH(); err != nil {
+		if err := verifyGOARCH(); err != nil {
 			printError(err, options, nil)
 			os.Exit(2)
 		}
@@ -796,10 +796,9 @@ func printError(err error, options *gbuild.Options, browserErrors *bytes.Buffer)
 	}
 }
 
-// verifyAndUnsetGOARCH verifies that GOARCH environment value is not set to
-// an unsupported value. It also unsets it, if set, because the gopherjs compiler
-// expects build.Default.GOARCH to actually be something like amd64 rather than js.
-func verifyAndUnsetGOARCH() error {
+// verifyGOARCH verifies that GOARCH environment value is not set to
+// an unsupported value.
+func verifyGOARCH() error {
 	goarch, ok := os.LookupEnv("GOARCH")
 	if !ok {
 		return nil
@@ -807,11 +806,6 @@ func verifyAndUnsetGOARCH() error {
 	if goarch != "js" {
 		return fmt.Errorf("gopherjs: unsupported GOOS/GOARCH pair %s/%s", build.Default.GOOS, goarch)
 	}
-	err := os.Unsetenv("GOARCH")
-	if err != nil {
-		return err
-	}
-	build.Default.GOARCH = runtime.GOARCH // Reset GOARCH to its default value, what it would've been had the GOARCH environment variable not overridden it.
 	return nil
 }
 


### PR DESCRIPTION
Externally, GOARCH=js is the only supported mode for gopherjs compiler. Make it so that setting GOARCH=js explicitly does what one would expect, which is normal gopherjs behavior instead of a strange error.

If GOARCH is set to any value other than js, which are not supported, exit with an error (similar to cmd/go behavior).

Set "GOARCH" env var to correct value for gopherjs in tests/run.go.

Fixes #594.