### PR TITLE
Bump Go version to 1.16.5 and GopherJS version to 1.16.3+go1.16.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ jobs:
     - run: nvm install 10.0.0 && nvm alias default 10.0.0
     - run: echo export "NODE_PATH='$(npm root --global)'" >> $BASH_ENV # Make nodejs able to require globally installed modules from any working path.
     - run: env
-    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.16.4.linux-amd64.tar.gz | sudo tar -xz
+    - run: cd /usr/local && sudo rm -rf go && curl https://storage.googleapis.com/golang/go1.16.5.linux-amd64.tar.gz | sudo tar -xz
     - run: echo 'export PATH="$PATH:/usr/local/go/bin:$HOME/go/bin"' >> $BASH_ENV
     - run: go get -t -d -v ./...
     - run: go install -v

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is the GopherJS compiler version string.
-const Version = "1.16.2+go1.16.4"
+const Version = "1.16.3+go1.16.5"
 
 // GoVersion is the current Go 1.x version that GopherJS is compatible with.
 const GoVersion = 16


### PR DESCRIPTION
This change is in preparation for a new release.