### PR TITLE
Move js package tests into tests package.

### DIFF
--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -1,6 +1,6 @@
 // +build js
 
-package js_test
+package tests_test
 
 import (
 	"fmt"


### PR DESCRIPTION
This way, all GopherJS-specific tests are in tests package, rather than
having an arbitrary split. None of the package js tests were internal
to the package.

This helps a future change where the js package becomes embedded into
the compiler. It makes it easier to add and modify GopherJS tests
without having to regenerate the js package.

Resolves #792.