### PR TITLE
internal/sysutil: Fix build error on FreeBSD due to Rlimit.Cur type mismatch.

### DIFF
--- a/internal/sysutil/sysutil.go
+++ b/internal/sysutil/sysutil.go
@@ -9,5 +9,5 @@ import "golang.org/x/sys/unix"
 func RlimitStack() (cur uint64, err error) {
 	var r unix.Rlimit
 	err = unix.Getrlimit(unix.RLIMIT_STACK, &r)
-	return uint64(r.Cur), err
+	return uint64(r.Cur), err // Type conversion because Cur is one of uint64, int64 depending on unix flavor.
 }

--- a/internal/sysutil/sysutil.go
+++ b/internal/sysutil/sysutil.go
@@ -9,5 +9,5 @@ import "golang.org/x/sys/unix"
 func RlimitStack() (cur uint64, err error) {
 	var r unix.Rlimit
 	err = unix.Getrlimit(unix.RLIMIT_STACK, &r)
-	return r.Cur, err
+	return uint64(r.Cur), err
 }


### PR DESCRIPTION
Trying to build [Perkeep](https://github.com/perkeep/perkeep) on FreeBSD:

```
➜ perkeep git:(master) go run make.go 
Now rebuilding gopherjs at /usr/home/juergen/perkeep/tmp/build-gopath-nosqlite/bin/gopherjs
error building gopherjs: error while building gopherjs: exit status 2, # perkeep.org/vendor/github.com/gopherjs/gopherjs/inter\
nal/sysutil
internal/sysutil/sysutil.go:12:10: cannot use r.Cur (type int64) as type uint64 in return argument
exit status 1

```