### PR TITLE
Add support to gopherjs tool for specifying import path patterns and relative import paths.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -62,7 +62,14 @@ func NewBuildContext(installSuffix string, buildTags []string) *build.Context {
 // If an error occurs, Import returns a non-nil error and a nil
 // *PackageData.
 func Import(path string, mode build.ImportMode, installSuffix string, buildTags []string) (*PackageData, error) {
-	return importWithSrcDir(path, "", mode, installSuffix, buildTags)
+	wd, err := os.Getwd()
+	if err != nil {
+		// Getwd may fail if we're in GOARCH=js mode. That's okay, handle
+		// it by falling back to empty working directory. It just means
+		// Import will not be able to resolve relative import paths.
+		wd = ""
+	}
+	return importWithSrcDir(path, wd, mode, installSuffix, buildTags)
 }
 
 func importWithSrcDir(path string, srcDir string, mode build.ImportMode, installSuffix string, buildTags []string) (*PackageData, error) {

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -6,4 +6,4 @@ package compiler
 const ___GOPHERJS_REQUIRES_GO_VERSION_1_8___ = true
 
 // Version is the GopherJS compiler version string.
-const Version = "1.8-1"
+const Version = "1.8-2"

--- a/tool.go
+++ b/tool.go
@@ -128,7 +128,6 @@ func main() {
 				pkgs := (&gotool.Context{BuildContext: *patternContext}).ImportPaths(args)
 
 				for _, pkgPath := range pkgs {
-					pkgPath = filepath.ToSlash(pkgPath)
 					if s.Watcher != nil {
 						pkg, err := gbuild.NewBuildContext(s.InstallSuffix(), options.BuildTags).Import(pkgPath, "", build.FindOnly)
 						if err != nil {
@@ -208,8 +207,6 @@ func main() {
 					}
 				}
 				for _, pkgPath := range pkgs {
-					pkgPath = filepath.ToSlash(pkgPath)
-
 					pkg, err := gbuild.Import(pkgPath, 0, s.InstallSuffix(), options.BuildTags)
 					if s.Watcher != nil && pkg != nil { // add watch even on error
 						s.Watcher.Add(pkg.Dir)
@@ -331,7 +328,6 @@ func main() {
 
 			pkgs := make([]*gbuild.PackageData, len(args))
 			for i, pkgPath := range args {
-				pkgPath = filepath.ToSlash(pkgPath)
 				var err error
 				pkgs[i], err = gbuild.Import(pkgPath, 0, "", options.BuildTags)
 				if err != nil {


### PR DESCRIPTION
This change improves the `gopherjs build`, `gopherjs install`, `gopherjs test` commands to behave more like the equivalent `go` commands. Namely, while previously not possible, one can now:

- Use import path [patterns](https://golang.org/cmd/go/#hdr-Description_of_package_lists) when specifying packages:

    ```
    gopherjs test github.com/user/repo/...
    ```

- Use relative import paths when specifying packages:

    ```
    gopherjs test ./foo/bar
    ```

- Use relative patterns when specifying packages:

    ```
    gopherjs test ./...
    ```

It also includes other minor improvements and simplifications to the code and behavior of the `gopherjs` tool.

The change is somewhat large, but broken up into 4 individual commits with detailed description in their commit message.

Fixes #302. /cc @slimsag FYI, since you recently felt the pain from it not being resolved.

Reviewing and/or testing this PR would be helpful.