### PR TITLE
Add GitHub action workflows to track GopherJS output size changes.

### DIFF
--- a/.github/workflows/measure-size.yml
+++ b/.github/workflows/measure-size.yml
@@ -1,0 +1,28 @@
+name: Measure canonical app size
+
+on: ['pull_request']
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.2'
+      - uses: gopherjs/output-size-action/measure@main
+        with:
+          name: jQuery TodoMVC
+          repo: https://github.com/gopherjs/todomvc
+          go-package: github.com/gopherjs/todomvc
+          report_json: /tmp/report.json
+          report_md: /tmp/report.md
+      - uses: actions/upload-artifact@v2
+        with:
+          name: size_report
+          path: |
+            /tmp/report.json
+            /tmp/report.md
+

--- a/.github/workflows/publish-size.yml
+++ b/.github/workflows/publish-size.yml
@@ -1,0 +1,14 @@
+name: Publish canonical app size
+
+on:
+  workflow_run:
+    workflows: ["Measure canonical app size"]
+    types: ["completed"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gopherjs/output-size-action/publish@main
+        with:
+          report_artifact: size_report


### PR DESCRIPTION
I had some interest in fiddling with GitHub actions, and made these two workflows that should help us keep track of the GopherJS-generated code size changes. Although I'm not yet ready to delve into #136, this will at least help us notice any accidental degradations. https://github.com/nevkontakte/gopherjs/pull/2 is an example of what the output of these actions looks like.

`measure-size` is triggered by a pull request or an update to a pull request. It compiles a reference app using GopherJS from a pull request and from the target branch, and generates a report with output size changes, if any.

`publish-size` is run upon completion of `measure-size` and posts the generated comment as a comment in the pull requests. If there are previous reports in the thread already, it will hide them to reduce confusion.

The two steps are implemented as separate workflows to ensure that untrusted code from a PR doesn't get executed in a workflow with a write access to the repository. See [this article](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for details.

Workflows use custom actions from https://github.com/gopherjs/output-size-action. Most of the logic related to report generation is written in Go and compiled by GopherJS (yay dogfooding!). I'm going to write up a better readme in that repository in the coming days.