### PR TITLE
Don't use nosync for the standard log package.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -299,7 +299,7 @@ func parseAndAugment(pkg *build.Package, isTest bool, fileSet *token.FileSet) ([
 		}
 
 		switch pkg.ImportPath {
-		case "crypto/rand", "encoding/gob", "encoding/json", "expvar", "go/token", "log", "math/big", "math/rand", "regexp", "testing", "time":
+		case "crypto/rand", "encoding/gob", "encoding/json", "expvar", "go/token", "math/big", "math/rand", "regexp", "testing", "time":
 			for _, spec := range file.Imports {
 				path, _ := strconv.Unquote(spec.Path.Value)
 				if path == "sync" {


### PR DESCRIPTION
**TL;DR;**  The standard library 'log' package uses locks around blocking IO calls which seems like an inappropriate use of the 'nosync' package.  Not using 'nosync' for this package fixed a bug observed in one of my applications.

---

I've just encountered the following error in one of my apps:

    main.js:1412 Uncaught Error: nosync: mutex is already locked
        at $callDeferred (main.js:1412)
        at $panic (main.js:1451)
        at Object.$packages.github.com/gopherjs/gopherjs/nosync.Mutex.ptr.Lock (main.js:6755)
        at Object.$packages.log.Logger.ptr.Output (main.js:67759)
        at Object.Printf (main.js:67957)
        at localize (main.js:167345)
        at $goroutine (main.js:1471)
        at $runScheduled (main.js:1511)

My [attempts](https://gopherjs.github.io/playground/#/jZGmyUZoDq) to build a minimal reproduction case have thus far failed, but here's my speculation:

I'm not entirely sure what 'nosync's purpose is, but I guess it's a lighter-weight version of 'sync', to be used when there's no possibility of synchronization being an actual issue, due to JS's single-threaded nature.

The failure:

    at Object.$packages.log.Logger.ptr.Output (main.js:67759)

Corresponds to this transpiled code:

    67757    file = "";
    67758    line = 0;
    67759    l.mu.Lock();
    67760    $deferred.push([$methodVal(l.mu, "Unlock"), []]);
    67761    if (!(((l.flag & 24) === 0))) {
    67762        l.mu.Unlock();
    67763        ok = false;

Which in turn corresponds to [this code](https://golang.org/src/log/log.go) in the standard library:

    147    var file string
    148    var line int
    149    l.mu.Lock()
    150    defer l.mu.Unlock()
    151    if l.flag&(Lshortfile|Llongfile) != 0 {
    152        // release lock while getting caller info - it's expensive.
    153        l.mu.Unlock()
    154        var ok bool
    ...
    168    _, err := l.out.Write(l.buf)
    169    return err

If I understand GopherJS's scheduling adequately (also reinforced by my reading of the [transpiled log function](https://gist.github.com/flimzy/714c7c8a3f5541c1b4595421929b3020)), it's quite possible for the `defer l.mu.Unlock()` execution to be significantly delayed in from the rest of the function, since there's a `Write()` call (on line 168), which triggers a blocking IO checkpoint, allowing other goroutines to be scheduled, leading to a possible race condition.
