### PR TITLE
Experimental support for go/packages in GopherJS build system

### DIFF
--- a/build/v2/augmenter.go
+++ b/build/v2/augmenter.go
@@ -1,0 +1,175 @@
+package build
+
+import (
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/natives"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
+)
+
+// SymbolFilter implements top-level symbol pruning for augmented packages.
+//
+// GopherJS provides custom implementations of some parts of standard library, which are added
+// on top of the original stdlib sources. To avoid compilation errors due to duplicate symbols,
+// SymbolFilter can Collect top-level symbols from overlay sources and then Prune conflicting
+// symbols from the original sources.
+type SymbolFilter map[string]bool
+
+func (sf SymbolFilter) funcName(d *ast.FuncDecl) string {
+	if d.Recv == nil || len(d.Recv.List) == 0 {
+		return d.Name.Name
+	}
+	recv := d.Recv.List[0].Type
+	if star, ok := recv.(*ast.StarExpr); ok {
+		recv = star.X
+	}
+	return recv.(*ast.Ident).Name + "." + d.Name.Name
+}
+
+// traverse top-level symbols within the file and prune top-level symbols for which keep() returned
+// false.
+//
+// This function is functionally very similar to ast.FilterFile with two differences: it doesn't
+// descend into interface methods and struct fields, and it preserves imports.
+func (sf SymbolFilter) traverse(f *ast.File, keep func(name string) bool) {
+	astutil.Apply(f, func(c *astutil.Cursor) bool {
+		switch d := c.Node().(type) {
+		case *ast.File: // Root node.
+			return true
+		case *ast.FuncDecl: // Child of *ast.File.
+			if !keep(sf.funcName(d)) {
+				c.Delete()
+			}
+		case *ast.GenDecl: // Child of *ast.File.
+			return c.Name() == "Decls"
+		case *ast.ValueSpec: // Child of *ast.GenDecl.
+			for i, name := range d.Names {
+				if !keep(name.Name) {
+					// Deleting variable/const declarations is somewhat fiddly (need to keep many different
+					// slices inside of *ast.ValueSpec in sync), so we simply rename it to "_", which will
+					// later be ignored.
+					d.Names[i] = ast.NewIdent("_")
+				}
+			}
+		case *ast.TypeSpec: // Child of *ast.GenDecl.
+			if !keep(d.Name.Name) {
+				c.Delete()
+			}
+		}
+		return false
+	}, nil)
+}
+
+// Collect names of top-level symbols in the source file. Doesn't modify the file itself.
+func (sf SymbolFilter) Collect(f *ast.File) {
+	sf.traverse(f, func(name string) bool {
+		sf[name] = true
+		return true
+	})
+}
+
+// Prune in-place top-level symbols with names that match previously collected.
+func (sf SymbolFilter) Prune(f *ast.File) {
+	sf.traverse(f, func(name string) bool {
+		return !sf[name]
+	})
+}
+
+type Augmenter struct {
+	natives *build.Context
+}
+
+func NewAugmenter() *Augmenter {
+	a := Augmenter{}
+
+	a.natives = &build.Context{
+		GOROOT:   "/",
+		GOOS:     build.Default.GOOS,
+		GOARCH:   "js",
+		Compiler: "gc",
+		JoinPath: path.Join,
+		SplitPathList: func(list string) []string {
+			if list == "" {
+				return nil
+			}
+			return strings.Split(list, "/")
+		},
+		IsAbsPath: path.IsAbs,
+		IsDir: func(name string) bool {
+			dir, err := natives.FS.Open(name)
+			if err != nil {
+				return false
+			}
+			defer dir.Close()
+			info, err := dir.Stat()
+			if err != nil {
+				return false
+			}
+			return info.IsDir()
+		},
+		HasSubdir: func(root, name string) (rel string, ok bool) {
+			panic("not implemented")
+		},
+		ReadDir: func(name string) (fi []os.FileInfo, err error) {
+			dir, err := natives.FS.Open(name)
+			if err != nil {
+				return nil, err
+			}
+			defer dir.Close()
+			return dir.Readdir(0)
+		},
+		OpenFile: func(name string) (r io.ReadCloser, err error) {
+			return natives.FS.Open(name)
+		},
+	}
+
+	return &a
+}
+
+func (a *Augmenter) Augment(pkg *packages.Package) error {
+	augments, err := a.natives.Import(pkg.PkgPath, "", 0)
+	if err != nil {
+		// This is probably not an augmented package.
+		// TODO: Make a more robust check.
+		return nil
+	}
+	// TODO: Handle test and x-test packages.
+	sources := augments.GoFiles
+
+	symbolFilter := SymbolFilter{}
+
+	extraAST := []*ast.File{}
+	extraFiles := []string{}
+
+	// TODO: Use parser.ParseDir?
+	for _, src := range sources {
+		src = path.Join(augments.Dir, src)
+		f, err := a.natives.OpenFile(src)
+		if err != nil {
+			return fmt.Errorf("failed to open augmentation file %q: %s", src, err)
+		}
+		defer f.Close()
+		parsed, err := parser.ParseFile(pkg.Fset, src, f, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("failed to parse augmentation file %q: %s", src, err)
+		}
+		symbolFilter.Collect(parsed)
+		extraAST = append(extraAST, parsed)
+		extraFiles = append(extraFiles, src)
+	}
+	for _, f := range pkg.Syntax {
+		symbolFilter.Prune(f)
+	}
+	pkg.Syntax = append(extraAST, pkg.Syntax...)
+	pkg.CompiledGoFiles = append(extraFiles, pkg.CompiledGoFiles...)
+
+	return nil
+}

