### PR TITLE
Use parenthesis for numeric expressions

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -539,7 +539,7 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 		plainFun := astutil.RemoveParens(e.Fun)
 
 		if astutil.IsTypeExpr(plainFun, c.p.Info.Info) {
-			return c.formatExpr("%s", c.translateConversion(e.Args[0], c.p.TypeOf(plainFun)))
+			return c.formatExpr("(%s)", c.translateConversion(e.Args[0], c.p.TypeOf(plainFun)))
 		}
 
 		sig := c.p.TypeOf(plainFun).Underlying().(*types.Signature)
@@ -1186,21 +1186,21 @@ func (c *funcContext) loadStruct(array, target string, s *types.Struct) string {
 func (c *funcContext) fixNumber(value *expression, basic *types.Basic) *expression {
 	switch basic.Kind() {
 	case types.Int8:
-		return c.formatParenExpr("(%s) << 24 >> 24", value)
+		return c.formatParenExpr("%s << 24 >> 24", value)
 	case types.Uint8:
-		return c.formatParenExpr("(%s) << 24 >>> 24", value)
+		return c.formatParenExpr("%s << 24 >>> 24", value)
 	case types.Int16:
-		return c.formatParenExpr("(%s) << 16 >> 16", value)
+		return c.formatParenExpr("%s << 16 >> 16", value)
 	case types.Uint16:
-		return c.formatParenExpr("(%s) << 16 >>> 16", value)
+		return c.formatParenExpr("%s << 16 >>> 16", value)
 	case types.Int32, types.Int, types.UntypedInt:
-		return c.formatParenExpr("(%s) >> 0", value)
+		return c.formatParenExpr("%s >> 0", value)
 	case types.Uint32, types.Uint, types.Uintptr:
-		return c.formatParenExpr("(%s) >>> 0", value)
+		return c.formatParenExpr("%s >>> 0", value)
 	case types.Float32:
 		return c.formatExpr("$fround(%s)", value)
 	case types.Float64:
-		return c.formatExpr("(%s)", value)
+		return value
 	default:
 		panic(fmt.Sprintf("fixNumber: unhandled basic.Kind(): %s", basic.String()))
 	}

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1186,21 +1186,21 @@ func (c *funcContext) loadStruct(array, target string, s *types.Struct) string {
 func (c *funcContext) fixNumber(value *expression, basic *types.Basic) *expression {
 	switch basic.Kind() {
 	case types.Int8:
-		return c.formatParenExpr("%s << 24 >> 24", value)
+		return c.formatParenExpr("(%s) << 24 >> 24", value)
 	case types.Uint8:
-		return c.formatParenExpr("%s << 24 >>> 24", value)
+		return c.formatParenExpr("(%s) << 24 >>> 24", value)
 	case types.Int16:
-		return c.formatParenExpr("%s << 16 >> 16", value)
+		return c.formatParenExpr("(%s) << 16 >> 16", value)
 	case types.Uint16:
-		return c.formatParenExpr("%s << 16 >>> 16", value)
+		return c.formatParenExpr("(%s) << 16 >>> 16", value)
 	case types.Int32, types.Int, types.UntypedInt:
-		return c.formatParenExpr("%s >> 0", value)
+		return c.formatParenExpr("(%s) >> 0", value)
 	case types.Uint32, types.Uint, types.Uintptr:
-		return c.formatParenExpr("%s >>> 0", value)
+		return c.formatParenExpr("(%s) >>> 0", value)
 	case types.Float32:
 		return c.formatExpr("$fround(%s)", value)
 	case types.Float64:
-		return value
+		return c.formatExpr("(%s)", value)
 	default:
 		panic(fmt.Sprintf("fixNumber: unhandled basic.Kind(): %s", basic.String()))
 	}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -612,3 +612,14 @@ func TestReceiverCapture(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestParenthesis(t *testing.T) {
+	i1, i2, i3 := 4, 2, 2
+	if (i1 - i2) / i3 != int(i1 - i2) / int(i3) {
+		t.Fail()
+	}
+	f1, f2, f3 := 4.0, 2.0, 2.0
+	if (f1 - f2) / f3 != float64(f1 - f2) / float64(f3) {
+		t.Fail()
+	}
+}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -613,7 +613,7 @@ func TestReceiverCapture(t *testing.T) {
 	}
 }
 
-func TestParenthesis(t *testing.T) {
+func TestTypeConversion(t *testing.T) {
 	i1, i2, i3 := 4, 2, 2
 	if (i1 - i2) / i3 != int(i1 - i2) / int(i3) {
 		t.Fail()

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -615,11 +615,11 @@ func TestReceiverCapture(t *testing.T) {
 
 func TestTypeConversion(t *testing.T) {
 	i1, i2, i3 := 4, 2, 2
-	if (i1 - i2) / i3 != int(i1 - i2) / int(i3) {
+	if (i1-i2)/i3 != int(i1-i2)/int(i3) {
 		t.Fail()
 	}
 	f1, f2, f3 := 4.0, 2.0, 2.0
-	if (f1 - f2) / f3 != float64(f1 - f2) / float64(f3) {
+	if (f1-f2)/f3 != float64(f1-f2)/float64(f3) {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
This PR fixes https://github.com/gopherjs/gopherjs/issues/649.

The problem was that a numeric expression like `float64(a - b) / c` was converted to `a - b / c` when `a -
 b` was float64. This PR adds parenthesis to all numeric expressions at `fixNumber`.

I think there was a potential bug that `int(a - b) / c` was converted to `a - b >> 0 / c`, but I couldn't find a actual problematic case.