### PR TITLE
syscall: fallback to process.exit when available

### DIFF
--- a/compiler/natives/src/syscall/syscall_unix.go
+++ b/compiler/natives/src/syscall/syscall_unix.go
@@ -67,6 +67,9 @@ func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
 		return uintptr(array.Length()), 0, 0
 	}
 	if trap == SYS_EXIT {
+		if process := js.Global.Get("process"); process != js.Undefined {
+			process.Call("exit", a1)
+		}
 		runtime.Goexit()
 	}
 	printWarning()


### PR DESCRIPTION
"go test" currently always fails with "fatal error: all goroutines are
asleep - deadlock!". In fact, all programs that use "os.Exit" will fail
with this.

It turns out that the current "runtime.Goexit" function throws an
exception which propagates up which violates the expected behavior of
the exit syscall (which should not return). Therefore call
"process.exit" when available.

Fixes #626
___
Test with `go test` on any package or just:
```go
package main

import "os"

func main() {
	os.Exit(0)
}
```

Also note that any functions registered with `process.on("exit", ...)` will still be executed. Not ideal, but this is better than nothing when syscalls are not available.