### PR TITLE
Build package cleanups and minor improvements

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -564,23 +564,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 		}
 
 		for _, importedPkgPath := range pkg.Imports {
-			// Ignore all imports that aren't mentioned in import specs of pkg.
-			// For example, this ignores imports such as runtime/internal/sys and runtime/internal/atomic.
-			ignored := true
-			for _, pos := range pkg.ImportPos[importedPkgPath] {
-				importFile := filepath.Base(pos.Filename)
-				for _, file := range pkg.GoFiles {
-					if importFile == file {
-						ignored = false
-						break
-					}
-				}
-				if !ignored {
-					break
-				}
-			}
-
-			if importedPkgPath == "unsafe" || ignored {
+			if importedPkgPath == "unsafe" {
 				continue
 			}
 			importedPkg, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)

--- a/build/build.go
+++ b/build/build.go
@@ -37,7 +37,7 @@ import (
 // DefaultGOROOT is the default GOROOT value for builds.
 //
 // It uses the GOPHERJS_GOROOT environment variable if it is set,
-// or else the default GOROOT value of the system Go distrubtion.
+// or else the default GOROOT value of the system Go distribution.
 var DefaultGOROOT = func() string {
 	if goroot, ok := os.LookupEnv("GOPHERJS_GOROOT"); ok {
 		// GopherJS-specific GOROOT value takes precedence.
@@ -47,6 +47,8 @@ var DefaultGOROOT = func() string {
 	return build.Default.GOROOT
 }()
 
+// ImportCError is returned when GopherJS attempts to build a package that uses
+// CGo.
 type ImportCError struct {
 	pkgPath string
 }
@@ -378,6 +380,7 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 	return files, nil
 }
 
+// Options controls build process behavior.
 type Options struct {
 	GOROOT         string
 	GOPATH         string
@@ -391,6 +394,7 @@ type Options struct {
 	BuildTags      []string
 }
 
+// PrintError message to the terminal.
 func (o *Options) PrintError(format string, a ...interface{}) {
 	if o.Color {
 		format = "\x1B[31m" + format + "\x1B[39m"
@@ -398,6 +402,7 @@ func (o *Options) PrintError(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, a...)
 }
 
+// PrintSuccess message to the terminal.
 func (o *Options) PrintSuccess(format string, a ...interface{}) {
 	if o.Color {
 		format = "\x1B[32m" + format + "\x1B[39m"
@@ -455,6 +460,10 @@ func (p *PackageData) XTestPackage() *PackageData {
 	}
 }
 
+// Session manages internal state GopherJS requires to perform a build.
+//
+// This is the main interface to GopherJS build system. Session lifetime is
+// roughly equivalent to a single GopherJS tool invocation.
 type Session struct {
 	options  *Options
 	xctx     XContext
@@ -463,6 +472,7 @@ type Session struct {
 	Watcher  *fsnotify.Watcher
 }
 
+// NewSession creates a new GopherJS build session.
 func NewSession(options *Options) (*Session, error) {
 	if options.GOROOT == "" {
 		options.GOROOT = DefaultGOROOT
@@ -499,9 +509,10 @@ func NewSession(options *Options) (*Session, error) {
 	return s, nil
 }
 
-// BuildContext returns the session's build context.
+// XContext returns the session's build context.
 func (s *Session) XContext() XContext { return s.xctx }
 
+// InstallSuffix returns the suffix added to the generated output file.
 func (s *Session) InstallSuffix() string {
 	if s.options.Minify {
 		return "min"
@@ -514,30 +525,10 @@ func (s *Session) GoRelease() string {
 	return compiler.GoRelease(s.options.GOROOT)
 }
 
-func (s *Session) BuildDir(packagePath string, importPath string, pkgObj string) error {
-	if s.Watcher != nil {
-		s.Watcher.Add(packagePath)
-	}
-	pkg, err := s.xctx.Import(".", packagePath, 0)
-	if err != nil {
-		return err
-	}
-
-	archive, err := s.BuildPackage(pkg)
-	if err != nil {
-		return err
-	}
-	if pkgObj == "" {
-		pkgObj = filepath.Base(packagePath) + ".js"
-	}
-	if pkg.IsCommand() && !pkg.UpToDate {
-		if err := s.WriteCommandPackage(archive, pkgObj); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
+// BuildFiles passed to the GopherJS tool as if they were a package.
+//
+// A ephemeral package will be created with only the provided files. This
+// function is intended for use with, for example, `gopherjs run main.go`.
 func (s *Session) BuildFiles(filenames []string, pkgObj string, packagePath string) error {
 	pkg := &PackageData{
 		Package: &build.Package{
@@ -566,11 +557,18 @@ func (s *Session) BuildFiles(filenames []string, pkgObj string, packagePath stri
 	return s.WriteCommandPackage(archive, pkgObj)
 }
 
+// BuildImportPath loads and compiles package with the given import path.
+//
+// Relative paths are interpreted relative to the current working dir.
 func (s *Session) BuildImportPath(path string) (*compiler.Archive, error) {
 	_, archive, err := s.buildImportPathWithSrcDir(path, "")
 	return archive, err
 }
 
+// buildImportPathWithSrcDir builds the package specified by the import path.
+//
+// Relative import paths are interpreted relative to the passed srcDir. If
+// srcDir is empty, current working directory is assumed.
 func (s *Session) buildImportPathWithSrcDir(path string, srcDir string) (*PackageData, *compiler.Archive, error) {
 	pkg, err := importWithSrcDir(s.xctx, path, srcDir, 0, s.InstallSuffix())
 	if s.Watcher != nil && pkg != nil { // add watch even on error
@@ -588,6 +586,7 @@ func (s *Session) buildImportPathWithSrcDir(path string, srcDir string) (*Packag
 	return pkg, archive, nil
 }
 
+// BuildPackage compiles an already loaded package.
 func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 	if archive, ok := s.Archives[pkg.ImportPath]; ok {
 		return archive, nil
@@ -732,6 +731,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 	return archive, nil
 }
 
+// writeLibraryPackage writes a compiled package archive to disk at pkgObj path.
 func (s *Session) writeLibraryPackage(archive *compiler.Archive, pkgObj string) error {
 	if err := os.MkdirAll(filepath.Dir(pkgObj), 0777); err != nil {
 		return err
@@ -746,6 +746,7 @@ func (s *Session) writeLibraryPackage(archive *compiler.Archive, pkgObj string) 
 	return compiler.WriteArchive(archive, objFile)
 }
 
+// WriteCommandPackage writes the final JavaScript output file at pkgObj path.
 func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) error {
 	if err := os.MkdirAll(filepath.Dir(pkgObj), 0777); err != nil {
 		return err
@@ -786,6 +787,7 @@ func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) 
 	return compiler.WriteProgramCode(deps, sourceMapFilter, s.GoRelease())
 }
 
+// NewMappingCallback creates a new callback for source map generation.
 func NewMappingCallback(m *sourcemap.Map, goroot, gopath string, localMap bool) func(generatedLine, generatedColumn int, originalPos token.Position) {
 	return func(generatedLine, generatedColumn int, originalPos token.Position) {
 		if !originalPos.IsValid() {
@@ -810,6 +812,8 @@ func NewMappingCallback(m *sourcemap.Map, goroot, gopath string, localMap bool) 
 	}
 }
 
+// jsFilesFromDir finds and loads any *.inc.js packages in the build context
+// directory.
 func jsFilesFromDir(bctx *build.Context, dir string) ([]string, error) {
 	files, err := buildutil.ReadDir(bctx, dir)
 	if err != nil {
@@ -837,6 +841,8 @@ func hasGopathPrefix(file, gopath string) (hasGopathPrefix bool, prefixLen int) 
 	return false, 0
 }
 
+// WaitForChange watches file system events and returns if either when one of
+// the source files is modified.
 func (s *Session) WaitForChange() {
 	s.options.PrintSuccess("watching for changes...\n")
 	for {

--- a/build/context.go
+++ b/build/context.go
@@ -161,20 +161,25 @@ func (sc simpleCtx) applyPackageTweaks(importPath string, mode build.ImportMode)
 	bctx := sc.bctx
 	switch importPath {
 	case "syscall":
-		// syscall needs to use a typical GOARCH like amd64 to pick up definitions for _Socklen, BpfInsn, IFNAMSIZ, Timeval, BpfStat, SYS_FCNTL, Flock_t, etc.
+		// syscall needs to use a typical GOARCH like amd64 to pick up definitions
+		// for _Socklen, BpfInsn, IFNAMSIZ, Timeval, BpfStat, SYS_FCNTL, Flock_t,
+		// etc.
 		bctx.GOARCH = build.Default.GOARCH
 		bctx.InstallSuffix += build.Default.GOARCH
 	case "syscall/js":
 		if !sc.isVirtual {
-			// There are no buildable files in this package upstream, but we need to use files in the virtual directory.
+			// There are no buildable files in this package upstream, but we need to
+			// use files in the virtual directory.
 			mode |= build.FindOnly
 		}
 	case "crypto/x509", "os/user":
-		// These stdlib packages have cgo and non-cgo versions (via build tags); we want the latter.
+		// These stdlib packages have cgo and non-cgo versions (via build tags); we
+		// want the latter.
 		bctx.CgoEnabled = false
 	case "github.com/gopherjs/gopherjs/js", "github.com/gopherjs/gopherjs/nosync":
-		// These packages are already embedded via gopherjspkg.FS virtual filesystem (which can be
-		// safely vendored). Don't try to use vendor directory to resolve them.
+		// These packages are already embedded via gopherjspkg.FS virtual filesystem
+		// (which can be safely vendored). Don't try to use vendor directory to
+		// resolve them.
 		mode |= build.IgnoreVendor
 	}
 


### PR DESCRIPTION
This PR contains several relatively minor refactoring within the `build` package, which set the foundation for bigger improvements I'm working on. It includes the following:

  - golint warning fixes in the package.
  - Removal of an unused BuildDir function. I did a search across GitHub and it doesn't seem to be used anywhere outside of our repo either.
  - Moved tweaks to files included into stdlib packages inside the simpleContext type. This puts pre- and post-load tweaks in the same logical place and fixes a bug where such tweaks weren't applied in some code paths.
  - Update loaded package's import lists to exclude dependencies from the excluded files. This doesn't fix any bugs per se, but it makes the API slightly less error-prone.

Since these changes are relatively self-contained and the next change is becoming pretty involved, I decided to split them into a separate pull request for review convenience :)