--- a/build/v2/augmenter_test.go
+++ b/build/v2/augmenter_test.go
@@ -1,0 +1,24 @@
+package build
+
+import (
+	"testing"
+)
+
+func TestAugmenter(t *testing.T) {
+	s, err := NewSession(Options{})
+	if err != nil {
+		t.Fatalf("failed to create build session: %s", err)
+	}
+	pkgs, err := s.load("runtime")
+	if err != nil {
+		t.Fatalf("failed to load package 'runtime': %s", err)
+	}
+	pkg := pkgs[0]
+
+	a := NewAugmenter()
+	err = a.Augment(pkg)
+	if err != nil {
+		t.Errorf("failed to augment package %s: %s", pkg, err)
+	}
+	t.Logf("Files parsed: %d", len(pkg.Syntax))
+}

--- a/build/v2/build.go
+++ b/build/v2/build.go
@@ -10,16 +10,33 @@ package build
 
 import (
 	"fmt"
+	"go/token"
+	"go/types"
+	"log"
+	"os"
+	"path/filepath"
 
+	"github.com/davecgh/go-spew/spew"
 	build_v1 "github.com/gopherjs/gopherjs/build"
 	"github.com/gopherjs/gopherjs/compiler"
+	"github.com/neelance/sourcemap"
+	"golang.org/x/tools/go/packages"
 )
+
+func init() {
+	spew.Config.DisablePointerAddresses = true
+	spew.Config.DisableMethods = true
+}
 
 type Options = build_v1.Options
 
 // Session manages build process.
 type Session struct {
 	opts Options
+
+	pkgs     map[string]*packages.Package
+	archives map[string]*compiler.Archive
+	types    map[string]*types.Package
 }
 
 // NewSession initializes a fresh build session.
@@ -34,9 +51,156 @@ func NewSession(opts Options) (*Session, error) {
 		return nil, fmt.Errorf("not implemented: build_v2 package doesn't support colored output yet")
 	}
 
-	return &Session{opts: opts}, nil
+	return &Session{
+		opts:     opts,
+		pkgs:     map[string]*packages.Package{},
+		archives: map[string]*compiler.Archive{},
+		types:    map[string]*types.Package{},
+	}, nil
 }
 
