### PR TITLE
compiler: update version to 1.12-2

### DIFF
--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -6,4 +6,4 @@ package compiler
 const ___GOPHERJS_REQUIRES_GO_VERSION_1_12___ = true
 
 // Version is the GopherJS compiler version string.
-const Version = "1.12-1"
+const Version = "1.12-2"


### PR DESCRIPTION
Introducing `syscall/js` (#899) is so significant that we update
the version.