### PR TITLE
syscalls: move away from deprecated CloneElementAt

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ dependencies:
   pre:
     - cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz | sudo tar -xz && sudo chmod a+w go/src/path/filepath
   override:
+    - mkdir -p ~/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}
+    - ln -s ${HOME}/${CIRCLE_PROJECT_REPONAME} ${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     - go get -t -d -v ./...
     - go build -v
     - npm install --no-save # install our (dev) dependencies from package.json

--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,16 @@
 machine:
   node:
-    version: 10.5.0
+    version: 10.0.0
   environment:
     SOURCE_MAP_SUPPORT: false
 
 dependencies:
   pre:
     - cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz | sudo tar -xz && sudo chmod a+w go/src/path/filepath
-  override:
-    - mkdir -p ~/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}
-    - ln -s ${HOME}/${CIRCLE_PROJECT_REPONAME} ${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-    - cd ~/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-    - go get -t -d -v ./...
-    - go build -v
-    - npm install --no-save # install our (dev) dependencies from package.json
   post:
     - mv ./gopherjs $HOME/bin
     - npm install --global node-gyp
+    - npm install # install our (dev) dependencies from package.json
     - cd node-syscall && node-gyp rebuild && mkdir -p ~/.node_libraries/ && cp build/Release/syscall.node ~/.node_libraries/syscall.node
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   post:
     - mv ./gopherjs $HOME/bin
     - npm install --global node-gyp
-    - npm install # install our (dev) dependencies from package.json
+    - npm install --no-save # install our (dev) dependencies from package.json
     - cd node-syscall && node-gyp rebuild && mkdir -p ~/.node_libraries/ && cp build/Release/syscall.node ~/.node_libraries/syscall.node
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.2.2
+    version: 10.0.0
   environment:
     SOURCE_MAP_SUPPORT: false
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,13 @@ machine:
 dependencies:
   pre:
     - cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz | sudo tar -xz && sudo chmod a+w go/src/path/filepath
+  override:
+    - go get -t -d -v ./...
+    - go build -v
+    - npm install --no-save # install our (dev) dependencies from package.json
   post:
     - mv ./gopherjs $HOME/bin
     - npm install --global node-gyp
-    - npm install --no-save # install our (dev) dependencies from package.json
     - cd node-syscall && node-gyp rebuild && mkdir -p ~/.node_libraries/ && cp build/Release/syscall.node ~/.node_libraries/syscall.node
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
   override:
     - mkdir -p ~/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}
     - ln -s ${HOME}/${CIRCLE_PROJECT_REPONAME} ${HOME}/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+    - cd ~/.go_project/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
     - go get -t -d -v ./...
     - go build -v
     - npm install --no-save # install our (dev) dependencies from package.json

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 10.0.0
+    version: 10.5.0
   environment:
     SOURCE_MAP_SUPPORT: false
 

--- a/node-syscall/syscall.cc
+++ b/node-syscall/syscall.cc
@@ -25,17 +25,7 @@ intptr_t toNative(Local<Value> value) {
     Local<Array> array = Local<Array>::Cast(value);
     intptr_t* native = reinterpret_cast<intptr_t*>(malloc(array->Length() * sizeof(intptr_t))); // TODO memory leak
     for (uint32_t i = 0; i < array->Length(); i++) {
-#if (NODE_MAJOR_VERSION >= 6)
-      Local<Value> elem = array->Get(i);
-      if (elem->IsObject()) {
-        Local<Object> obj = Local<Object>::Cast(elem);
-        native[i] = toNative(obj->Clone());
-      } else {
-        native[i] = toNative(elem);
-      }
-#else
-      native[i] = toNative(array->CloneElementAt(i));
-#endif
+      native[i] = toNative(array->Get(i));
     }
     return reinterpret_cast<intptr_t>(native);
   }

