### PR TITLE
build: unify setting of ulimit and stack_size

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
     - diff -u <(echo -n) <(go list ./compiler/natives/src/...) # All those packages should have // +build js.
     - gopherjs install -v net/http # Should build successfully (can't run tests, since only client is supported).
     - >
-      gopherjs test --minify -v --short
+      ulimit -s 10000 && ulimit -s && gopherjs test --short -v --minify
       github.com/gopherjs/gopherjs/tests
       github.com/gopherjs/gopherjs/tests/main
       github.com/gopherjs/gopherjs/js

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
     - diff -u <(echo -n) <(go list ./compiler/natives/src/...) # All those packages should have // +build js.
     - gopherjs install -v net/http # Should build successfully (can't run tests, since only client is supported).
     - >
-      ulimit -s 10000 && ulimit -s && gopherjs test --short -v --minify
+      ulimit -s 10000 && gopherjs test --minify -v --short
       github.com/gopherjs/gopherjs/tests
       github.com/gopherjs/gopherjs/tests/main
       github.com/gopherjs/gopherjs/js

--- a/tool.go
+++ b/tool.go
@@ -750,26 +750,25 @@ func runNode(script string, args []string, dir string, quiet bool) error {
 	}
 
 	if runtime.GOOS != "windows" {
-		// For non-windows OS environments, we've seen issues with stack space
-		// limits causeing Go std library tests that are recursion-heavy to fail
-		// (see https://github.com/gopherjs/gopherjs/issues/661 for more detail).
+		// For non-Windows environments, we've seen issues with stack space
+		// limits causing Go standard library tests that are recursion-heavy to
+		// fail (see https://github.com/gopherjs/gopherjs/issues/661 for more details).
 		//
-		// There are two limits that come into play here, listed in order:
+		// There are two limits that come into play here:
 		//
 		// 1. V8 limit (NodeJS effectively wraps V8)
 		// 2. OS process limit
 		//
 		// In order to limit the surface area of the gopherjs command and not
-		// expose V8 flags/options etc to the caller, we control limit 1 via
-		// limit 2. That is to say, whatever value is returned by ulimit -s is
-		// essentially the value that we pass on to NodeJS via the appropriate V8
-		// flag.
+		// expose V8 flags/options etc. to the caller, we control limit 1 via
+		// limit 2. Whatever value is returned by ulimit -s is the value that we
+		// pass on to NodeJS via the appropriate V8 flag.
 		var r syscall.Rlimit
 		err := syscall.Getrlimit(syscall.RLIMIT_STACK, &r)
 		if err != nil {
 			return fmt.Errorf("failed to get stack size limit: %v", err)
 		}
-		// rlimit value is in bytes, we need rounded kBytes value per node --v8-options.
+		// rlimit value is in bytes, we need rounded kilobytes value per node --v8-options.
 		stackSize := fmt.Sprintf("--stack_size=%v", r.Cur/1000)
 		allArgs = append(allArgs, stackSize)
 	}


### PR DESCRIPTION
~Waiting for the Go 1.9 branch to land first - DONE in https://github.com/gopherjs/gopherjs/pull/651~

Picking up on @shurcooL's comment in https://github.com/gopherjs/gopherjs/pull/669#issuecomment-325138883.

We've started randomly seeing std library tests tip over the V8 stack size limit, causing text/template TestMaxExecDepth to fail randomly locally and on CI. This had previously been addressed by @neelance in 1f89545; the `--stack_size` flag was passed to NodeJS which in turn passed the value onto V8. But per https://github.com/nodejs/node/issues/14567#issuecomment-319367412 it was pointed out that the value of `ulimit -s` must be `>=` the value of `--stack_size` for the `--stack_size` to make any sort of sense. Hence this commit also harmonises the setting of `ulimit -s` during the CI test run with the value of `--stack_size` that is passed to NodeJS (which in turn passes that value onto V8) when running either gopherjs test or gopherjs run.