### PR TITLE
Add `strings.Join` function that uses native code

### DIFF
--- a/compiler/natives/src/strings/strings.go
+++ b/compiler/natives/src/strings/strings.go
@@ -20,6 +20,10 @@ func LastIndex(s, sep string) int {
 	return js.InternalObject(s).Call("lastIndexOf", js.InternalObject(sep)).Int()
 }
 
+func Join(a []string, sep string) string {
+	return js.InternalObject(a).Get("$array").Call("join", js.InternalObject(sep)).String()
+}
+
 func Count(s, sep string) int {
 	n := 0
 	// special cases


### PR DESCRIPTION
Added `strings.Join` function in `natives/src/strings` that uses the
native js function `array.join(separator)`