### PR TITLE
Go1.16 support for several more stdlib packages

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -183,6 +183,10 @@ func importWithSrcDir(bctx build.Context, path string, srcDir string, mode build
 		pkg.GoFiles = nil
 	case "internal/poll":
 		pkg.GoFiles = exclude(pkg.GoFiles, "fd_poll_runtime.go")
+	case "sync":
+		// GopherJS completely replaces sync.Pool implementation with a simpler one,
+		// since it always executes in a single-threaded environment.
+		pkg.GoFiles = exclude(pkg.GoFiles, "pool.go")
 	case "crypto/rand":
 		pkg.GoFiles = []string{"rand.go", "util.go"}
 		pkg.TestGoFiles = exclude(pkg.TestGoFiles, "rand_linux_test.go") // Don't want linux-specific tests (since linux-specific package files are excluded too).

--- a/build/build.go
+++ b/build/build.go
@@ -177,7 +177,7 @@ func importWithSrcDir(bctx build.Context, path string, srcDir string, mode build
 		pkg.GoFiles = excludeExecutable(pkg.GoFiles) // Need to exclude executable implementation files, because some of them contain package scope variables that perform (indirectly) syscalls on init.
 		// Prefer dirent_js.go version, since it targets a similar environment to
 		// ours. Arguably this file should be excluded by the build tags (see
-		// https://github.com/gopherjs/gopherjs/issues/991).
+		// https://github.com/gopherjs/gopherjs/issues/693).
 		pkg.GoFiles = exclude(pkg.GoFiles, "dirent_linux.go")
 	case "runtime":
 		pkg.GoFiles = []string{} // Package sources are completely replaced in natives.

--- a/build/build.go
+++ b/build/build.go
@@ -175,6 +175,10 @@ func importWithSrcDir(bctx build.Context, path string, srcDir string, mode build
 	switch path {
 	case "os":
 		pkg.GoFiles = excludeExecutable(pkg.GoFiles) // Need to exclude executable implementation files, because some of them contain package scope variables that perform (indirectly) syscalls on init.
+		// Prefer dirent_js.go version, since it targets a similar environment to
+		// ours. Arguably this file should be excluded by the build tags (see
+		// https://github.com/gopherjs/gopherjs/issues/991).
+		pkg.GoFiles = exclude(pkg.GoFiles, "dirent_linux.go")
 	case "runtime":
 		pkg.GoFiles = []string{} // Package sources are completely replaced in natives.
 	case "runtime/internal/sys":

--- a/compiler/natives/src/internal/poll/fd_poll.go
+++ b/compiler/natives/src/internal/poll/fd_poll.go
@@ -33,7 +33,7 @@ func (pd *pollDesc) wait(mode int, isFile bool) error {
 	if pd.closing {
 		return errClosing(isFile)
 	}
-	return ErrTimeout
+	return ErrDeadlineExceeded
 }
 
 func (pd *pollDesc) waitRead(isFile bool) error { return pd.wait('r', isFile) }

--- a/compiler/natives/src/internal/syscall/unix/unix.go
+++ b/compiler/natives/src/internal/syscall/unix/unix.go
@@ -4,8 +4,12 @@ package unix
 
 import "syscall"
 
-const randomTrap = 0
-const fstatatTrap = 0
+const (
+	randomTrap        uintptr = 0
+	fstatatTrap       uintptr = 0
+	getrandomTrap     uintptr = 0
+	copyFileRangeTrap uintptr = 0
+)
 
 func IsNonblock(fd int) (nonblocking bool, err error) {
 	return false, nil

--- a/compiler/natives/src/math/math.go
+++ b/compiler/natives/src/math/math.go
@@ -7,10 +7,10 @@ import (
 )
 
 var math = js.Global.Get("Math")
-var zero float64 = 0
-var posInf = 1 / zero
-var negInf = -1 / zero
-var nan = 0 / zero
+var _zero float64 = 0
+var posInf = 1 / _zero
+var negInf = -1 / _zero
+var nan = 0 / _zero
 
 func Acos(x float64) float64 {
 	return math.Call("acos", x).Float()

--- a/compiler/natives/src/os/os.go
+++ b/compiler/natives/src/os/os.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
+const isBigEndian = false
+
 func runtime_args() []string { // not called on Windows
 	return Args
 }

--- a/compiler/natives/src/sync/pool.go
+++ b/compiler/natives/src/sync/pool.go
@@ -2,12 +2,25 @@
 
 package sync
 
-import "unsafe"
-
+// A Pool is a set of temporary objects that may be individually saved and
+// retrieved.
+//
+// GopherJS provides a simpler, naive implementation with no synchronization at
+// all. This is still correct for the GopherJS runtime because:
+//
+//  1. JavaScript is single-threaded, so it is impossible for two threads to be
+//     accessing the pool at the same moment in time.
+//  2. GopherJS goroutine implementation uses cooperative multi-tasking model,
+//     which only allows passing control to other goroutines when the function
+//     might block.
+//
+// TODO(nevkontakte): Consider adding a mutex just to be safe if it doesn't
+// create a large performance hit.
+//
+// Note: there is a special handling in the gopherjs/build package that filters
+// out all original Pool implementation in order to avoid awkward unused fields
+// referenced by dead code.
 type Pool struct {
-	local     unsafe.Pointer
-	localSize uintptr
-
 	store []interface{}
 	New   func() interface{}
 }
@@ -29,7 +42,4 @@ func (p *Pool) Put(x interface{}) {
 		return
 	}
 	p.store = append(p.store, x)
-}
-
-func runtime_registerPoolCleanup(cleanup func()) {
 }

--- a/compiler/natives/src/sync/sync.go
+++ b/compiler/natives/src/sync/sync.go
@@ -18,13 +18,13 @@ var semWaiters = make(map[*uint32][]chan bool)
 var semAwoken = make(map[*uint32]uint32)
 
 func runtime_Semacquire(s *uint32) {
-	runtime_SemacquireMutex(s, false)
+	runtime_SemacquireMutex(s, false, 1)
 }
 
 // SemacquireMutex is like Semacquire, but for profiling contended Mutexes.
 // Mutex profiling is not supported, so just use the same implementation as runtime_Semacquire.
 // TODO: Investigate this. If it's possible to implement, consider doing so, otherwise remove this comment.
-func runtime_SemacquireMutex(s *uint32, lifo bool) {
+func runtime_SemacquireMutex(s *uint32, lifo bool, skipframes int) {
 	if (*s - semAwoken[s]) == 0 {
 		ch := make(chan bool)
 		if lifo {
@@ -41,7 +41,7 @@ func runtime_SemacquireMutex(s *uint32, lifo bool) {
 	*s--
 }
 
-func runtime_Semrelease(s *uint32, handoff bool) {
+func runtime_Semrelease(s *uint32, handoff bool, skipframes int) {
 	// TODO: Use handoff if needed/possible.
 	*s++
 

--- a/compiler/natives/src/time/time.go
+++ b/compiler/natives/src/time/time.go
@@ -21,6 +21,7 @@ type runtimeTimer struct {
 	period  int64
 	f       func(interface{}, uintptr)
 	arg     interface{}
+	seq     uintptr
 	timeout *js.Object
 	active  bool
 }
@@ -76,6 +77,22 @@ func stopTimer(t *runtimeTimer) bool {
 	js.Global.Call("clearTimeout", t.timeout)
 	wasActive := t.active
 	t.active = false
+	return wasActive
+}
+
+func modTimer(t *runtimeTimer, when, period int64, f func(interface{}, uintptr), arg interface{}, seq uintptr) {
+	stopTimer(t)
+	t.when = when
+	t.period = period
+	t.f = f
+	t.arg = arg
+	t.seq = seq
+	startTimer(t)
+}
+
+func resetTimer(t *runtimeTimer, when int64) bool {
+	wasActive := t.active
+	modTimer(t, when, t.period, t.f, t.arg, t.seq)
 	return wasActive
 }
 


### PR DESCRIPTION
I'm slowly working towards making `gopherjs test` run. With this PR it is able to compile tests, but it fails at runtime because I haven't updated support reflectlite yet.

Packages covered in this PR:

 - math
 - sync
 - time
 - os
 - internal/syscall/unix

Issue #989.