### PR TITLE
Future-proof untyped nil handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ If you include an argument, it will be the root from which everything is served.
 
 There is one GopherJS-specific environment variable:
 
-```
-GOPHERJS_GOROOT - if set, GopherJS uses this value as the default GOROOT value,
-                  instead of using the system GOROOT as the default GOROOT value
-```
+ - `GOPHERJS_GOROOT` - if set, GopherJS uses this value as the default GOROOT
+   value, instead of using the system GOROOT as the default GOROOT value
+ - `GOPHERJS_SKIP_VERSION_CHECK` - if set to true, GopherJS will not check 
+   Go version in the GOROOT for compatibility with the GopherJS release. This
+	 is primarily useful for testing GopherJS against unreleased versions of Go.
 
 ### Performance Tips
 

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -386,7 +386,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		case len(s.Lhs) == 1 && len(s.Rhs) == 1:
 			lhs := astutil.RemoveParens(s.Lhs[0])
 			if isBlank(lhs) {
-				fc.Printf("$unused(%s);", fc.translateExpr(s.Rhs[0]))
+				fc.Printf("$unused(%s);", fc.translateImplicitConversion(s.Rhs[0], fc.pkgCtx.TypeOf(s.Lhs[0])))
 				return
 			}
 			fc.Printf("%s", fc.translateAssign(lhs, s.Rhs[0], s.Tok == token.DEFINE))

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strconv"
 )
 
 // Version is the GopherJS compiler version string.
@@ -19,6 +21,9 @@ const GoVersion = 16
 // at goroot, and reports an error if it's not compatible
 // with this version of the GopherJS compiler.
 func CheckGoVersion(goroot string) error {
+	if nvc, err := strconv.ParseBool(os.Getenv("GOPHERJS_SKIP_VERSION_CHECK")); err == nil && nvc {
+		return nil
+	}
 	v, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION"))
 	if err != nil {
 		return fmt.Errorf("GopherJS %s requires a Go 1.16.x distribution, but failed to read its VERSION file: %v", Version, err)

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -712,7 +712,8 @@ func TestReflectMapIterationAndDelete(t *testing.T) {
 }
 
 func TestUntypedNil(t *testing.T) {
-	// This test makes sure GopherJS compiler correctly handles untyped nil.
+	// This test makes sure GopherJS compiler is able to correctly infer the
+	// desired type of an untyped nil ident.
 	// See https://github.com/gopherjs/gopherjs/issues/1011 for details.
 
 	// Code below is based on test cases from https://golang.org/cl/284052.

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -710,3 +710,136 @@ func TestReflectMapIterationAndDelete(t *testing.T) {
 		t.Fatalf("got %d, want %d", got, want)
 	}
 }
+
+func TestUntypedNil(t *testing.T) {
+	// This test makes sure GopherJS compiler correctly handles untyped nil.
+	// See https://github.com/gopherjs/gopherjs/issues/1011 for details.
+
+	// Code below is based on test cases from https://golang.org/cl/284052.
+	var _ *int = nil
+	var _ func() = nil
+	var _ []byte = nil
+	var _ map[int]int = nil
+	var _ chan int = nil
+	var _ interface{} = nil
+
+	{
+		var (
+			x *int = nil
+			_      = x
+		)
+	}
+	{
+		var (
+			x func() = nil
+			_        = x
+		)
+	}
+	{
+		var (
+			x []byte = nil
+			_        = x
+		)
+	}
+	{
+		var (
+			x map[int]int = nil
+			_             = x
+		)
+	}
+	{
+		var (
+			x chan int = nil
+			_          = x
+		)
+	}
+	{
+		var (
+			x interface{} = nil
+			_             = x
+		)
+	}
+
+	{
+		var (
+			x *int
+			_ = x == nil
+		)
+	}
+	{
+		var (
+			x func()
+			_ = x == nil
+		)
+	}
+	{
+		var (
+			x []byte
+			_ = x == nil
+		)
+	}
+	{
+		var (
+			x map[int]int
+			_ = x == nil
+		)
+	}
+	{
+		var (
+			x chan int
+			_ = x == nil
+		)
+	}
+	{
+		var (
+			x interface{}
+			_ = x == nil
+		)
+	}
+	var _ = (*int)(nil)
+	var _ = (func())(nil)
+	var _ = ([]byte)(nil)
+	var _ = (map[int]int)(nil)
+	var _ = (chan int)(nil)
+	var _ = (interface{})(nil)
+	{
+		f := func(*int) {}
+		f(nil)
+	}
+	{
+		f := func(func()) {}
+		f(nil)
+	}
+	{
+		f := func([]byte) {}
+		f(nil)
+	}
+	{
+		f := func(map[int]int) {}
+		f(nil)
+	}
+	{
+		f := func(chan int) {}
+		f(nil)
+	}
+	{
+		f := func(interface{}) {}
+		f(nil)
+	}
+	{
+		f := func(*int) {}
+		f(nil)
+	}
+	{
+		f := func(*int) {}
+		f(nil)
+	}
+	{
+		f := func(*int) {}
+		f(nil)
+	}
+	{
+		f := func(*int) {}
+		f(nil)
+	}
+}


### PR DESCRIPTION
Upstream changes introduced in https://golang.org/cl/284052 introduced several new cases where `nil` identifier would be treated as untyped by `go/types` and an implicit type conversion would be expected. These changes future-proof GopherJS against this particular change.

I've also discovered an additional case, where untyped nil was causing a panic even with Go 1.16: `var _ *int = nil`, I fixed that as well.

I've manually tested these changes against Go `tip`: `go-tip install . && GOPHERJS_NO_VERSION_CHECK=true GOROOT="$(go-tip env GOROOT)" gopherjs test ./tests`.

This PR also includes a couple of changes that make debugging compiler panics and testing with unreleased versions a bit easier.

Fixes #1011.