### PR TITLE
Correctly handle built-ins and `js.Object` methods with go keyword.

### DIFF
--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/constant"
+	"go/printer"
 	"go/token"
 	"go/types"
 	"strings"
@@ -39,6 +40,8 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			pos = fc.pos
 		}
 		fmt.Fprintf(bail, "Occurred while compiling statement at %s:\n", fc.pkgCtx.fileSet.Position(pos))
+		(&printer.Config{Tabwidth: 2, Indent: 1, Mode: printer.UseSpaces}).Fprint(bail, fc.pkgCtx.fileSet, stmt)
+		fmt.Fprintf(bail, "\n\nDetailed AST:\n")
 		ast.Fprint(bail, fc.pkgCtx.fileSet, stmt, ast.NotNilFilter)
 		panic(bail) // Initiate orderly bailout.
 	}()

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -10,6 +10,7 @@ import (
 	"go/token"
 	"go/types"
 	"net/url"
+	"regexp"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -791,12 +792,14 @@ func (b *FatalError) Write(p []byte) (n int, err error) { return b.clues.Write(p
 
 func (b FatalError) Error() string {
 	buf := &strings.Builder{}
-	fmt.Fprintln(buf, "[compiler panic] ", b.Unwrap())
+	fmt.Fprintln(buf, "[compiler panic] ", strings.TrimSpace(b.Unwrap().Error()))
 	if b.clues.Len() > 0 {
-		fmt.Fprintln(buf, "\n", b.clues.String())
+		fmt.Fprintln(buf, "\n"+b.clues.String())
 	}
 	if len(b.stack) > 0 {
-		fmt.Fprintln(buf, "\n", string(b.stack))
+		// Shift stack track by 2 spaces for better readability.
+		stack := regexp.MustCompile("(?m)^").ReplaceAll(b.stack, []byte("  "))
+		fmt.Fprintln(buf, "\nOriginal stack trace:\n", string(stack))
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Built-ins and `js.Object` methods are represented by JS expressions that may not be straightforward function calls, or reference functions defined in the prelude. In such cases, the callable expression must be wrapped in a lambda.

#998 has fixed a similar issue for the `defer` keyword, and this change generalizes the same fix for the `go` keyword.

This change also contains a small improvement to the compiler panic message, which makes it easier to read at-a-glance.

Fixes #547.
