### PR TITLE
build: Fix shadowing bug in staleness calculation.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -532,11 +532,11 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 			if importedPkgPath == "unsafe" || ignored {
 				continue
 			}
-			pkg, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
+			importedPkg, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
 			if err != nil {
 				return nil, err
 			}
-			impModeTime := pkg.SrcModTime
+			impModeTime := importedPkg.SrcModTime
 			if impModeTime.After(pkg.SrcModTime) {
 				pkg.SrcModTime = impModeTime
 			}


### PR DESCRIPTION
The parent scope `pkg` variable was inadvertently shadowed in #411. As a result, the value of `impModeTime` was wrong, and the if statement could never be true, and `pkg.SrcModTime` was never updated to a later time.

The shadow happened at https://github.com/gopherjs/gopherjs/commit/e3a9838fe85c461e4cd869da5065ea1f21b1759e#commitcomment-21940173.

Fixes #559 (possibly other similar issues, but they'll need to be verified).