### PR TITLE
Improve ordering of EscapingObjects

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -369,12 +369,6 @@ func (c *funcContext) handleEscapingVars(n ast.Node) {
 
 	var names []string
 	objs := analysis.EscapingObjects(n, c.p.Info.Info)
-	sort.Slice(objs, func(i, j int) bool {
-		if objs[i].Name() == objs[j].Name() {
-			return objs[i].Pos() < objs[j].Pos()
-		}
-		return objs[i].Name() < objs[j].Name()
-	})
 	for _, obj := range objs {
 		names = append(names, c.objectName(obj))
 		c.p.escapingVars[obj] = true


### PR DESCRIPTION
EscapingObjects [returns a slice](https://github.com/gopherjs/gopherjs/blob/95deb33d587c9f6e24b494ea9bdf9648c48f9a60/compiler/analysis/escape.go#L9), which is created [from a map](https://github.com/gopherjs/gopherjs/blob/95deb33d587c9f6e24b494ea9bdf9648c48f9a60/compiler/analysis/escape.go#L18-L20) so the order is undefined. It is then [sorted here](https://github.com/gopherjs/gopherjs/blob/95deb33d587c9f6e24b494ea9bdf9648c48f9a60/compiler/utils.go#L372-L377). 

This PR improves the situation by maintaining the order that the objects were found in the source. This means that the sorting in `utils.go` is not needed. 

This fixes https://github.com/gopherjs/gopherjs/issues/759