### PR TITLE
compiler: support arbitrary value js struct tag values

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -516,9 +516,9 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 			fields, jsTag := c.translateSelection(sel, e.Pos())
 			if jsTag != "" {
 				if _, ok := sel.Type().(*types.Signature); ok {
-					return c.formatExpr("$internalize(%1e.%2s.%3s, %4s, %1e.%2s)", e.X, strings.Join(fields, "."), jsTag, c.typeName(sel.Type()))
+					return c.formatExpr("$internalize(%1e.%2s%3s, %4s, %1e.%2s)", e.X, strings.Join(fields, "."), formatJSStructTagVal(jsTag), c.typeName(sel.Type()))
 				}
-				return c.internalize(c.formatExpr("%e.%s.%s", e.X, strings.Join(fields, "."), jsTag), sel.Type())
+				return c.internalize(c.formatExpr("%e.%s%s", e.X, strings.Join(fields, "."), formatJSStructTagVal(jsTag)), sel.Type())
 			}
 			return c.formatExpr("%e.%s", e.X, strings.Join(fields, "."))
 		case types.MethodVal:
@@ -669,7 +669,7 @@ func (c *funcContext) translateExpr(expr ast.Expr) *expression {
 			case types.FieldVal:
 				fields, jsTag := c.translateSelection(sel, f.Pos())
 				if jsTag != "" {
-					call := c.formatExpr("%e.%s.%s(%s)", f.X, strings.Join(fields, "."), jsTag, externalizeArgs(e.Args))
+					call := c.formatExpr("%e.%s%s(%s)", f.X, strings.Join(fields, "."), formatJSStructTagVal(jsTag), externalizeArgs(e.Args))
 					switch sig.Results().Len() {
 					case 0:
 						return call

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -703,7 +703,7 @@ func (c *funcContext) translateAssign(lhs, rhs ast.Expr, define bool) string {
 		}
 		fields, jsTag := c.translateSelection(sel, l.Pos())
 		if jsTag != "" {
-			return fmt.Sprintf("%s.%s.%s = %s;", c.translateExpr(l.X), strings.Join(fields, "."), jsTag, c.externalize(rhsExpr.String(), sel.Type()))
+			return fmt.Sprintf("%s.%s%s = %s;", c.translateExpr(l.X), strings.Join(fields, "."), formatJSStructTagVal(jsTag), c.externalize(rhsExpr.String(), sel.Type()))
 		}
 		return fmt.Sprintf("%s.%s = %s;", c.translateExpr(l.X), strings.Join(fields, "."), rhsExpr)
 	case *ast.StarExpr:

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -656,19 +656,12 @@ func encodeIdent(name string) string {
 // Uses definition of an identifier from
 // https://developer.mozilla.org/en-US/docs/Glossary/Identifier
 func formatJSStructTagVal(jsTag string) string {
-	useDot := true
-
 	for i, r := range jsTag {
 		ok := unicode.IsLetter(r) || (i != 0 && unicode.IsNumber(r)) || r == '$' || r == '_'
 		if !ok {
-			useDot = false
-			break
+			return "[\"" + template.JSEscapeString(jsTag) + "\"]"
 		}
 	}
 
-	if useDot {
-		return "." + jsTag
-	}
-
-	return "[\"" + template.JSEscapeString(jsTag) + "\"]"
+	return "." + jsTag
 }

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -598,33 +598,25 @@ func TestTypeSwitchJSObject(t *testing.T) {
 	}
 }
 
-type StructWithNonIdentifierJsTags struct {
-	object *js.Object
-	Name   string `js:"@&\"'<>//my name"`
-}
-
-func TestStructWithNonIdentifierJsTags(t *testing.T) {
-	s := StructWithNonIdentifierJsTags{
-		object: js.Global.Get("Object").New(),
+func TestStructWithNonIdentifierJSTag(t *testing.T) {
+	type S struct {
+		*js.Object
+		Name string `js:"@&\"'<>//my name"`
 	}
+	s := S{Object: js.Global.Get("Object").New()}
 
-	const want = "Paul"
+	// externalise a value via field
+	s.Name = "Paul"
 
-	// externalise a value
-	s.Name = want
-
-	// internalise again
+	// internalise via field
 	got := s.Name
-
-	if want != got {
-		t.Errorf("Value via non-identifier js tag field gave %q, want %q", got, want)
+	if want := "Paul"; got != want {
+		t.Errorf("value via field with non-identifier js tag gave %q, want %q", got, want)
 	}
 
 	// verify we can do a Get with the struct tag
-	got = s.object.Get("@&\"'<>//my name").String()
-
-	if want != got {
-		t.Errorf("Value via .Get gave %q, want %q", got, want)
+	got = s.Get("@&\"'<>//my name").String()
+	if want := "Paul"; got != want {
+		t.Errorf("value via js.Object.Get gave %q, want %q", got, want)
 	}
-
 }

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -597,3 +597,34 @@ func TestTypeSwitchJSObject(t *testing.T) {
 		}
 	}
 }
+
+type StructWithNonIdentifierJsTags struct {
+	object *js.Object
+	Name   string `js:"@&\"'<>//my name"`
+}
+
+func TestStructWithNonIdentifierJsTags(t *testing.T) {
+	s := StructWithNonIdentifierJsTags{
+		object: js.Global.Get("Object").New(),
+	}
+
+	const want = "Paul"
+
+	// externalise a value
+	s.Name = want
+
+	// internalise again
+	got := s.Name
+
+	if want != got {
+		t.Errorf("Value via non-identifier js tag field gave %q, want %q", got, want)
+	}
+
+	// verify we can do a Get with the struct tag
+	got = s.object.Get("@&\"'<>//my name").String()
+
+	if want != got {
+		t.Errorf("Value via .Get gave %q, want %q", got, want)
+	}
+
+}


### PR DESCRIPTION
Javascript allows for arbitrary strings to be used as index values on an
Object. A good example of where this comes up is React where `"data-*"`
and `"aria-*"` indexes are used on objects
(https://reactjs.org/docs/dom-elements.html). 

By switching from property selectors to the index operator (where required) we can support arbitrary string values in js-tagged fields for `*js.Object` special structs.

Fixes #778