### PR TITLE
js: Point to new location of Interface conversion details.

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -73,7 +73,7 @@ func (o *Object) Uint64() uint64 { return o.object.Uint64() }
 // Float returns the object converted to float64 according to JavaScript type conversions (parseFloat).
 func (o *Object) Float() float64 { return o.object.Float() }
 
-// Interface returns the object converted to interface{}. See GopherJS' README for details.
+// Interface returns the object converted to interface{}. See table in package comment for details.
 func (o *Object) Interface() interface{} { return o.object.Interface() }
 
 // Unsafe returns the object as an uintptr, which can be converted via unsafe.Pointer. Not intended for public use.


### PR DESCRIPTION
When the "See GopherJS' README for details." phrase was added in 88f12aa6b316ade3347e7723510a954e09edff1d, the JavaScript <-> Go conversion table was in README. It was moved in c6e849f88527ab0a93f7d4ee4d9c67a65db5285c to the [package comment of `js` package](https://github.com/gopherjs/gopherjs/blob/3496c6f94e1b945f3fc9580f6982675c0a74cd6c/js/js.go#L5-L23).

Fixes #622.