### PR TITLE
update to Go 1.12.16

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ jobs:
     - checkout
     - run: git clone https://github.com/creationix/nvm $HOME/.nvm && cd $HOME/.nvm && git checkout v0.33.9 && echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
     - run: nvm install 10.0.0 && nvm alias default 10.0.0
-    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.12.9.linux-amd64.tar.gz | sudo tar -xz
+    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.12.16.linux-amd64.tar.gz | sudo tar -xz
     - run: echo 'export PATH="$PATH:/usr/local/go/bin:$HOME/go/bin"' >> $BASH_ENV
     - run: go get -t -d -v ./...
     - run: go install -v


### PR DESCRIPTION
This change updates the CI script to test against Go 1.12.16¹,
the latest minor release within the Go 1.12.x series.

¹ https://groups.google.com/d/msg/golang-announce/Hsw4mHYc470/WJeW5wguEgAJ