### PR TITLE
Fix build error on Windows due to syscall package.

### DIFF
--- a/internal/sysutil/sysutil.go
+++ b/internal/sysutil/sysutil.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+// Package sysutil contains system-specific utilities.
+package sysutil
+
+import "golang.org/x/sys/unix"
+
+// RlimitStack reports the current stack size limit in bytes.
+func RlimitStack() (cur uint64, err error) {
+	var r unix.Rlimit
+	err = unix.Getrlimit(unix.RLIMIT_STACK, &r)
+	return r.Cur, err
+}

--- a/internal/sysutil/sysutil_windows.go
+++ b/internal/sysutil/sysutil_windows.go
@@ -1,0 +1,7 @@
+package sysutil
+
+import "errors"
+
+func RlimitStack() (uint64, error) {
+	return 0, errors.New("RlimitStack is not implemented on Windows")
+}

--- a/tool.go
+++ b/tool.go
@@ -31,6 +31,7 @@ import (
 
 	gbuild "github.com/gopherjs/gopherjs/build"
 	"github.com/gopherjs/gopherjs/compiler"
+	"github.com/gopherjs/gopherjs/internal/sysutil"
 	"github.com/kisielk/gotool"
 	"github.com/neelance/sourcemap"
 	"github.com/spf13/cobra"
@@ -765,12 +766,11 @@ func runNode(script string, args []string, dir string, quiet bool) error {
 		//
 		// 	ulimit -s 10000 && gopherjs test
 		//
-		var r syscall.Rlimit
-		err := syscall.Getrlimit(syscall.RLIMIT_STACK, &r)
+		cur, err := sysutil.RlimitStack()
 		if err != nil {
 			return fmt.Errorf("failed to get stack size limit: %v", err)
 		}
-		allArgs = append(allArgs, fmt.Sprintf("--stack_size=%v", r.Cur/1000)) // Convert from bytes to KB.
+		allArgs = append(allArgs, fmt.Sprintf("--stack_size=%v", cur/1000)) // Convert from bytes to KB.
 	}
 
 	allArgs = append(allArgs, script)


### PR DESCRIPTION
Move the `syscall` use into an internal helper package, behind a non-Windows build constraint.

Also switch from `syscall` to `golang.org/x/sys/unix`, since `syscall` documentation recommends doing so.

Fixes #695.