### PR TITLE
compiler: fix incorrect emitted Javascript for type switch

### DIFF
--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -123,7 +123,9 @@ func (c *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			var bodyPrefix []ast.Stmt
 			if implicit := c.p.Implicits[clause]; implicit != nil {
 				value := refVar
-				if _, isInterface := implicit.Type().Underlying().(*types.Interface); !isInterface {
+				if typesutil.IsJsObject(implicit.Type().Underlying()) {
+					value += ".$val.object"
+				} else if _, ok := implicit.Type().Underlying().(*types.Interface); !ok {
 					value += ".$val"
 				}
 				bodyPrefix = []ast.Stmt{&ast.AssignStmt{

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -571,3 +571,28 @@ func TestUint8Array(t *testing.T) {
 		t.Errorf("Non-empty byte array is not externalized as a Uint8Array")
 	}
 }
+
+func TestTypeSwitchJsObject(t *testing.T) {
+	obj := js.Global.Get("Object").New()
+	obj.Set("foo", "bar")
+
+	exp := "bar"
+
+	if act := obj.Get("foo").String(); act != exp {
+		t.Fatalf("Direct access to *js.Object field gave %q; expected %q", act, exp)
+	}
+
+	var x interface{} = obj
+	switch x := x.(type) {
+	case *js.Object:
+		if act := x.Get("foo").String(); act != exp {
+			t.Fatalf("Value passed through interface and type switch gave %q; expected %q", act, exp)
+		}
+	}
+
+	if y, ok := x.(*js.Object); ok {
+		if act := y.Get("foo").String(); act != exp {
+			t.Fatalf("Value passed through interface and type assert gave %q; expected %q", act, exp)
+		}
+	}
+}

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -572,27 +572,27 @@ func TestUint8Array(t *testing.T) {
 	}
 }
 
-func TestTypeSwitchJsObject(t *testing.T) {
+func TestTypeSwitchJSObject(t *testing.T) {
 	obj := js.Global.Get("Object").New()
 	obj.Set("foo", "bar")
 
-	exp := "bar"
+	want := "bar"
 
-	if act := obj.Get("foo").String(); act != exp {
-		t.Fatalf("Direct access to *js.Object field gave %q; expected %q", act, exp)
+	if got := obj.Get("foo").String(); got != want {
+		t.Fatalf("Direct access to *js.Object field gave %q, want %q", got, want)
 	}
 
 	var x interface{} = obj
 	switch x := x.(type) {
 	case *js.Object:
-		if act := x.Get("foo").String(); act != exp {
-			t.Fatalf("Value passed through interface and type switch gave %q; expected %q", act, exp)
+		if got := x.Get("foo").String(); got != want {
+			t.Fatalf("Value passed through interface and type switch gave %q, want %q", got, want)
 		}
 	}
 
 	if y, ok := x.(*js.Object); ok {
-		if act := y.Get("foo").String(); act != exp {
-			t.Fatalf("Value passed through interface and type assert gave %q; expected %q", act, exp)
+		if got := y.Get("foo").String(); got != want {
+			t.Fatalf("Value passed through interface and type assert gave %q, want %q", got, want)
 		}
 	}
 }

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -579,20 +579,21 @@ func TestTypeSwitchJSObject(t *testing.T) {
 	want := "bar"
 
 	if got := obj.Get("foo").String(); got != want {
-		t.Fatalf("Direct access to *js.Object field gave %q, want %q", got, want)
+		t.Errorf("Direct access to *js.Object field gave %q, want %q", got, want)
 	}
 
 	var x interface{} = obj
+
 	switch x := x.(type) {
 	case *js.Object:
 		if got := x.Get("foo").String(); got != want {
-			t.Fatalf("Value passed through interface and type switch gave %q, want %q", got, want)
+			t.Errorf("Value passed through interface and type switch gave %q, want %q", got, want)
 		}
 	}
 
 	if y, ok := x.(*js.Object); ok {
 		if got := y.Get("foo").String(); got != want {
-			t.Fatalf("Value passed through interface and type assert gave %q, want %q", got, want)
+			t.Errorf("Value passed through interface and type assert gave %q, want %q", got, want)
 		}
 	}
 }


### PR DESCRIPTION
This brings the code emitted for a type switch with a `*js.Object`
case in line with the runtime `$assertType` function. In the case of
a `*js.Object` value, we have to dereference via `.$val.object`.

Fixes #682