### PR TITLE
update to Go 1.12.9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ jobs:
     - checkout
     - run: git clone https://github.com/creationix/nvm $HOME/.nvm && cd $HOME/.nvm && git checkout v0.33.9 && echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
     - run: nvm install 10.0.0 && nvm alias default 10.0.0
-    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz | sudo tar -xz
+    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.12.9.linux-amd64.tar.gz | sudo tar -xz
     - run: echo 'export PATH="$PATH:/usr/local/go/bin:$HOME/go/bin"' >> $BASH_ENV
     - run: go get -t -d -v ./...
     - run: go install -v

--- a/tests/run.go
+++ b/tests/run.go
@@ -120,6 +120,11 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue27201.go":  {desc: "incorrect stack trace for nil dereference in inlined function"},
 	"fixedbugs/issue27518b.go": {desc: "sigpanic can make dead pointer live again"},
 	"fixedbugs/issue29190.go":  {desc: "append does not fail when length overflows"},
+
+	// These are new tests in Go 1.12.9.
+	"fixedbugs/issue30977.go": {category: neverTerminates, desc: "does for { runtime.GC() }"},
+	"fixedbugs/issue32477.go": {category: notApplicable, desc: "uses runtime.SetFinalizer and runtime.GC"},
+	"fixedbugs/issue32680.go": {category: notApplicable, desc: "uses -gcflags=-d=ssa/check/on flag"},
 }
 
 type failCategory uint8


### PR DESCRIPTION
This change updates the CI script to test against Go 1.12.9¹, the latest minor release within the Go 1.12.x series. It updates the fixedbugs skip table accordingly.

¹ https://groups.google.com/d/msg/golang-announce/oeMaeUnkvVE/a49yvTLqAAAJ