### PR TITLE
Remove vendored from misc_test.go

### DIFF
--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"vendored"
 
 	"github.com/gopherjs/gopherjs/tests/otherpkg"
 )
@@ -502,12 +501,6 @@ func TestGoexit(t *testing.T) {
 	go func() {
 		runtime.Goexit()
 	}()
-}
-
-func TestVendoring(t *testing.T) {
-	if vendored.Answer != 42 {
-		t.Fail()
-	}
 }
 
 func TestShift(t *testing.T) {


### PR DESCRIPTION
`vendored` package was introduced at f8510c9aef19750ec5a1178b33932a7f9defd197,
but now the package has gone. I presume that testing `vendored`
package no longer makes sense.