--- a/node-syscall/syscall.cc
+++ b/node-syscall/syscall.cc
@@ -25,10 +25,10 @@ intptr_t toNative(Local<Value> value) {
     Local<Array> array = Local<Array>::Cast(value);
     intptr_t* native = reinterpret_cast<intptr_t*>(malloc(array->Length() * sizeof(intptr_t))); // TODO memory leak
     for (uint32_t i = 0; i < array->Length(); i++) {
-#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
-      v8::Local<v8::Value> elem = array->Get(i);
+#if (NODE_MAJOR_VERSION >= 6)
+      Local<Value> elem = array->Get(i);
       if (elem->IsObject()) {
-        v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(elem);
+        Local<Object> obj = Local<Object>::Cast(elem);
         native[i] = toNative(obj->Clone());
       } else {
         native[i] = toNative(elem);

--- a/node-syscall/syscall.cc
+++ b/node-syscall/syscall.cc
@@ -25,7 +25,17 @@ intptr_t toNative(Local<Value> value) {
     Local<Array> array = Local<Array>::Cast(value);
     intptr_t* native = reinterpret_cast<intptr_t*>(malloc(array->Length() * sizeof(intptr_t))); // TODO memory leak
     for (uint32_t i = 0; i < array->Length(); i++) {
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
+      v8::Local<v8::Value> elem = array->Get(i);
+      if (elem->IsObject()) {
+        v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(elem);
+        native[i] = toNative(obj->Clone());
+      } else {
+        native[i] = toNative(elem);
+      }
+#else
       native[i] = toNative(array->CloneElementAt(i));
+#endif
     }
     return reinterpret_cast<intptr_t>(native);
   }


### PR DESCRIPTION
We currently use [Node 6.2.2](https://github.com/gopherjs/gopherjs/blob/8dffc02ea1cb8398bb73f30424697c60fcf8d4c5/circle.yml#L3) in CI for our `gopherjs test` runs. 

Ever since the start of the Node 6.x series, `v8::Array::CloneElementAt` has been deprecated; here's an example from [our most recent `master` build](https://circleci.com/gh/gopherjs/gopherjs/1584):

```
make: Entering directory `/home/ubuntu/gopherjs/node-syscall/build'
  CXX(target) Release/obj.target/syscall/syscall.o
../syscall.cc: In function ‘intptr_t toNative(v8::Local<v8::Value>)’:
../syscall.cc:28:51: warning: ‘v8::Local<v8::Object> v8::Array::CloneElementAt(uint32_t)’ is deprecated (declared at /home/ubuntu/.node-gyp/6.2.2/include/node/v8.h:3009): Cloning is not supported. [-Wdeprecated-declarations]
       native[i] = toNative(array->CloneElementAt(i));
                                                   ^
```

Per #809, in Node 10.x they have finally removed this method and hence attempts to [follow the syscall steps](https://github.com/gopherjs/gopherjs/blob/master/doc/syscalls.md#nodejs-on-linux-and-macos) fail with:

```
make: Entering directory '/home/norunners/poc/vert/src/github.com/gopherjs/gopherjs/node-syscall/build'
  CXX(target) Release/obj.target/syscall/syscall.o
../syscall.cc: In function ‘intptr_t toNative(v8::Local<v8::Value>)’:
../syscall.cc:28:35: error: ‘class v8::Array’ has no member named ‘CloneElementAt’
       native[i] = toNative(array->CloneElementAt(i));
                                   ^~~~~~~~~~~~~~
```

This PR therefore drops our usage of the deprecated method, instead preferring to use [`v8::Object::Clone()`](https://github.com/v8/v8/blob/a7e6b0ee42db7509a716ca8380255bee2f6a6341/src/api.cc#L5015) as required. 

My C++ skills are however sorely lacking... so perhaps @neelance can offer some thoughts here (given I assume he originated the code?)

We also bump to using Node 10.x in the CI which brings us up-to-date and helps to verify the fix (all the tests pass).

Fixes #809 