### PR TITLE
Improve []byte to string conversion performance on NodeJS

### DIFF
--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -209,6 +209,11 @@ var $bytesToString = function(slice) {
   if (slice.$length === 0) {
     return "";
   }
+
+  if ($global.Buffer !== "undefined") {
+    return Buffer.from(slice.$array).toString("binary", slice.$offset, slice.$offset + slice.$length);
+  }
+
   var str = "";
   for (var i = 0; i < slice.$length; i += 10000) {
     str += String.fromCharCode.apply(undefined, slice.$array.subarray(slice.$offset + i, slice.$offset + Math.min(slice.$length, i + 10000)));


### PR DESCRIPTION
Using `Buffer.from(array).toString("binary")` gives a 13x performance boost when doing `[]byte` to `string` conversion.

`Buffer` is only supported on NodeJS AFAIK (since v5.10.0). If `Buffer` is not supported it falls back to default implementation.

### Benchmark
The benchmark function was:
```go
var str string

func BenchmarkBytesToString(b *testing.B) {
	x := []byte("abcdefghijklmnopqrstuvwxyz")
	for i := 0; i < 15; i++ {
		x = append(x, x...)
	}
	b.SetBytes(int64(len(x)))
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		str = string(x)
	}
}
```

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkBytesToString     35366666      2734000       -92.27%

benchmark                  old MB/s     new MB/s     speedup
BenchmarkBytesToString     24.09        311.62       12.94x
```