### PR TITLE
Revert "Handle GOARCH env var similarly to cmd/go."

### DIFF
--- a/tests/run.go
+++ b/tests/run.go
@@ -620,9 +620,7 @@ func (t *test) run() {
 		os.Setenv("GOOS", runtime.GOOS)
 	}
 	if os.Getenv("GOARCH") == "" {
-		//os.Setenv("GOARCH", runtime.GOARCH)
-		// GOPHERJS.
-		os.Setenv("GOARCH", "js") // We're running this script natively, but the tests are executed with js architecture.
+		os.Setenv("GOARCH", runtime.GOARCH)
 	}
 
 	useTmp := true

--- a/tool.go
+++ b/tool.go
@@ -91,10 +91,6 @@ func main() {
 	cmdBuild.Flags().AddFlag(flagTags)
 	cmdBuild.Flags().AddFlag(flagLocalMap)
 	cmdBuild.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		options.BuildTags = strings.Fields(*tags)
 		for {
 			s := gbuild.NewSession(options)
@@ -177,10 +173,6 @@ func main() {
 	cmdInstall.Flags().AddFlag(flagTags)
 	cmdInstall.Flags().AddFlag(flagLocalMap)
 	cmdInstall.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		options.BuildTags = strings.Fields(*tags)
 		for {
 			s := gbuild.NewSession(options)
@@ -248,10 +240,6 @@ func main() {
 		Short: "display documentation for the requested, package, method or symbol",
 	}
 	cmdDoc.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		goDoc := exec.Command("go", append([]string{"doc"}, args...)...)
 		goDoc.Stdout = os.Stdout
 		goDoc.Stderr = os.Stderr
@@ -279,10 +267,6 @@ func main() {
 		Short: "compile and run Go program",
 	}
 	cmdRun.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		err := func() error {
 			lastSourceArg := 0
 			for {
@@ -337,10 +321,6 @@ func main() {
 	cmdTest.Flags().AddFlag(flagTags)
 	cmdTest.Flags().AddFlag(flagLocalMap)
 	cmdTest.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		options.BuildTags = strings.Fields(*tags)
 		err := func() error {
 			pkgs := make([]*gbuild.PackageData, len(args))
@@ -536,10 +516,6 @@ func main() {
 	var addr string
 	cmdServe.Flags().StringVarP(&addr, "http", "", ":8080", "HTTP bind address to serve")
 	cmdServe.Run = func(cmd *cobra.Command, args []string) {
-		if err := verifyGOARCH(); err != nil {
-			printError(err, options, nil)
-			os.Exit(2)
-		}
 		options.BuildTags = strings.Fields(*tags)
 		dirs := append(filepath.SplitList(build.Default.GOPATH), build.Default.GOROOT)
 		var root string
@@ -799,19 +775,6 @@ func sprintError(err error) string {
 	default:
 		return fmt.Sprintf("%s", e)
 	}
-}
-
-// verifyGOARCH verifies that GOARCH environment value is not set to
-// an unsupported value.
-func verifyGOARCH() error {
-	goarch, ok := os.LookupEnv("GOARCH")
-	if !ok {
-		return nil
-	}
-	if goarch != "js" {
-		return fmt.Errorf("gopherjs: unsupported GOOS/GOARCH pair %s/%s", build.Default.GOOS, goarch)
-	}
-	return nil
 }
 
 func runNode(script string, args []string, dir string, quiet bool) error {


### PR DESCRIPTION
This reverts commit 62bca28b2835514b22712edb8104a624030a08c0.

We've originally discussed two possible fixes in issue #594:

> The gopherjs tool does not use the GOARCH environment variable
> in any way. Internally, GopherJS always uses js as GOARCH value
> when compiling user code, but it does other internal stuff when
> compiling standard library.
>
> 1. One fix is to make the gopherjs tool really ignore GOARCH env
> var. In other words, setting it to any value should have no effect;
> it shouldn't cause this failure.
>
> 2. We could also consider making it use the value of GOARCH, and
> error out if it's set to anything other than js (which is the
> default and the only supported value). Since gopherjs can't compile
> for any other architectures.

Upon further consideration, after seeing issue #601 and gopherjs/gopherjs.github.io#66,
we've decided (see discussion in https://github.com/gopherjs/gopherjs.github.io/pull/66#issuecomment-286519322)
to revisit this issue and change gopherjs to completely ignore GOARCH
environment variable, instead of requiring it to be unset or equal to js.

Closes #601.
Updates #594.