### PR TITLE
Added viewport support and defered execution on gopherjs serve

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -641,7 +641,14 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 
 	if isIndex {
 		// If there was no index.html file in any dirs, supply our own.
-		return newFakeFile("index.html", []byte(`<html><head><meta charset="utf-8"><script src="`+base+`.js"></script></head><body></body></html>`)), nil
+		return newFakeFile("index.html", []byte(`<html>
+<head>
+	<meta name="viewport" content="initial-scale=1">
+	<meta charset="utf-8">
+	<script defer src="`+base+`.js"></script>
+</head>
+	<body></body>
+	</html>`)), nil
 	}
 
 	return nil, os.ErrNotExist

--- a/tool.go
+++ b/tool.go
@@ -647,8 +647,9 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 	<meta charset="utf-8">
 	<script defer src="`+base+`.js"></script>
 </head>
-	<body></body>
-	</html>`)), nil
+<body>
+</body>
+</html>`)), nil
 	}
 
 	return nil, os.ErrNotExist


### PR DESCRIPTION
### viewport
Added `<meta name="viewport" content="initial-scale=1">` for responsive web development environment with gopherjs via `gopherjs serve` command!

### Deferred execution

```html
<script defer src="`+base+`.js"></script>`
```

Added `defer` to execute the script as soon as the page load finished!