### PR TITLE
Preserve position information for top-level variable declarations.

### DIFF
--- a/compiler/package.go
+++ b/compiler/package.go
@@ -360,6 +360,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 		lhs := make([]ast.Expr, len(init.Lhs))
 		for i, o := range init.Lhs {
 			ident := ast.NewIdent(o.Name())
+			ident.NamePos = o.Pos()
 			funcCtx.pkgCtx.Defs[ident] = o
 			lhs[i] = funcCtx.setType(ident, o.Type())
 			varsWithInit[o] = true


### PR DESCRIPTION
This allows sourcemap to be generated for top-level variable
declarations with initializer, for example:

```go
var x = initX() // Might panic.
```

This is particularly helpful when debugging panics in such initializers.