-func (s *Session) Build(patterns ...string) (*compiler.Archive, error) {
-	return nil, fmt.Errorf("building is not implemented yet")
+func (s *Session) Build(patterns ...string) ([]*compiler.Archive, error) {
+	fmt.Printf("Building %s...\n", patterns)
+
+	pkgs, err := s.load(patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load packages %q: %s", patterns, err)
+	}
+
+	archives, err := s.compile(pkgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile packages %s: %s", pkgs, err)
+	}
+	return archives, nil
+}
+
+func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) error {
+	if err := os.MkdirAll(filepath.Dir(pkgObj), 0777); err != nil {
+		return err
+	}
+	codeFile, err := os.Create(pkgObj)
+	if err != nil {
+		return err
+	}
+	defer codeFile.Close()
+
+	sourceMapFilter := &compiler.SourceMapFilter{Writer: codeFile}
+	if s.opts.CreateMapFile {
+		m := &sourcemap.Map{File: filepath.Base(pkgObj)}
+		mapFile, err := os.Create(pkgObj + ".map")
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			m.WriteTo(mapFile)
+			mapFile.Close()
+			fmt.Fprintf(codeFile, "//# sourceMappingURL=%s.map\n", filepath.Base(pkgObj))
+		}()
+
+		sourceMapFilter.MappingCallback = build_v1.NewMappingCallback(m, s.opts.GOROOT, s.opts.GOPATH, s.opts.MapToLocalDisk)
+	}
+
+	deps, err := compiler.ImportDependencies(archive, s.loadAndCompile)
+	if err != nil {
+		return err
+	}
+	// deps := []*compiler.Archive{archive}
+	return compiler.WriteProgramCode(deps, sourceMapFilter)
+}
+
+func (s *Session) load(patterns ...string) ([]*packages.Package, error) {
+	log.Printf("Loading %s...", patterns)
+
+	cfg := packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedSyntax | packages.NeedDeps | packages.NeedTypes,
+		Fset: token.NewFileSet(),
+		// TODO: This is different from the currently documented GopherJS behavior, which uses
+		// GOOS=linux (or darvin) and GOARCH=js. We can't do exactly this because `go list` considers
+		// this combination invalid. Since compiler uses 32-bit sizes, setting GOARCH=386 helps with
+		// avoiding literal size mismatches down the road. However, this won't be necessary if we
+		// implement natives VFS support and pruning for runtime package.
+		//
+		// With all that said, maybe its a good idea to use GOOS=js GOARCH=wasm? It seems to me implying
+		// 64-bit sizes, though.
+		Env: append(os.Environ(), "GOARCH=386"),
+		// TODO: make sure to pass "js" build tag if we end up not using GOOS=js.
+	}
+
+	pkgs, err := packages.Load(&cfg, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %v: %s", patterns, err)
+	}
+
+	if count := packages.PrintErrors(pkgs); count > 0 {
+		return nil, fmt.Errorf("encountered %d errors while loading %q", count, patterns)
+	}
+
+	// TODO: parseAndAugment()
+
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		log.Printf("Putting %s package into cache...", p.ID)
+		// TODO: Verify that this doesn't cause collisions with odd packages such as main or test.
+		// If it does, consider using p.ID as a key.
+		s.pkgs[p.PkgPath] = p
+	})
+
+	return pkgs, nil
+}
+
+func (s *Session) compile(pkgs ...*packages.Package) ([]*compiler.Archive, error) {
+	// TODO: Check if recompilation is not required. Can we use go compiler's cache?
+	log.Printf("Compiling %s...", pkgs)
+
+	importCtx := &compiler.ImportContext{
+		Packages: s.types,
+		Import:   s.loadAndCompile,
+	}
+
+	archives := []*compiler.Archive{}
+
+	for _, pkg := range pkgs {
+		archive, err := compiler.Compile(pkg.PkgPath, pkg.Syntax, pkg.Fset, importCtx, s.opts.Minify)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build package %q: %s", pkg, err)
+		}
+		archives = append(archives, archive)
+		s.archives[archive.ImportPath] = archive
+		log.Printf("Putting %q archive into cache...", archive.ImportPath)
+	}
+
+	return archives, nil
+}
+
+func (s *Session) loadAndCompile(path string) (*compiler.Archive, error) {
+	if a, ok := s.archives[path]; ok {
+		// We've already compiled this package during this session.
+		return a, nil
+	}
+
+	var err error
+	var pkgs []*packages.Package
+
+	if p, ok := s.pkgs[path]; ok {
+		// We've already loaded this package during this session, but haven't compiled it yet.
+		pkgs = []*packages.Package{p}
+	} else {
+		// This is the first time we need this package during the session, let's load it.
+		pkgs, err = s.load(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %q: %s", path, err)
+		}
+		if count := len(pkgs); count != 1 {
+			return nil, fmt.Errorf("s.load(%q) returned %d packages, expected 1", path, count)
+		}
+	}
+
+	archives, err := s.compile(pkgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile %q: %s", path, err)
+	}
+	if count := len(archives); count != 1 {
+		return nil, fmt.Errorf("s.compile(%q) returned %d archives, expected 1", path, count)
+	}
+	return archives[0], nil
 }

