### PR TITLE
compiler/natives/src/syscall: support copy bytes to/from js

### DIFF
--- a/compiler/natives/src/syscall/js/js.go
+++ b/compiler/natives/src/syscall/js/js.go
@@ -281,3 +281,27 @@ func (e *ValueError) Error() string {
 type Wrapper interface {
 	JSValue() Value
 }
+
+// CopyBytesToGo copies bytes from the Uint8Array src to dst.
+// It returns the number of bytes copied, which will be the minimum of the lengths of src and dst.
+// CopyBytesToGo panics if src is not an Uint8Array.
+func CopyBytesToGo(dst []byte, src Value) int {
+	vlen := src.v.Length()
+	if dlen := len(dst); dlen < vlen {
+		vlen = dlen
+	}
+	copy(dst, src.v.Interface().([]byte))
+	return vlen
+}
+
+// CopyBytesToJS copies bytes from src to the Uint8Array dst.
+// It returns the number of bytes copied, which will be the minimum of the lengths of src and dst.
+// CopyBytesToJS panics if dst is not an Uint8Array.
+func CopyBytesToJS(dst Value, src []byte) int {
+	dt, ok := dst.([]byte)
+	if !ok {
+		panic("syscall/js: CopyBytesToJS: expected dst to be an Uint8Array")
+	}
+	copy(dt, src)
+	return n
+}


### PR DESCRIPTION
This is an old addition that I've been using for a long time, maybe suitable to include in syscall