### PR TITLE
Replaces sync import with nosync before build

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -565,6 +565,14 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 			if importedPkgPath == "unsafe" || ignored {
 				continue
 			}
+
+			switch pkg.ImportPath {
+			case "crypto/rand", "encoding/gob", "encoding/json", "expvar", "go/token", "log", "math/big", "math/rand", "regexp", "testing", "time":
+				if importedPkgPath == "sync" {
+					importedPkgPath = "github.com/gopherjs/gopherjs/nosync"
+				}
+			}
+
 			importedPkg, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The `parseAndAugment` function replaces the `sync` import with `github.com/gopherjs/gopherjs/nosync`, however [this](https://github.com/gopherjs/gopherjs/blob/00a3767085dffc9baa5e1c320b28e3629a56d323/build/build.go#L568) builds all imports before the replacement. 

This results in the `sync` package being built when compiling `math/rand` amongst others. Copying the sync/nosync replacement logic from `parseAndAugment` fixes the problem.