--- a/build/v2/build.go
+++ b/build/v2/build.go
@@ -1,0 +1,42 @@
+// Package build provides high-level API for building GopherJS targets.
+//
+// This package acts as a bridge between GopherJS compiler (represented by compiler package) and the
+// environment and is responsible for such tasks as package loading, dependency resolution, etc.
+//
+// Compared to v1, this package now delegates most of the work to go/packages provided by the Go
+// Team, which hides most of logic related to the build system (e.g. GOPATH-based, Go modules, or
+// other build systems).
+package build
+
+import (
+	"fmt"
+
+	build_v1 "github.com/gopherjs/gopherjs/build"
+	"github.com/gopherjs/gopherjs/compiler"
+)
+
+type Options = build_v1.Options
+
+// Session manages build process.
+type Session struct {
+	opts Options
+}
+
+// NewSession initializes a fresh build session.
+func NewSession(opts Options) (*Session, error) {
+	if opts.Watch {
+		return nil, fmt.Errorf("not implemented: build_v2 package doesn't support watch option yet")
+	}
+	if opts.CreateMapFile || opts.MapToLocalDisk {
+		return nil, fmt.Errorf("not implemented: build_v2 package doesn't support source maps yet")
+	}
+	if opts.Color {
+		return nil, fmt.Errorf("not implemented: build_v2 package doesn't support colored output yet")
+	}
+
+	return &Session{opts: opts}, nil
+}
+
+func (s *Session) Build(patterns ...string) (*compiler.Archive, error) {
+	return nil, fmt.Errorf("building is not implemented yet")
+}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -42,6 +42,11 @@ type Archive struct {
 	Minified     bool
 }
 
