### PR TITLE
add Go modules support

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -550,11 +550,6 @@ func (s *Session) checkMod(pkg *PackageData) (err error) {
 	return nil
 }
 
-func (s *Session) CheckModFromDir(dir string) (err error) {
-	s.mod, err = fastmod.LoadPackage(dir, s.bctx)
-	return
-}
-
 // BuildContext returns the session's build context.
 func (s *Session) BuildContext() *build.Context { return s.bctx }
 

--- a/build/build.go
+++ b/build/build.go
@@ -521,6 +521,7 @@ func NewSession(options *Options) (*Session, error) {
 		Archives: make(map[string]*compiler.Archive),
 	}
 	s.bctx = NewBuildContext(s.InstallSuffix(), s.options.BuildTags)
+	s.mod = fastmod.NewPackage(s.bctx)
 	s.Types = make(map[string]*types.Package)
 	if options.Watch {
 		if out, err := exec.Command("ulimit", "-n").Output(); err == nil {
@@ -538,16 +539,17 @@ func NewSession(options *Options) (*Session, error) {
 	return s, nil
 }
 
-func (s *Session) CheckMod(pkg *PackageData) {
-	if pkg.Goroot {
-		s.mod = nil
-	} else {
-		s.mod, _ = fastmod.LoadPackage(pkg.Dir, s.bctx)
+func (s *Session) CheckMod(pkg *PackageData) (err error) {
+	s.mod = nil
+	if !pkg.Goroot {
+		s.mod, err = fastmod.LoadPackage(pkg.Dir, s.bctx)
 	}
+	return
 }
 
-func (s *Session) CheckModFromDir(dir string) {
-	s.mod, _ = fastmod.LoadPackage(dir, s.bctx)
+func (s *Session) CheckModFromDir(dir string) (err error) {
+	s.mod, err = fastmod.LoadPackage(dir, s.bctx)
+	return
 }
 
 // BuildContext returns the session's build context.

--- a/tests/gopherjsmodules_test.sh
+++ b/tests/gopherjsmodules_test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Don't run this file directly. It's executed as part of TestGopherJSCanBeModules.
+
+set -e
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/gopherjsmodules_test.XXXXXXXXXX")
+
+cleanup() {
+    rm -rf "$tmp"
+    exit
+}
+
+trap cleanup EXIT HUP INT TERM
+
+# Make a hello project that will Go modules GopherJS.
+mkdir -p "$tmp/src/example.org/hello"
+echo 'package main
+
+import (
+    "github.com/gopherjs/gopherjs/js"
+    _ "github.com/gopherjs/websocket"
+)
+
+func main() {
+    js.Global.Get("console").Call("log", "hello using js pkg")
+}' > "$tmp/src/example.org/hello/main.go"
+
+# install gopherjs
+go install github.com/gopherjs/gopherjs
+
+# go mod init
+(cd "$tmp/src/example.org/hello" && go mod init example.org/hello)
+
+# go mod tidy
+(cd "$tmp/src/example.org/hello" && go mod tidy)
+
+# Use it to build and run the hello command.
+(cd "$tmp/src/example.org/hello" && "$HOME/go/bin/gopherjs" run main.go)

--- a/tests/gorepo_test.go
+++ b/tests/gorepo_test.go
@@ -43,3 +43,20 @@ func TestGopherJSCanBeVendored(t *testing.T) {
 		t.Errorf("unexpected stdout from gopherjsvendored_test.sh:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
+
+// Test that GopherJS can be Go modules into a project, and then used to build Go programs.
+func TestGopherJSCanBeModules(t *testing.T) {
+	if runtime.GOARCH == "js" {
+		t.Skip("test meant to be run using normal Go compiler (needs os/exec)")
+	}
+
+	cmd := exec.Command("sh", "gopherjsmodules_test.sh")
+	cmd.Stderr = os.Stdout
+	got, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "hello using js pkg\n"; string(got) != want {
+		t.Errorf("unexpected stdout from gopherjsmodules_test.sh:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/tool.go
+++ b/tool.go
@@ -120,6 +120,7 @@ func main() {
 							s.Watcher.Add(name)
 						}
 					}
+					s.CheckModFromDir(currentDirectory)
 					err := s.BuildFiles(args, pkgObj, currentDirectory)
 					return err
 				}
@@ -140,6 +141,7 @@ func main() {
 					if err != nil {
 						return err
 					}
+					s.CheckMod(pkg)
 					archive, err := s.BuildPackage(pkg)
 					if err != nil {
 						return err
@@ -204,7 +206,7 @@ func main() {
 					if err != nil {
 						return err
 					}
-
+					s.CheckMod(pkg)
 					archive, err := s.BuildPackage(pkg)
 					if err != nil {
 						return err
@@ -286,6 +288,7 @@ func main() {
 			if err != nil {
 				return err
 			}
+			s.CheckModFromDir(currentDirectory)
 			if err := s.BuildFiles(args[:lastSourceArg], tempfile.Name(), currentDirectory); err != nil {
 				return err
 			}
@@ -345,6 +348,7 @@ func main() {
 				if err != nil {
 					return err
 				}
+				s.CheckMod(pkg)
 
 				tests := &testFuncs{BuildContext: s.BuildContext(), Package: pkg.Package}
 				collectTests := func(testPkg *gbuild.PackageData, testPkgName string, needVar *bool) error {
@@ -610,6 +614,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 
 		switch {
 		case isPkg:
+			s.CheckMod(pkg)
 			buf := new(bytes.Buffer)
 			browserErrors := new(bytes.Buffer)
 			err := func() error {

--- a/tool.go
+++ b/tool.go
@@ -120,7 +120,6 @@ func main() {
 							s.Watcher.Add(name)
 						}
 					}
-					s.CheckModFromDir(currentDirectory)
 					err := s.BuildFiles(args, pkgObj, currentDirectory)
 					return err
 				}
@@ -141,7 +140,6 @@ func main() {
 					if err != nil {
 						return err
 					}
-					s.CheckMod(pkg)
 					archive, err := s.BuildPackage(pkg)
 					if err != nil {
 						return err
@@ -206,7 +204,7 @@ func main() {
 					if err != nil {
 						return err
 					}
-					s.CheckMod(pkg)
+
 					archive, err := s.BuildPackage(pkg)
 					if err != nil {
 						return err
@@ -288,7 +286,6 @@ func main() {
 			if err != nil {
 				return err
 			}
-			s.CheckModFromDir(currentDirectory)
 			if err := s.BuildFiles(args[:lastSourceArg], tempfile.Name(), currentDirectory); err != nil {
 				return err
 			}
@@ -348,7 +345,6 @@ func main() {
 				if err != nil {
 					return err
 				}
-				s.CheckMod(pkg)
 
 				tests := &testFuncs{BuildContext: s.BuildContext(), Package: pkg.Package}
 				collectTests := func(testPkg *gbuild.PackageData, testPkgName string, needVar *bool) error {
@@ -614,7 +610,6 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 
 		switch {
 		case isPkg:
-			s.CheckMod(pkg)
 			buf := new(bytes.Buffer)
 			browserErrors := new(bytes.Buffer)
 			err := func() error {


### PR DESCRIPTION
Add Go modules build/run support and test. ( project use `go env GOMOD` lookup go.mod)
add fastmod for check Go modules and lookup package from go.mod. 
The fastmod is read-only for go.mod, please 'go mod tidy' first if need.