### PR TITLE
Improve Mac OS (darwin) support.

### DIFF
--- a/compiler/linkname.go
+++ b/compiler/linkname.go
@@ -101,6 +101,15 @@ func parseGoLinknames(fset *token.FileSet, pkgPath string, file *ast.File) ([]Go
 
 		obj := file.Scope.Lookup(localName)
 		if obj == nil {
+			if pkgPath == "syscall" {
+				// Syscall uses go:cgo_import_dynamic pragma to import symbols from
+				// dynamic libraries when build with GOOS=darwin, which GopherJS doesn't
+				// support. Silently ignore such directives.
+				//
+				// In the long term https://github.com/gopherjs/gopherjs/issues/693 is a
+				// preferred solution.
+				return nil
+			}
 			return fmt.Errorf("//go:linkname local symbol %q is not found in the current source file", localName)
 		}
 

--- a/compiler/natives/src/syscall/syscall_darwin.go
+++ b/compiler/natives/src/syscall/syscall_darwin.go
@@ -20,10 +20,6 @@ func funcPC(f func()) uintptr {
 		return SYS_CHDIR
 	case js.InternalObject(libc_rmdir_trampoline):
 		return SYS_RMDIR
-	case js.InternalObject(libc___getdirentries64_trampoline):
-		return SYS_GETDIRENTRIES64
-	case js.InternalObject(libc_getattrlist_trampoline):
-		return SYS_GETATTRLIST
 	case js.InternalObject(libc_symlink_trampoline):
 		return SYS_SYMLINK
 	case js.InternalObject(libc_readlink_trampoline):


### PR DESCRIPTION
Changes in this commit ensure that we can at least build supported
standard library packages with GOOS=darwin. In theory, GOOS shouldn't
even matter, since we always target the same platform (nodejs or
browser), but for historical reasons, it does matter and we need to take
extra steps to make it work.

See https://github.com/gopherjs/gopherjs/issues/693 for more details.

Changes tested with `GOOS=darwin gopherjs build --minify -v $(go list std | grep -v -x -f .std_test_pkg_exclusions | grep -v -E "(vendor|internal)" | sort)`. Unfortunately, I don't have access to an Mac OS machine to run actual test… Ideally we should set up CI to do that.

Fixes #1023.