### PR TITLE
Don't ignore array type for special JS array types

### DIFF
--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -119,9 +119,6 @@ var $substring = function(str, low, high) {
 };
 
 var $sliceToArray = function(slice) {
-  if (slice.$length === 0) {
-    return new slice.$array.constructor;
-  }
   if (slice.$array.constructor !== Array) {
     return slice.$array.subarray(slice.$offset, slice.$offset + slice.$length);
   }

--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -120,7 +120,7 @@ var $substring = function(str, low, high) {
 
 var $sliceToArray = function(slice) {
   if (slice.$length === 0) {
-    return [];
+    return new slice.$array.constructor;
   }
   if (slice.$array.constructor !== Array) {
     return slice.$array.subarray(slice.$offset, slice.$offset + slice.$length);

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -43,6 +43,9 @@ var dummys = js.Global.Call("eval", `({
 	call: function(f, a) {
 		f(a);
 	},
+	return: function(x) {
+		return x;
+	},
 })`)
 
 func TestBool(t *testing.T) {
@@ -559,16 +562,12 @@ func TestSurrogatePairs(t *testing.T) {
 	}
 }
 
-func instanceof(x interface{}, y *js.Object) bool {
-	return js.Global.Call("$instanceof", x, y).Bool()
-}
-
 func TestUint8Array(t *testing.T) {
 	uint8Array := js.Global.Get("Uint8Array")
-	if !instanceof([]byte{}, uint8Array) {
+	if dummys.Call("return", []byte{}).Get("constructor") != uint8Array {
 		t.Errorf("Empty byte array is not externalized as a Uint8Array")
 	}
-	if !instanceof([]byte{0x01}, uint8Array) {
+	if dummys.Call("return", []byte{0x01}).Get("constructor") != uint8Array {
 		t.Errorf("Non-empty byte array is not externalized as a Uint8Array")
 	}
 }

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -558,3 +558,17 @@ func TestSurrogatePairs(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func instanceof(x interface{}, y *js.Object) bool {
+	return js.Global.Call("$instanceof", x, y).Bool()
+}
+
+func TestUint8Array(t *testing.T) {
+	uint8Array := js.Global.Get("Uint8Array")
+	if !instanceof([]byte{}, uint8Array) {
+		t.Errorf("Empty byte array is not externalized as a Uint8Array")
+	}
+	if !instanceof([]byte{0x01}, uint8Array) {
+		t.Errorf("Non-empty byte array is not externalized as a Uint8Array")
+	}
+}

--- a/js/js_test.inc.js
+++ b/js/js_test.inc.js
@@ -1,1 +1,0 @@
-$global.$instanceof = function(x,y) { return x instanceof y };

--- a/js/js_test.inc.js
+++ b/js/js_test.inc.js
@@ -1,0 +1,1 @@
+$global.$instanceof = function(x,y) { return x instanceof y };

--- a/tests/deferblock_test.go
+++ b/tests/deferblock_test.go
@@ -26,7 +26,7 @@ func outer(ch chan struct{}, b bool) ([]byte, error) {
 func TestBlockingInDefer(t *testing.T) {
 	defer func() {
 		if x := recover(); x != nil {
-			t.Error("run time panic: %v", x)
+			t.Errorf("run time panic: %v", x)
 		}
 	}()
 


### PR DESCRIPTION
This PR should fix the problem mentioned in #597 .

Using this sample program:

    package main

    import "honnef.co/go/js/console"

    func main() {
    	x := []byte{}
    	var y []byte
    	z := []byte{0x01}
    	console.Log(x)
    	console.Log(y)
    	console.Log(z)
    }

Before:

    []
    []
    Uint8Array [ 1 ]

After:

    Uint8Array [  ]
    Uint8Array [  ]
    Uint8Array [ 1 ]
