### PR TITLE
Update README.md wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you include an argument, it will be the root from which everything is served.
 
 #### Environment Variables
 
-There is one GopherJS-specific environment variable:
+There are some GopherJS-specific environment variables:
 
  - `GOPHERJS_GOROOT` - if set, GopherJS uses this value as the default GOROOT
    value, instead of using the system GOROOT as the default GOROOT value


### PR DESCRIPTION
Since there are now multiple environment variables, this changes `is` → `are`.