+// IsCommand returns true if the archive represents an executable binary (i.e. a package "main").
+func (a *Archive) IsCommand() bool {
+	return a.Name == "main"
+}
+
 type Decl struct {
 	FullName        string
 	Vars            []string

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -865,7 +865,7 @@ func (c *funcContext) translateBuiltin(name string, sig *types.Signature, args [
 		}
 	case "len":
 		switch argType := c.p.TypeOf(args[0]).Underlying().(type) {
-		case *types.Basic:
+		case *types.Basic, *types.Array:
 			return c.formatExpr("%e.length", args[0])
 		case *types.Slice:
 			return c.formatExpr("%e.$length", args[0])

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -118,7 +118,7 @@ func (pi packageImporter) Import(path string) (*types.Package, error) {
 	return pi.importContext.Packages[a.ImportPath], nil
 }
 
-func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, importContext *ImportContext, minify bool) (*Archive, error) {
+func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, importContext *ImportContext, minify bool) (_ *Archive, err error) {
 	typesInfo := &types.Info{
 		Types:      make(map[ast.Expr]types.TypeAndValue),
 		Defs:       make(map[*ast.Ident]types.Object),

--- a/tool.go
+++ b/tool.go
@@ -29,6 +29,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/davecgh/go-spew/spew"
 	build_v1 "github.com/gopherjs/gopherjs/build"
 	build_v2 "github.com/gopherjs/gopherjs/build/v2"
 	"github.com/gopherjs/gopherjs/compiler"
@@ -180,6 +181,7 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("failed to build %s: %s", args, err)
 			}
+			spew.Dump(archives)
 
 			if len(archives) == 1 && archives[0].IsCommand() {
 				a := archives[0]

--- a/tool.go
+++ b/tool.go
@@ -29,7 +29,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/davecgh/go-spew/spew"
 	build_v1 "github.com/gopherjs/gopherjs/build"
 	build_v2 "github.com/gopherjs/gopherjs/build/v2"
 	"github.com/gopherjs/gopherjs/compiler"
@@ -181,7 +180,6 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("failed to build %s: %s", args, err)
 			}
-			spew.Dump(archives)
 
 			if len(archives) == 1 && archives[0].IsCommand() {
 				a := archives[0]

--- a/tool.go
+++ b/tool.go
@@ -176,13 +176,20 @@ func main() {
 				return fmt.Errorf("failed to initialize build session with options %+v: %s", options, err)
 			}
 
-			archive, err := session.Build(args...)
+			archives, err := session.Build(args...)
 			if err != nil {
 				return fmt.Errorf("failed to build %s: %s", args, err)
 			}
 
-			// TODO: Write the compiled code to the appropriate location.
-			_ = archive
+			if len(archives) == 1 && archives[0].IsCommand() {
+				a := archives[0]
+				if pkgObj == "" {
+					pkgObj = filepath.Base(a.ImportPath) + ".js"
+				}
+				if err := session.WriteCommandPackage(a, pkgObj); err != nil {
+					return fmt.Errorf("failed to write command package to %q: %s", pkgObj, err)
+				}
+			}
 			return nil
 		}()
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1,0 +1,75 @@
+package tracer
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var global = tracer{}
+
+func Tracef(format string, args ...interface{}) {
+	global.Tracef(format, args...)
+}
+
+func Scope(format string, args ...interface{}) scope {
+	return global.Scope(format, args...)
+}
+
+type scope struct {
+	t    *tracer
+	name string
+}
+
+func (s scope) String() string { return s.name }
+
+func (s scope) Leave(e *error) {
+	s.t.mu.Lock()
+	defer s.t.mu.Unlock()
+
+	top := s.t.stack[0]
+	if top.name != s.name {
+		s.t.Tracef("WARNING: Leaving scope %q, when expected to leave %q.", top, s)
+	}
+	oldStack := s.t.stack
+	s.t.stack = s.t.stack[1:]
+	s.t.traceInternal("<< Leaving %s...", oldStack)
+	if e != nil && *e != nil {
+		s.t.traceInternal("   ! with error: %s", *e)
+	}
+}
+
+type scopes []scope
+
+func (ss scopes) String() string {
+	names := []string{}
+	for _, s := range ss {
+		names = append(names, s.name)
+	}
+	return strings.Join(names, " → ")
+}
+
+type tracer struct {
+	mu    sync.Mutex
+	stack scopes
+}
+
+func (t *tracer) Tracef(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.traceInternal(format, args...)
+}
+
+func (t *tracer) traceInternal(format string, args ...interface{}) {
+	fmt.Printf(strings.Repeat("   ", len(t.stack))+format+"\n", args...)
+}
+
+func (t *tracer) Scope(format string, args ...interface{}) scope {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := scope{t: t, name: fmt.Sprintf(format, args...)}
+	newStack := append(scopes{s}, t.stack...)
+	t.traceInternal(">> Entering %s...", newStack)
+	t.stack = newStack
+	return s
+}


### PR DESCRIPTION
As described in #947, go/packages might be an opportunity for GopherJS to shed some maintenance burden and gain better build system support at the same time.

I'm opening this PR mostly as an early preview of my progress, it is **not** ready to be merged just yet. I'm writing the code in such a way that it would be able to coexist with the current implementation until we decide it is good enough to be the default.

The end goal for this PR is to reach feature parity for `gopherjs build` command. At the moment, it is able to produce sensible-ish JS artifacts, but I haven't implemented support for `natives` VFS as well as standard library packages pruning.

I'll be updating this PR as I go.