### PR TITLE
compiler/prelude: Optimize ASCII string detection.

### DIFF
--- a/compiler/prelude/jsmapping.go
+++ b/compiler/prelude/jsmapping.go
@@ -78,7 +78,7 @@ var $externalize = function(v, t) {
     }
     return $sliceToArray(v);
   case $kindString:
-    if (v.search(/^[\x00-\x7F]*$/) !== -1) {
+    if ($isASCII(v)) {
       return v;
     }
     var s = "", r;
@@ -322,7 +322,7 @@ var $internalize = function(v, t, recv) {
     return new t($mapArray(v, function(e) { return $internalize(e, t.elem); }));
   case $kindString:
     v = String(v);
-    if (v.search(/^[\x00-\x7F]*$/) !== -1) {
+    if ($isASCII(v)) {
       return v;
     }
     var s = "";
@@ -371,5 +371,15 @@ var $internalize = function(v, t, recv) {
     }
   }
   $throwRuntimeError("cannot internalize " + t.string);
+};
+
+/* $isASCII reports whether string s contains only ASCII characters. */
+var $isASCII = function(s) {
+  for (var i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) >= 128) {
+      return false;
+    }
+  }
+  return true;
 };
 `


### PR DESCRIPTION
I [noticed](https://github.com/shurcooL/backlog/issues/21#issue-159100785) that the code that does string internalization/externalization uses a regexp to detect if the string consists of ASCII characters only, in order to shortcut the conversion process.

Regexps are a general tool that optimizes for brevity, not performance. When inside a hot loops, it's often possible to write faster code rather than using a regexp.

I modified the prelude code as follows to gather some timing information:

```JavaScript
var regexpTaken = 0;

setInterval(function() {
  console.log("regexpTaken: " + regexpTaken + " ms");
}, 3000);
```

```JavaScript
var t0 = performance.now();
var x = $isASCII(v);
var t1 = performance.now();
regexpTaken += t1 - t0;
```

I found that for most programs, the process of string internalization and externalization does not occur very often. The total time spent doing the regexp matching, as reported by `regexpTaken`, was in the order of 1-10 milliseconds.

However, one of the workloads I've tested, which heavily uses `encoding/binary` package to decode a binary data file, ended up performing the string internalization/externalization process as much as 2372654 times. At that point, `regexpTaken` reported around 1 second of time doing regexp matches. I thought it would be worthwhile to see if it can be optimized.

I compared three implementations of `$isASCII`:


```JavaScript
// $isASCII reports whether string s contains only ASCII characters.
var $isASCII = function(s) {
  // The original code that uses a regexp search.
  return s.search(/^[\x00-\x7F]*$/) !== -1;
};
```

```JavaScript
// $isASCII reports whether string s contains only ASCII characters.
var $isASCII = function(s) {
  // Can use test to directly report if there is or isn't a match,
  // since the index returned by search isn't really used.
  //
  // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test.
  return /^[\x00-\x7F]*$/.test(s);
};
```

```JavaScript
// $isASCII reports whether string s contains only ASCII characters.
var $isASCII = function(s) {
  // Use a simple for loop instead of regexp.
  for (var i = 0; i < s.length; i++) {
    if (s.charCodeAt(i) >= 128) {
      return false;
    }
  }
  return true;
};
```

# Benchmark Summary

I've done 3 runs in each browser, clearing cache before each run. I used latest nightly versions of each browser. This is the summary:

|               | Chrome    | Safari   | Firefox   |
|---------------|----------:|---------:|----------:|
| regexp search | 1565.4 ms | 888.4 ms | 1589.3 ms |
| regexp test   | 1378.1 ms | 823.4 ms |  550.1 ms |
| for loop      | 1145.6 ms | 507.4 ms |  326.5 ms |

Using a simple for loop is significantly faster in all browsers tested. The code is also readable.

# Raw Benchmark Data

I've made a reproducible version of the benchmark at https://godoc.org/github.com/shurcooL/play/220.

Expand details to see full raw benchmark data:

<details>

## Chrome (Canary)

Version 60.0.3073.0 canary (64-bit)

### regexp search

	error: <nil>
	taken: 8.739s
	regexpTaken: 1545.4199999996802 ms (regexp search)

	error: <nil>
	taken: 8.877s
	regexpTaken: 1591.3450000003045 ms (regexp search)

	error: <nil>
	taken: 9.324s
	regexpTaken: 1559.3650000002176 ms (regexp search)

### regexp test

	error: <nil>
	taken: 8.723s
	regexpTaken: 1373.3849999998802 ms (regexp test)

	error: <nil>
	taken: 8.607s
	regexpTaken: 1343.4000000002388 ms (regexp test)

	error: <nil>
	taken: 8.505s
	regexpTaken: 1417.6350000003717 ms (regexp test)

### for loop

	error: <nil>
	taken: 8.431s
	regexpTaken: 1155.0099999999627 ms (for loop)

	error: <nil>
	taken: 8.263s
	regexpTaken: 1112.3549999996135 ms (for loop)

	error: <nil>
	taken: 8.439s
	regexpTaken: 1169.4249999998735 ms (for loop)

## Safari (Nightly)

Version 10.1 (12603.1.30.0.34, r214532)
(WebKit r214532)

### regexp search

	error: <nil>
	taken: 15.161s
	regexpTaken: 804.50000000002 ms (regexp search)

	error: <nil>
	taken: 15.824s
	regexpTaken: 968.2000000000613 ms (regexp search)

	error: <nil>
	taken: 15.433s
	regexpTaken: 892.6000000001185 ms (regexp search)

### regexp test

	error: <nil>
	taken: 15.124s
	regexpTaken: 812.2000000000239 ms (regexp test)

	error: <nil>
	taken: 15.314s
	regexpTaken: 817.4999999999961 ms (regexp test)

	error: <nil>
	taken: 14.813s
	regexpTaken: 840.3999999999807 ms (regexp test)

### for loop

	error: <nil>
	taken: 15.189s
	regexpTaken: 504.89999999999554 ms (for loop)

	error: <nil>
	taken: 14.997s
	regexpTaken: 495.49999999997397 ms (for loop)

	error: <nil>
	taken: 14.502s
	regexpTaken: 521.6999999999838 ms (for loop)

## Firefox (Nightly)

55.0a1 (2017-04-17) (64-bit)

### regexp search

	error: <nil>
	taken: 22.209s
	regexpTaken: 1593.4050000013594 ms (regexp search)

	error: <nil>
	taken: 22.561s
	regexpTaken: 1598.6150000002183 ms (regexp search)

	error: <nil>
	taken: 22.463s
	regexpTaken: 1575.924999999782 ms (regexp search)

### regexp test

	error: <nil>
	taken: 21.638s
	regexpTaken: 604.6649999994956 ms (regexp test)

	error: <nil>
	taken: 21.258s
	regexpTaken: 555.4449999998646 ms (regexp test)

	error: <nil>
	taken: 21.16s
	regexpTaken: 490.3299999996898 ms (regexp test)

### for loop

	error: <nil>
	taken: 21.162s
	regexpTaken: 356.909999999438 ms (for loop)

	error: <nil>
	taken: 21.041s
	regexpTaken: 317.9899999998993 ms (for loop)

	error: <nil>
	taken: 21.193s
	regexpTaken: 304.4800000006801 ms (for loop)

</details>

# References

- http://stackoverflow.com/questions/14313183/javascript-regex-how-do-i-check-if-the-string-is-ascii-only
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test