### PR TITLE
ci: upgrade to Go 1.11.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ jobs:
     - checkout
     - run: git clone https://github.com/creationix/nvm $HOME/.nvm && cd $HOME/.nvm && git checkout v0.33.9 && echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
     - run: nvm install 10.0.0 && nvm alias default 10.0.0
-    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.11.2.linux-amd64.tar.gz | sudo tar -xz
+    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz | sudo tar -xz
     - run: echo 'export PATH="$PATH:/usr/local/go/bin:$HOME/go/bin"' >> $BASH_ENV
     - run: go get -t -d -v ./...
     - run: go install -v

--- a/tests/run.go
+++ b/tests/run.go
@@ -112,6 +112,9 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue22662b.go": {category: usesUnsupportedPackage, desc: "os/exec.Command unsupported"},
 	"fixedbugs/issue23188.go":  {desc: "incorrect order of evaluation of index operations"},
 	"fixedbugs/issue24547.go":  {desc: "incorrect computing method sets with shadowed methods"},
+
+	// These are new tests in Go 1.11.5
+	"fixedbugs/issue28688.go": {category: notApplicable, desc: "testing runtime optimisations"},
 }
 
 type failCategory uint8


### PR DESCRIPTION
So that we can then see the true diff that the Go 1.12 changes in
#900 will introduce.