### PR TITLE
Add support for analyzing GopherJS artifact size.

### DIFF
--- a/build/analysis/rect.go
+++ b/build/analysis/rect.go
@@ -1,0 +1,283 @@
+package analysis
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+)
+
+// rect represents a single rectangle area on the SVG rendering of the TreeMap diagram.
+type rect struct {
+	left       float64
+	top        float64
+	right      float64
+	bottom     float64
+	transposed bool
+}
+
+func newRect(w, h float64) rect { return rect{0, 0, w, h, false} }
+
+func (r rect) width() float64 { return r.right - r.left }
+
+func (r rect) height() float64 { return r.bottom - r.top }
+
+// long returns the length of the longer side of the rectangle.
+func (r rect) long() float64 {
+	w, h := r.width(), r.height()
+	if w > h {
+		return w
+	}
+	return h
+}
+
+// short returns the length of the shorter side of the rectangle.
+func (r rect) short() float64 {
+	w, h := r.width(), r.height()
+	if w < h {
+		return w
+	}
+	return h
+}
+
+// padding between the current rect's bounds and nested rectangles representing
+// child nodes in the TreeMap.
+func (r rect) padding() float64 {
+	const factor = 0.025
+	padding := r.short() * factor
+	if padding > 10 {
+		padding = 10
+	}
+	return padding
+}
+
+// shrink the rectangle bounds by the given margin on every side.
+//
+// The center of the shrinked rectangle will be the same. Padding is
+// automatically reduced to prevent shrinking to zero if necessary.
+func (r rect) shrink(padding float64) rect {
+	if padding*2 > r.short()/2 {
+		padding = r.short() / 4
+	}
+	shrinked := rect{
+		left:       r.left + padding,
+		top:        r.top + padding,
+		right:      r.right - padding,
+		bottom:     r.bottom - padding,
+		transposed: r.transposed,
+	}
+	return shrinked
+}
+
+// aspectRatio returns width divided by height.
+func (r rect) aspectRatio() float64 { return r.width() / r.height() }
+
+// transpose flips X and Y coordinates of the rectangle and sets the
+// "transposed" flag appropriately.
+func (r rect) transpose() rect {
+	return rect{
+		left:       r.top,
+		top:        r.left,
+		right:      r.bottom,
+		bottom:     r.right,
+		transposed: !r.transposed,
+	}
+}
+
+// orientHorizontally transposes the rectangle such that the horizontal size is
+// always the longer.
+//
+// When subdividing a rectangle in the diagram we always lay down stacks of
+// children along the longer side for better readability, always orienting the
+// rectangle horizontally prevents a lot of branching in the layout code.
+// Calling restoreOrientation() will place the rectangle in the corrent place
+// regardless of how many times it or its parents were transposed.
+func (r rect) orientHorizontally() rect {
+	if r.aspectRatio() < 1 {
+		return r.transpose()
+	}
+	return r
+}
+
+// restoreOrientation transposes the rectangle if necessary to return it to the
+// original coordinate system.
+func (r rect) restoreOrientation() rect {
+	if r.transposed {
+		return r.transpose()
+	}
+	return r
+}
+
+// split the rectangle along the horizontal axis in protortion to the weights.
+// transpose() the rectangle first in order to split along the vertical axis.
+func (r rect) split(weights ...float64) rects {
+	var total float64
+	for _, w := range weights {
+		total += w
+	}
+
+	parts := []rect{}
+	var processedFraction float64
+	for _, w := range weights {
+		fraction := w / total
+		parts = append(parts, rect{
+			left:       r.left + r.width()*processedFraction,
+			top:        r.top,
+			right:      r.left + r.width()*(processedFraction+fraction),
+			bottom:     r.bottom,
+			transposed: r.transposed,
+		})
+		processedFraction += fraction
+	}
+
+	return parts
+}
+
+// toSVG writes the SVG code to represent the current rect given the display options.
+//
+// Coordinates and sizes are rounded to 2 decimal digits to reduce chances of
+// tests flaking out due to floating point imprecision. This will have no
+// visible impact on the rendering since 0.01 unit == 0.01 pixel by default.
+func (r rect) toSVG(w io.Writer, opts ...svgOpt) error {
+	normal := r.restoreOrientation() // Make sure we render the rect in its actual position.
+
+	// Populate the default SVG representation of the rect for its coordinates.
+	data := svgGroup{
+		Rect: &svgRect{
+			X:           round2(normal.left),
+			Y:           round2(normal.top),
+			Width:       round2(normal.width()),
+			Height:      round2(normal.height()),
+			Fill:        "black",
+			FillOpacity: 1,
+			Stroke:      "black",
+			StrokeWidth: 0,
+		},
+		Text: &svgText{
+			X:          round2(normal.left + normal.width()/2),
+			Y:          round2(normal.top + normal.height()/2),
+			TextAnchor: "middle",
+			Baseline:   "middle",
+			FontSize:   20,
+		},
+	}
+
+	// Apply all the display options passed by the caller.
+	for _, o := range opts {
+		o(&data)
+	}
+
+	// Adjust rect label display such that it is readable and fits rectangle
+	// bounds. The constants below are empirically determined.
+	const (
+		fontFactorX = 1.5
+		fontFactorY = 0.8
+		minFont     = 8
+	)
+	if data.Text.FontSize > normal.short()*fontFactorY {
+		data.Text.FontSize = normal.short() * fontFactorY
+	}
+	if l := float64(len(data.Text.Text)); l*data.Text.FontSize > normal.long()*fontFactorX {
+		data.Text.FontSize = normal.long() / l * fontFactorX
+	}
+	if data.Text.FontSize < minFont {
+		data.Text.Text = ""
+	}
+	data.Text.FontSize = round2(data.Text.FontSize)
+	if normal.aspectRatio() < 1 {
+		data.Text.Transform = fmt.Sprintf("rotate(270 %0.2f %0.2f)", data.Text.X, data.Text.Y)
+	}
+
+	if data.Text.Text == "" {
+		// Remove the text element if there's nothing to show.
+		data.Text = nil
+	}
+	if data.Rect.FillOpacity == 0 && data.Rect.StrokeWidth == 0 {
+		// Remove the rect element if it isn't supposed to be visible.
+		data.Rect = nil
+	}
+
+	defer w.Write([]byte("\n"))
+	return xml.NewEncoder(w).Encode(data)
+}
+
+type svgGroup struct {
+	XMLName struct{} `xml:"g"`
+	Rect    *svgRect
+	Text    *svgText `xml:",omitempty"`
+}
+
+type svgRect struct {
+	XMLName     struct{} `xml:"rect"`
+	X           float64  `xml:"x,attr"`
+	Y           float64  `xml:"y,attr"`
+	Width       float64  `xml:"width,attr"`
+	Height      float64  `xml:"height,attr"`
+	Fill        string   `xml:"fill,attr,omitempty"`
+	FillOpacity float64  `xml:"fill-opacity,attr"`
+	Stroke      string   `xml:"stroke,attr,omitempty"`
+	StrokeWidth float64  `xml:"stroke-width,attr,omitempty"`
+	Title       string   `xml:"title,omitempty"`
+}
+
+type svgText struct {
+	XMLName    struct{} `xml:"text"`
+	Text       string   `xml:",chardata"`
+	X          float64  `xml:"x,attr"`
+	Y          float64  `xml:"y,attr"`
+	FontSize   float64  `xml:"font-size,attr"`
+	Transform  string   `xml:"transform,attr,omitempty"`
+	TextAnchor string   `xml:"text-anchor,attr,omitempty"`
+	Baseline   string   `xml:"dominant-baseline,attr,omitempty"`
+}
+
+type svgOpt func(r *svgGroup)
+
+// WithTitle adds a hover tooltip text to the rectangle.
+func WithTooltip(t string) svgOpt {
+	return func(g *svgGroup) { g.Rect.Title = t }
+}
+
+// WithText adds a text label over the rectangle.
+func WithText(t string) svgOpt {
+	return func(g *svgGroup) { g.Text.Text = t }
+}
+
+// WithFill sets rectangle fill style.
+func WithFill(color string, opacity float64) svgOpt {
+	return func(g *svgGroup) {
+		g.Rect.Fill = color
+		g.Rect.FillOpacity = opacity
+	}
+}
+
+// WithStroke sets rectangle outline stroke style.
+func WithStroke(color string, width float64) svgOpt {
+	return func(g *svgGroup) {
+		g.Rect.Stroke = color
+		g.Rect.StrokeWidth = width
+	}
+}
+
+// rects is a group of rectangles representing sibling nodes in the tree.
+type rects []rect
+
+// maxAspect returns the highest aspect ratio amount the rect group.
+//
+// Aspect ratios lesser than 1 are inverted to be above 1. The closer the return
+// value is to 1, the closer all rectangles in the group are to squares.
+func (rr rects) maxAspect() float64 {
+	var result float64 = 1 // Start as if we have a perfectly square layout.
+	for _, r := range rr {
+		aspect := r.aspectRatio()
+		if aspect < 1 {
+			aspect = 1 / aspect
+		}
+		if aspect > result {
+			result = aspect
+		}
+	}
+	return result
+}
+
+func round2(v float64) float64 { return math.Round(v*100) / 100 }

