### PR TITLE
Use high resolution time API

### DIFF
--- a/compiler/natives/src/time/time.go
+++ b/compiler/natives/src/time/time.go
@@ -39,7 +39,7 @@ func initLocal() {
 }
 
 func runtimeNano() int64 {
-	return js.Global.Get("Date").New().Call("getTime").Int64() * int64(Millisecond)
+	return int64(js.Global.Get("performance").Call("now").Float() * float64(time.Millisecond))
 }
 
 func now() (sec int64, nsec int32, mono int64) {


### PR DESCRIPTION
High resolution time API is available in most browsers: https://caniuse.com/#feat=high-resolution-time

As the Go time is expected to have nano precision (e.g. `Nano()` function), I think it is natural to return more precise time than `Date.getTime`.
