### PR TITLE
compiler: fix variadic args not being nil when zero length.

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -116,7 +116,7 @@ func (fc *funcContext) translateArgs(sig *types.Signature, argExprs []ast.Expr, 
 	sigTypes := signatureTypes{Sig: sig}
 
 	if sig.Variadic() && len(argExprs) == 0 {
-		return []string{fmt.Sprintf("%s.nil", c.typeName(varargType))}
+		return []string{fmt.Sprintf("%s.nil", fc.typeName(sigTypes.VariadicType()))}
 	}
 
 	preserveOrder := false

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -115,6 +115,10 @@ func (fc *funcContext) translateArgs(sig *types.Signature, argExprs []ast.Expr, 
 
 	sigTypes := signatureTypes{Sig: sig}
 
+	if sig.Variadic() && len(argExprs) == 0 {
+		return []string{fmt.Sprintf("%s.nil", c.typeName(varargType))}
+	}
+
 	preserveOrder := false
 	for i := 1; i < len(argExprs); i++ {
 		preserveOrder = preserveOrder || fc.Blocking[argExprs[i]]

--- a/tests/compiler_test.go
+++ b/tests/compiler_test.go
@@ -10,6 +10,6 @@ func TestVariadicNil(t *testing.T) {
 	}
 
 	if got := printVari(); got != nil {
-		t.Errorf("expected printVari() to be %v; got: %v", nil, got)
+		t.Errorf("printVari(): got: %#v; want %#v.", got, nil)
 	}
 }

--- a/tests/compiler_test.go
+++ b/tests/compiler_test.go
@@ -12,4 +12,18 @@ func TestVariadicNil(t *testing.T) {
 	if got := printVari(); got != nil {
 		t.Errorf("printVari(): got: %#v; want %#v.", got, nil)
 	}
+
+	{
+		var want []string
+		if got := printVari(want...); got != nil {
+			t.Errorf("printVari(want...): got: %#v; want %#v.", got, nil)
+		}
+	}
+
+	{
+		want := []string{}
+		if got := printVari(want...); got == nil || len(got) != len(want) {
+			t.Errorf("printVari(want...): got: %#v; want %#v.", got, want)
+		}
+	}
 }

--- a/tests/compiler_test.go
+++ b/tests/compiler_test.go
@@ -1,0 +1,17 @@
+// +build js
+
+package tests
+
+import (
+	"testing"
+)
+
+func TestVariadicNil(t *testing.T) {
+	printVari := func(strs ...string) []string {
+		return strs
+	}
+
+	if v := printVari(); v != nil {
+		t.Errorf("expected printVari() to be %v; got: %v", nil, v)
+	}
+}

--- a/tests/compiler_test.go
+++ b/tests/compiler_test.go
@@ -1,5 +1,3 @@
-// +build js
-
 package tests
 
 import (
@@ -11,7 +9,7 @@ func TestVariadicNil(t *testing.T) {
 		return strs
 	}
 
-	if v := printVari(); v != nil {
-		t.Errorf("expected printVari() to be %v; got: %v", nil, v)
+	if got := printVari(); got != nil {
+		t.Errorf("expected printVari() to be %v; got: %v", nil, got)
 	}
 }


### PR DESCRIPTION
This PR is simply a rebase of #807 plus a small patch to work with a modern version of GopherJS.

Fixes #806 