### PR TITLE
Detect unsupported GOOS

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -59,6 +59,11 @@ func init() {
 		fmt.Fprintf(os.Stderr, "$GOPATH not set. For more details see: go help gopath\n")
 		os.Exit(1)
 	}
+
+	if build.Default.GOOS != "linux" && build.Default.GOOS != "darwin" {
+		fmt.Fprintf(os.Stderr, "GOOS is not supported, the supported GOOS values are linux and darwin. The GopherJS is falling back to GOOS=linux\n")
+		build.Default.GOOS = "linux"
+	}
 }
 
 func main() {


### PR DESCRIPTION
Currently the developer running on Windows should use `set GOOS=linux` and then run the `gopherjs`. Have some issues about it: https://github.com/gopherjs/gopherjs/issues/875, https://github.com/gopherjs/gopherjs/issues/776.

This changes makes the `gopherjs` to use the `GOOS=linux`, clearly telling that the GOOS was changed, the user can still use the `GOOS=darwin` or `GOOS=linux` manually.

The README says:

> gopherjs uses your platform's default GOOS value when generating code. Supported GOOS values are: linux, darwin. If you're on a different platform (e.g., Windows or FreeBSD), you'll need to set the GOOS environment variable to a supported value. For example, GOOS=linux gopherjs build [package].

This change makes the gopherjs use the `GOOS=linux` by default on any unsupported GOOS and plataform. If the user are using `darwin` it will still `darwin`, even if it's not set on `GOOS` explicit.

-------------

I only test with the `gopherjs build`, maybe more test should be done.