### PR TITLE
- convert thrown errors to go errors

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -49,7 +49,7 @@ func (o *Object) SetIndex(i int, value interface{}) { o.object.SetIndex(i, value
 // Call calls the object's method with the given name.
 func (o *Object) Call(name string, args ...interface{}) *Object { return o.object.Call(name, args...) }
 
-// Call calls the object's method with the given name. If object's method throws a Javascript
+// Call2 calls the object's method with the given name. If object's method throws a Javascript
 // error, an *Error is returned.
 func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error) {
 	defer func() {
@@ -67,7 +67,7 @@ func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error)
 // Invoke calls the object itself. This will fail if it is not a function. 
 func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(args...) }
 
-// Invoke calls the object itself. This will fail if it is not a function.
+// Invoke2 calls the object itself. This will fail if it is not a function.
 // If the call throws a Javascript error, an *Error is returned.
 func (o *Object) Invoke2(args ...interface{}) (_ *Object, rerr error) {
 	defer func() {
@@ -85,7 +85,7 @@ func (o *Object) Invoke2(args ...interface{}) (_ *Object, rerr error) {
 // New creates a new instance of this type object. This will fail if it not a function (constructor).
 func (o *Object) New(args ...interface{}) *Object { return o.object.New(args...) }
 
-// New creates a new instance of this type object. This will fail if it not a function (constructor).
+// New2 creates a new instance of this type object. This will fail if it not a function (constructor).
 // If calling New throws a Javascript error, an *Error is returned.
 func (o *Object) New2(args ...interface{}) (_ *Object, rerr error) {
 	defer func() {

--- a/js/js.go
+++ b/js/js.go
@@ -64,7 +64,6 @@ func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error)
 	return o.object.Call(name, args...)
 }
 
-
 // Invoke calls the object itself. This will fail if it is not a function. 
 func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(args...) }
 

--- a/js/js.go
+++ b/js/js.go
@@ -49,11 +49,57 @@ func (o *Object) SetIndex(i int, value interface{}) { o.object.SetIndex(i, value
 // Call calls the object's method with the given name.
 func (o *Object) Call(name string, args ...interface{}) *Object { return o.object.Call(name, args...) }
 
-// Invoke calls the object itself. This will fail if it is not a function.
+// Call calls the object's method with the given name. If object's method throws a Javascript
+// error, an *Error is returned.
+func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err, ok := e.(*Error)
+			if !ok {
+				panic(e)
+			}
+			rErr = err
+		}
+	}()
+	return o.object.Call(name, args...)
+}
+
+
+// Invoke calls the object itself. This will fail if it is not a function. 
 func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(args...) }
+
+// Invoke calls the object itself. This will fail if it is not a function.
+// If the call throws a Javascript error, an *Error is returned.
+func (o *Object) Invoke2(args ...interface{}) (_ *Object, rerr error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err, ok := e.(*Error)
+			if !ok {
+				panic(e)
+			}
+			rErr = err
+		}
+	}()
+	return o.object.Invoke(args...)
+}
 
 // New creates a new instance of this type object. This will fail if it not a function (constructor).
 func (o *Object) New(args ...interface{}) *Object { return o.object.New(args...) }
+
+// New creates a new instance of this type object. This will fail if it not a function (constructor).
+// If calling New throws a Javascript error, an *Error is returned.
+func (o *Object) New2(args ...interface{}) (_ *Object, rerr error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err, ok := e.(*Error)
+			if !ok {
+				panic(e)
+			}
+			rErr = err
+		}
+	}()
+	return o.object.New(args...)
+}
 
 // Bool returns the object converted to bool according to JavaScript type conversions.
 func (o *Object) Bool() bool { return o.object.Bool() }

--- a/js/js.go
+++ b/js/js.go
@@ -86,8 +86,8 @@ func (o *Object) Invoke2(args ...interface{}) (_ *Object, rErr error) {
 func (o *Object) New(args ...interface{}) *Object { return o.object.New(args...) }
 
 // New2 creates a new instance of this type object. This will fail if it not a function (constructor).
-// If calling New throws a Javascript error, an *Error is returned.
-func (o *Object) New2(args ...interface{}) (_ *Object, rerr error) {
+// If calling New2 throws a Javascript error, an *Error is returned.
+func (o *Object) New2(args ...interface{}) (_ *Object, rErr error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err, ok := e.(*Error)
@@ -97,7 +97,7 @@ func (o *Object) New2(args ...interface{}) (_ *Object, rerr error) {
 			rErr = err
 		}
 	}()
-	return o.object.New(args...)
+	return o.object.New(args...), nil
 }
 
 // Bool returns the object converted to bool according to JavaScript type conversions.

--- a/js/js.go
+++ b/js/js.go
@@ -61,7 +61,7 @@ func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error)
 			rErr = err
 		}
 	}()
-	return o.object.Call(name, args...)
+	return o.object.Call(name, args...), nil
 }
 
 // Invoke calls the object itself. This will fail if it is not a function. 
@@ -79,7 +79,7 @@ func (o *Object) Invoke2(args ...interface{}) (_ *Object, rerr error) {
 			rErr = err
 		}
 	}()
-	return o.object.Invoke(args...)
+	return o.object.Invoke(args...), nil
 }
 
 // New creates a new instance of this type object. This will fail if it not a function (constructor).

--- a/js/js.go
+++ b/js/js.go
@@ -51,7 +51,7 @@ func (o *Object) Call(name string, args ...interface{}) *Object { return o.objec
 
 // Call2 calls the object's method with the given name. If object's method throws a Javascript
 // error, an *Error is returned.
-func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rerr error) {
+func (o *Object) Call2(name string, args ...interface{}) (_ *Object, rErr error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err, ok := e.(*Error)
@@ -69,7 +69,7 @@ func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(ar
 
 // Invoke2 calls the object itself. This will fail if it is not a function.
 // If the call throws a Javascript error, an *Error is returned.
-func (o *Object) Invoke2(args ...interface{}) (_ *Object, rerr error) {
+func (o *Object) Invoke2(args ...interface{}) (_ *Object, rErr error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err, ok := e.(*Error)


### PR DESCRIPTION
You cans see that having a number at the end of the function is idiomatic.

https://golang.org/pkg/reflect/#Value.Slice3