### PR TITLE
Prevent non-blocking select from making function appear blocking.

### DIFF
--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -520,7 +520,9 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			Fun:  fc.newIdent("$select", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", types.NewInterface(nil, nil))), types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)),
 			Args: []ast.Expr{fc.newIdent(fmt.Sprintf("[%s]", strings.Join(channels, ", ")), types.NewInterface(nil, nil))},
 		}, types.Typ[types.Int])
-		fc.Blocking[selectCall] = !hasDefault
+		if !hasDefault {
+			fc.Blocking[selectCall] = true
+		}
 		fc.Printf("%s = %s;", selectionVar, fc.translateExpr(selectCall))
 
 		if len(caseClauses) != 0 {


### PR DESCRIPTION
In almost every place compiler checks whether a function is blocking by
checking `len(c.Blocking) > 0`, so assigning false to the map confuses
the check, causing unnecessary checkpointing prologue and epilogue to be
added to the function.

Fixes https://github.com/gopherjs/gopherjs/issues/1106.