### PR TITLE
build: Add "purego" build tag to default context.

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -41,7 +41,7 @@ func NewBuildContext(installSuffix string, buildTags []string) *build.Context {
 		GOARCH:        "js",
 		InstallSuffix: installSuffix,
 		Compiler:      "gc",
-		BuildTags:     append(buildTags, "netgo"),
+		BuildTags:     append(buildTags, "netgo", "purego"),
 		ReleaseTags:   build.Default.ReleaseTags,
 		CgoEnabled:    true, // detect `import "C"` to throw proper error
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -41,9 +41,12 @@ func NewBuildContext(installSuffix string, buildTags []string) *build.Context {
 		GOARCH:        "js",
 		InstallSuffix: installSuffix,
 		Compiler:      "gc",
-		BuildTags:     append(buildTags, "netgo", "purego"),
-		ReleaseTags:   build.Default.ReleaseTags,
-		CgoEnabled:    true, // detect `import "C"` to throw proper error
+		BuildTags: append(buildTags,
+			"netgo",  // See https://godoc.org/net#hdr-Name_Resolution.
+			"purego", // See https://golang.org/issues/23172.
+		),
+		ReleaseTags: build.Default.ReleaseTags,
+		CgoEnabled:  true, // detect `import "C"` to throw proper error
 	}
 }
 

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -6,4 +6,4 @@ package compiler
 const ___GOPHERJS_REQUIRES_GO_VERSION_1_9___ = true
 
 // Version is the GopherJS compiler version string.
-const Version = "1.9-1"
+const Version = "1.9-2"


### PR DESCRIPTION
The proposal in golang/go#23172 was accepted. The "purego" build tag
is intended to be a community agreed upon soft-signal to indicate the
forbidden use of unsafe, assembly, or cgo.

Since GopherJS doesn't support those, it should always use "purego"
versions of Go packages when they're available. This is done by always
setting the "purego" build constraint.

Fixes #746.