### PR TITLE
Revert "Added viewport support and defered execution on gopherjs serve (#860)"

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -641,15 +641,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 
 	if isIndex {
 		// If there was no index.html file in any dirs, supply our own.
-		return newFakeFile("index.html", []byte(`<html>
-<head>
-	<meta name="viewport" content="initial-scale=1">
-	<meta charset="utf-8">
-	<script defer src="`+base+`.js"></script>
-</head>
-<body>
-</body>
-</html>`)), nil
+		return newFakeFile("index.html", []byte(`<html><head><meta charset="utf-8"><script src="`+base+`.js"></script></head><body></body></html>`)), nil
 	}
 
 	return nil, os.ErrNotExist


### PR DESCRIPTION
This reverts commit bf5fc7d381404c2a218d4c28865b251d6e8e1cb8.

Reason: Discussion at https://github.com/gopherjs/gopherjs/pull/570#issuecomment-271660965