--- a/build/analysis/rect_test.go
+++ b/build/analysis/rect_test.go
@@ -1,0 +1,111 @@
+package analysis
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestRectSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		original rect
+		weights  []float64
+		parts    rects
+	}{
+		{
+			name:     "single part",
+			original: rect{0, 1, 10, 2, true},
+			weights:  []float64{42},
+			parts:    rects{{0, 1, 10, 2, true}},
+		},
+		{
+			name:     "two parts",
+			original: rect{0, 1, 10, 2, true},
+			weights:  []float64{4, 6},
+			parts:    rects{{0, 1, 4, 2, true}, {4, 1, 10, 2, true}},
+		},
+		{
+			name:     "many parts",
+			original: rect{0, 1, 10, 2, true},
+			weights:  []float64{2, 4, 6, 8},
+			parts:    rects{{0, 1, 1, 2, true}, {1, 1, 3, 2, true}, {3, 1, 6, 2, true}, {6, 1, 10, 2, true}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.original.split(test.weights...)
+			if diff := cmp.Diff(test.parts, got, cmp.AllowUnexported(rect{}), cmpopts.EquateApprox(0.0001, 0.0001)); diff != "" {
+				t.Errorf("rect.split(%v) returned diff:\n%s", test.weights, diff)
+			}
+		})
+	}
+}
+
+func TestRectToSVG(t *testing.T) {
+	tests := []struct {
+		name string
+		rect rect
+		opts []svgOpt
+		want string
+	}{
+		{
+			name: "default",
+			rect: rect{left: 1, top: 2, right: 3, bottom: 4, transposed: false},
+			want: `<g><rect x="1" y="2" width="2" height="2" fill="black" fill-opacity="1" stroke="black"></rect></g>`,
+		}, {
+			name: "transposed",
+			rect: rect{left: 2, top: 1, right: 4, bottom: 3, transposed: true},
+			want: `<g><rect x="1" y="2" width="2" height="2" fill="black" fill-opacity="1" stroke="black"></rect></g>`,
+		}, {
+			name: "red stroke",
+			rect: rect{left: 1, top: 2, right: 3, bottom: 4, transposed: false},
+			opts: []svgOpt{WithStroke("#F00", 0.5)},
+			want: `<g><rect x="1" y="2" width="2" height="2" fill="black" fill-opacity="1" stroke="#F00" stroke-width="0.5"></rect></g>`,
+		}, {
+			name: "red fill",
+			rect: rect{left: 1, top: 2, right: 3, bottom: 4, transposed: false},
+			opts: []svgOpt{WithFill("#F00", 0.5)},
+			want: `<g><rect x="1" y="2" width="2" height="2" fill="#F00" fill-opacity="0.5" stroke="black"></rect></g>`,
+		}, {
+			name: "with text",
+			rect: rect{left: 10, top: 10, right: 80, bottom: 40, transposed: false},
+			opts: []svgOpt{WithText("Hello, world!")},
+			want: `<g><rect x="10" y="10" width="70" height="30" fill="black" fill-opacity="1" stroke="black"></rect>` +
+				`<text x="45" y="25" font-size="8.08" text-anchor="middle" dominant-baseline="middle">Hello, world!</text></g>`,
+		}, {
+			name: "with text vertical",
+			rect: rect{left: 10, top: 10, right: 40, bottom: 80, transposed: false},
+			opts: []svgOpt{WithText("Hello, world!")},
+			want: `<g><rect x="10" y="10" width="30" height="70" fill="black" fill-opacity="1" stroke="black"></rect>` +
+				`<text x="25" y="45" font-size="8.08" transform="rotate(270 25.00 45.00)" text-anchor="middle" dominant-baseline="middle">Hello, world!</text></g>`,
+		}, {
+			name: "with text too small",
+			rect: rect{left: 1, top: 1, right: 8, bottom: 4, transposed: false},
+			opts: []svgOpt{WithText("Hello, world!")},
+			want: `<g><rect x="1" y="1" width="7" height="3" fill="black" fill-opacity="1" stroke="black"></rect></g>`,
+		}, {
+			name: "with tooltip",
+			rect: rect{left: 1, top: 2, right: 3, bottom: 4, transposed: false},
+			opts: []svgOpt{WithTooltip("Hello, world!")},
+			want: `<g><rect x="1" y="2" width="2" height="2" fill="black" fill-opacity="1" stroke="black"><title>Hello, world!</title></rect></g>`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			if err := test.rect.toSVG(b, test.opts...); err != nil {
+				t.Fatalf("rect.toSVG() returned error: %s", err)
+			}
+			got := strings.TrimSpace(b.String())
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("rect.toSVG() returned diff (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/build/analysis/tree.go
+++ b/build/analysis/tree.go
@@ -1,0 +1,245 @@
+package analysis
+
+import (
+	"crypto/md5"
+	"fmt"
+	"image/color"
+	"io"
+	"math"
+	"math/bits"
+	"sort"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+)
+
+// treeMapNode represents a single node in a Tree Map diagram.
+//
+// Each node has a label and own size associated with it, as well as a list of
+// direct descendants.
+//
+// Even though this type can be used for building Tree Map diagrams of anything
+// (e.g. file system) it has extra features to handle dependency graph use case.
+// Node's children must form a directed acyclic graph, not necessarily a tree.
+// It will be later transformed into a tree by a organizeTree() call.
+type treeMapNode struct {
+	Label    string
+	Size     float64
+	Children nodeGroup
+
+	// The following fields are populated from the tree structure by organizeTree()
+	depth             int          // Shortest distance between the node and the tree root.
+	parent            *treeMapNode // Selected tree parent for the current node.
+	effectiveChildren nodeGroup    // Nodes for which this node was selected as a parent sorted by cumulative size.
+	cumulativeSize    float64
+}
+
+// organizeTree transforms the acyclic import graph into a spanning tree.
+//
+// In order to visualize import graph and package sizes as a Tree Map diagram we
+// need to reduce it to a tree to make sure we don't double-count size
+// contribution of transitive dependencies even if they are imported by multiple
+// other packages. We solve this by selecting a single parent for every node of
+// the import graph and rendering the node only under the selected parent.
+// Empirically, the diagram is most readable if we selected the parent with the
+// shortest distance from the tree root (main package).
+func (root *treeMapNode) organizeTree() *treeMapNode {
+	// Mark all nodes as initially not visited.
+	var prepare func(node *treeMapNode)
+	prepare = func(node *treeMapNode) {
+		node.depth = 1<<(bits.UintSize-1) - 1 // Max int
+		for _, c := range node.Children {
+			prepare(c)
+		}
+	}
+	prepare(root)
+	root.depth = 0
+
+	// Use Dijkstra's algorithm to build a spanning tree.
+	queue := []*treeMapNode{root}
+	processNode := func(node *treeMapNode) {
+		// Sort children by name to ensure deterministic result.
+		sort.Slice(node.Children, func(i, j int) bool {
+			return node.Children[i].Label < node.Children[j].Label
+		})
+		// Select provisional parents for all children.
+		for _, child := range node.Children {
+			if child.depth > node.depth+1 {
+				child.depth = node.depth + 1
+				child.parent = node
+			}
+			queue = append(queue, child)
+		}
+	}
+	for len(queue) > 0 {
+		processNode(queue[0])
+		queue = queue[1:]
+	}
+
+	// Precompute some numbers we'll been to build the diagram.
+	var precompute func(node *treeMapNode)
+	precompute = func(node *treeMapNode) {
+		node.cumulativeSize = node.Size
+		for _, child := range node.Children {
+			if child.parent == node {
+				precompute(child) // Compute all the metrics for the child first.
+				node.effectiveChildren = append(node.effectiveChildren, child)
+				node.cumulativeSize += child.cumulativeSize
+			}
+		}
+		// Sort effective children by size descending, this tends to produce better-looking diagrams.
+		sort.Slice(node.effectiveChildren, func(i, j int) bool {
+			if node.effectiveChildren[i].cumulativeSize != node.effectiveChildren[j].cumulativeSize {
+				return node.effectiveChildren[i].cumulativeSize > node.effectiveChildren[j].cumulativeSize
+			}
+			return node.effectiveChildren[i].Label < node.effectiveChildren[j].Label // To guarantee determinism.
+		})
+	}
+	precompute(root)
+	return root
+}
+
+// color assigns a deterministic pseudo-random color to the node. Colors are in
+// light pastel gamma to provide good readable contrast for text labels.
+func (n *treeMapNode) color() string {
+	hash := md5.Sum([]byte(n.Label))
+	cb := hash[0]
+	cr := hash[1]
+	y := uint8(256 * (0.25 + math.Pow(0.9, float64(n.depth))/2))
+	r, g, b := color.YCbCrToRGB(y, cb, cr)
+	return fmt.Sprintf("#%02x%02x%02x", r, g, b)
+}
+
+// renderSelf renders a labeled rectangle for the node itself within the given
+// bounding area and returns a sub-area where children nodes should be rendered.
+// Bounding area is split between self and children based on the relative
+// weights.
+func (n *treeMapNode) renderSelf(w io.Writer, bounds rect) (rect, error) {
+	// Output own bounding rect into the SVG stream.
+	if err := bounds.toSVG(w, WithTooltip(n.Describe()), WithFill(n.color(), 0.1), WithStroke("black", 0.5)); err != nil {
+		return rect{}, fmt.Errorf("failed to render self to svg: %s", err)
+	}
+
+	// Create a bit of a border for better visualization of the tree hierarchy.
+	bounds = bounds.shrink(bounds.padding())
+
+	// Reserve some space to represent own size.
+	ownSplit := bounds.split(n.Size, n.cumulativeSize-n.Size)
+	ownSplit[0].toSVG(w, WithFill("none", 0), WithText(fmt.Sprintf("%s — %s", n.Label, humanize.IBytes(uint64(n.Size)))))
+
+	// The rest will be allocated to children.
+	bounds = ownSplit[1]
+	return bounds, nil
+}
+
+// toSVG renders Tree Map diagram for the node and its children in the given bounding area.
+//
+// This function implements a simplified version of the Squarified Treemaps [1]
+// algorithm to avoid generating a lot of thin and long nodes, which are
+// difficult to read and label.
+//
+// Note that organizeTree() needs to be called prior to this method to ensure
+// every element in the graph is rendered exactly once.
+//
+// [1]: Bruls, Mark, Kees Huizing, and Jarke J. Van Wijk. "Squarified treemaps."
+// Data visualization 2000. Springer, Vienna, 2000. 33-42.
+func (n *treeMapNode) toSVG(w io.Writer, bounds rect) error {
+	// Reserve a fraction of the bounding area to represent node's own weight.
+	bounds, err := n.renderSelf(w, bounds)
+	if err != nil {
+		return fmt.Errorf("failed to render self: %s", err)
+	}
+
+	if len(n.effectiveChildren) == 0 {
+		return nil
+	}
+
+	// Renders a stack of child nodes within the corresponding bounding areas.
+	renderStack := func(stack nodeGroup, bounds rects) error {
+		if len(stack) != len(bounds) {
+			// This should never happen ™.
+			panic(fmt.Sprintf("Tried to lay out node stack %v inside %d bounding rects, need %d", stack, len(bounds), len(stack)))
+		}
+		for i, node := range stack {
+			node.toSVG(w, bounds[i])
+		}
+		return nil
+	}
+
+	bounds = bounds.orientHorizontally()
+	stack := nodeGroup{n.effectiveChildren[0]}                  // Seed the first stack of children.
+	queue := n.effectiveChildren[1:]                            // Queue the remaining children.
+	split := bounds.split(stack.totalSize(), queue.totalSize()) // Split the available space between the stack and the remainder.
+	stackBounds := split[0].split(stack.cumulativeSizes()...)   // Subdivide stack space for each stack element.
+
+	// Attempt to arrange children into one or more "stacks" inside the bounding
+	// area such that each child's area is as square as possible. We do it
+	// greedily by adding children into stacks as long as it improves aspect
+	// ratios within the stack.
+	for len(queue) > 0 {
+		var candidate *treeMapNode
+		candidate, queue = queue[0], queue[1:]
+		newStack := append(stack, candidate)
+		newSplit := bounds.split(newStack.totalSize(), queue.totalSize())
+		newStackBounds := newSplit[0].orientHorizontally().split(newStack.cumulativeSizes()...)
+
+		if newStackBounds.maxAspect() > stackBounds.maxAspect() {
+			// The new stack made the layout less square, so we commit the the
+			// previous version of the stack and seed a new stack.
+			if err := renderStack(stack, stackBounds); err != nil {
+				return fmt.Errorf("failed to lay out children of %q: %s", n.Label, err)
+			}
+
+			bounds = split[1]            // Reduce the available layout space to that's left.
+			stack = nodeGroup{candidate} // Seed the new stack.
+			split = bounds.split(stack.totalSize(), queue.totalSize())
+			stackBounds = split[0].split(stack.cumulativeSizes()...)
+		} else {
+			// The new stack looks better, accept it and keep adding to it.
+			stack = newStack
+			split = newSplit
+			stackBounds = newStackBounds
+		}
+	}
+
+	// Render the last stack as it is.
+	if err := renderStack(stack, stackBounds); err != nil {
+		return fmt.Errorf("failed to lay out children of %q: %s", n.Label, err)
+	}
+
+	return nil
+}
+
+// Describe the node itself.
+func (n *treeMapNode) Describe() string {
+	return fmt.Sprintf("%s — %s own size, %s with children", n.Label, humanize.IBytes(uint64(n.Size)), humanize.IBytes(uint64(n.cumulativeSize)))
+}
+
+// String representation of the node and its effective children.
+func (n *treeMapNode) String() string {
+	s := &strings.Builder{}
+	fmt.Fprintf(s, " %s %s\n", strings.Repeat(" *", n.depth), n.Describe())
+	for _, c := range n.effectiveChildren {
+		s.WriteString(c.String())
+	}
+	return s.String()
+}
+
+// nodeGroup represents a group of adjacent tree nodes.
+type nodeGroup []*treeMapNode
+
+func (ng nodeGroup) totalSize() float64 {
+	var size float64
+	for _, c := range ng {
+		size += c.cumulativeSize
+	}
+	return size
+}
+
+func (ng nodeGroup) cumulativeSizes() []float64 {
+	sizes := []float64{}
+	for _, c := range ng {
+		sizes = append(sizes, c.cumulativeSize)
+	}
+	return sizes
+}

--- a/build/analysis/tree_test.go
+++ b/build/analysis/tree_test.go
@@ -1,0 +1,72 @@
+package analysis
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTreeNodeOrganize(t *testing.T) {
+	io := &treeMapNode{Label: "io", Size: 10 * 1024}
+	strconv := &treeMapNode{Label: "strconv", Size: 1 * 1024}
+	fmt := &treeMapNode{Label: "fmt", Size: 50 * 1024, Children: nodeGroup{io, strconv}}
+	main := &treeMapNode{Label: "main", Size: 1024 * 1024, Children: nodeGroup{io, fmt}}
+
+	main.organizeTree()
+
+	// Text representation of the spanning tree for the acyclic dependency graph.
+	// Note that "io" is assigned as effective child of "main", since this is a
+	// shorter path to the tree root.
+	want := "" +
+		"  main — 1.0 MiB own size, 1.1 MiB with children\n" +
+		"  * fmt — 50 KiB own size, 51 KiB with children\n" +
+		"  * * strconv — 1.0 KiB own size, 1.0 KiB with children\n" +
+		"  * io — 10 KiB own size, 10 KiB with children\n"
+	got := main.String()
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("main.organizeTree() produced unexpected structure (-want,+got):\n%s", diff)
+	}
+}
+
+func TestTreeNodeToSVG(t *testing.T) {
+	// Build a dependency graph for a very simple project.
+	cpu := &treeMapNode{Label: "internal/cpu", Size: 342}
+	bytealg := &treeMapNode{Label: "internal/bytealg", Size: 468, Children: nodeGroup{cpu}}
+	sys := &treeMapNode{Label: "runtime/internal/sys", Size: 350}
+	js := &treeMapNode{Label: "gopherjs/js", Size: 5.2 * 1024}
+	runtime := &treeMapNode{Label: "runtime", Size: 3.8 * 1024, Children: nodeGroup{js, bytealg, sys}}
+	prelude := &treeMapNode{Label: "$prelude", Size: 32 * 1024}
+	main := &treeMapNode{Label: "main", Size: 434}
+	artifact := &treeMapNode{Label: "$artifact", Size: 0, Children: nodeGroup{prelude, runtime, main}}
+
+	artifact.organizeTree()
+	b := &bytes.Buffer{}
+	if err := artifact.toSVG(b, newRect(1000, 1000)); err != nil {
+		t.Fatalf("artifact.toSVG() returned error: %s", err)
+	}
+
+	want := `<g><rect x="0" y="0" width="1000" height="1000" fill="#fd7bff" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>$artifact — 0 B own size, 43 KiB with children</title></rect></g>
+<g></g>
+<g><rect x="10" y="10" width="736.9" height="980" fill="#a898ff" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>$prelude — 32 KiB own size, 32 KiB with children</title></rect></g>
+<g><text x="378.45" y="500" font-size="20" transform="rotate(270 378.45 500.00)" text-anchor="middle" dominant-baseline="middle">$prelude — 32 KiB</text></g>
+<g><rect x="746.9" y="10" width="233.34" height="980" fill="#e886ff" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>runtime — 3.8 KiB own size, 10 KiB with children</title></rect></g>
+<g><text x="794.3" y="500" font-size="20" transform="rotate(270 794.30 500.00)" text-anchor="middle" dominant-baseline="middle">runtime — 3.8 KiB</text></g>
+<g><rect x="835.87" y="15.83" width="138.54" height="795.12" fill="#0cf3b7" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>gopherjs/js — 5.2 KiB own size, 5.2 KiB with children</title></rect></g>
+<g><text x="905.14" y="413.39" font-size="20" transform="rotate(270 905.14 413.39)" text-anchor="middle" dominant-baseline="middle">gopherjs/js — 5.2 KiB</text></g>
+<g><rect x="835.87" y="810.95" width="138.54" height="120.95" fill="#53c7e0" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>internal/bytealg — 468 B own size, 810 B with children</title></rect></g>
+<g></g>
+<g><rect x="838.89" y="880.36" width="132.49" height="48.52" fill="#fb7d4c" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>internal/cpu — 342 B own size, 342 B with children</title></rect></g>
+<g><text x="905.14" y="904.62" font-size="8.87" text-anchor="middle" dominant-baseline="middle">internal/cpu — 342 B</text></g>
+<g><rect x="835.87" y="931.9" width="138.54" height="52.26" fill="#45ff00" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>runtime/internal/sys — 350 B own size, 350 B with children</title></rect></g>
+<g></g>
+<g><rect x="980.24" y="10" width="9.76" height="980" fill="#ff4dff" fill-opacity="0.1" stroke="black" stroke-width="0.5"><title>main — 434 B own size, 434 B with children</title></rect></g>
+<g></g>
+`
+	got := b.String()
+	fmt.Println(got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("artifact.toSVG() returned diff (-want,+got):\n%s", diff)
+	}
+}

--- a/build/analysis/visualize.go
+++ b/build/analysis/visualize.go
@@ -1,0 +1,75 @@
+package analysis
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gopherjs/gopherjs/compiler"
+)
+
+// Visualizer renders a TreeMap diagram representing the generated JS file and
+// how different packages contributed it its size.
+type Visualizer struct {
+	File *os.File
+	Main *compiler.Archive
+	Deps []*compiler.Archive
+}
+
+// Render a Tree Map diagram for the given package sizes.
+//
+// Stats contains amount of bytes written that correspond to a given package.
+func (v *Visualizer) Render(stats map[string]int) error {
+	tree := v.buildTree(stats)
+	// This roughly corresponds to browser viewport dimensions on a 1080p screen.
+	const w = 1500
+	const h = 700
+	fmt.Fprintf(v.File, `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width='%d' height='%d' viewBox="0 0 %d %d" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<style> text { font-family: "Lucida Console", Monaco, monospace; text-rendering: optimizeLegibility; } </style>
+`, w, h, w, h)
+	if err := tree.toSVG(v.File, newRect(w, h)); err != nil {
+		return err
+	}
+	fmt.Fprintf(v.File, "</svg>\n")
+	return nil
+}
+
+func (v *Visualizer) buildTree(stats map[string]int) *treeMapNode {
+	deps := map[string]*compiler.Archive{}
+
+	for _, dep := range v.Deps {
+		deps[dep.ImportPath] = dep
+	}
+
+	nodes := map[string]*treeMapNode{} // List of all nodes in the tree.
+	roots := map[string]*treeMapNode{} // Nodes that are not someone's dependency.
+	for name, size := range stats {
+		nodes[name] = &treeMapNode{
+			Label: name,
+			Size:  float64(size),
+		}
+		roots[name] = nodes[name]
+	}
+
+	for name, node := range nodes {
+		if dep, ok := deps[name]; ok {
+			for _, depName := range dep.Imports {
+				node.Children = append(node.Children, nodes[depName])
+				delete(roots, depName)
+			}
+		}
+	}
+
+	topLevel := []*treeMapNode{}
+	for _, node := range roots {
+		topLevel = append(topLevel, node)
+	}
+
+	return (&treeMapNode{
+		Label:    "$artifact",
+		Size:     0, // No own size, just children.
+		Children: topLevel,
+		depth:    0,
+	}).organizeTree()
+}

--- a/tool.go
+++ b/tool.go
@@ -78,6 +78,7 @@ func main() {
 	compilerFlags.BoolVar(&options.Color, "color", terminal.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb", "colored output")
 	compilerFlags.StringVar(&tags, "tags", "", "a list of build tags to consider satisfied during the build")
 	compilerFlags.BoolVar(&options.MapToLocalDisk, "localmap", false, "use local paths for sourcemap")
+	compilerFlags.BoolVar(&options.AnalyzeSize, "analyze_size", false, "produce an Tree Map diagram visualizing each package's contribution to the output artifact size")
 
 	flagWatch := pflag.NewFlagSet("", 0)
 	flagWatch.BoolVarP(&options.Watch, "watch", "w", false, "watch for changes to the source files")


### PR DESCRIPTION
When --analyze_size flag is passed to GopherJS, an additional
${packagename}.js.svg file is creates with a TreeMap diagram that
visualizes which packages contributed to the artifact size and how much.

The data is obtained by counting bytes written for each section of the
file including GopherJS's own prelude and works accurately both in
minified and default modes.

Most of diagram-related logic is isolated to the build/analysis package
with minimal changes to the rest of the code base.

Fixes #982. 