### PR TITLE
Disable test output buffering when testing only one package.

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -343,6 +343,10 @@ func main() {
 			}
 
 			parallelSlots := make(chan (bool), *parallelTests) // Semaphore for parallel test executions.
+			if len(matches) == 1 {
+				// Disable output buffering if testing only one package.
+				parallelSlots = make(chan (bool), 1)
+			}
 			executions := errgroup.Group{}
 
 			pkgs := make([]*gbuild.PackageData, len(matches))


### PR DESCRIPTION
Buffering is already disabled when -p=1, which allows to see test output
in real time. With this change it will be done automatically if only one
package matched.