### PR TITLE
Improve "source maps disabled" warning text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@ go get -u github.com/gopherjs/gopherjs
 
 Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherjs install [package]` which behave similar to the `go` tool. For `main` packages, these commands create a `.js` file and `.js.map` source map in the current directory or in `$GOPATH/bin`. The generated JavaScript file can be used as usual in a website. Use `gopherjs help [command]` to get a list of possible command line flags, e.g. for minification and automatically watching for changes.
 
-If you want to use `gopherjs run` or `gopherjs test` to run the generated code locally, install Node.js 4.x and the module `source-map-support`:
+*Note: GopherJS will try to write compiled object files of the core packages to your $GOROOT/pkg directory. If that fails, it will fall back to $GOPATH/pkg.*
+
+#### gopherjs run, gopherjs test
+
+If you want to use `gopherjs run` or `gopherjs test` to run the generated code locally, install Node.js 4.x (or newer), and the `source-map-support` module:
 
 ```
 npm install --global source-map-support
 ```
 
 For system calls (file system access, etc.), see [this page](https://github.com/gopherjs/gopherjs/blob/master/doc/syscalls.md).
-
-*Note: GopherJS will try to write compiled object files of the core packages to your $GOROOT/pkg directory. If that fails, it will fall back to $GOPATH/pkg.*
 
 #### gopherjs serve
 

--- a/tool.go
+++ b/tool.go
@@ -771,7 +771,7 @@ func runNode(script string, args []string, dir string, quiet bool) error {
 		allArgs = []string{"--require", "source-map-support/register"}
 		if err := exec.Command("node", "--require", "source-map-support/register", "--eval", "").Run(); err != nil {
 			if !quiet {
-				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Use Node.js 4.x with source-map-support module for nice stack traces.")
+				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Install source-map-support module for nice stack traces. See https://github.com/gopherjs/gopherjs#installation-and-usage.")
 			}
 			allArgs = []string{}
 		}

--- a/tool.go
+++ b/tool.go
@@ -771,7 +771,7 @@ func runNode(script string, args []string, dir string, quiet bool) error {
 		allArgs = []string{"--require", "source-map-support/register"}
 		if err := exec.Command("node", "--require", "source-map-support/register", "--eval", "").Run(); err != nil {
 			if !quiet {
-				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Install source-map-support module for nice stack traces. See https://github.com/gopherjs/gopherjs#installation-and-usage.")
+				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Install source-map-support module for nice stack traces. See https://github.com/gopherjs/gopherjs#gopherjs-run-gopherjs-test.")
 			}
 			allArgs = []string{}
 		}


### PR DESCRIPTION
Be more specific that it's the source-map-support module that needs to be installed. Point to the instructions for source-map-support module installation.

Fixes #627.

/cc @slimsag Can you review this text? Do you think it's an improvement in readability over what you saw before?