### PR TITLE
Fix: Don't bust cache so aggressively when compiling test sources

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -458,13 +458,12 @@ func NewSession(options *Options) (*Session, error) {
 	}
 	s.xctx = NewBuildContext(s.InstallSuffix(), s.options.BuildTags)
 	s.buildCache = cache.BuildCache{
-		GOOS:          s.xctx.GOOS(),
-		GOARCH:        "js",
-		GOROOT:        options.GOROOT,
-		GOPATH:        options.GOPATH,
-		BuildTags:     options.BuildTags,
-		Minify:        options.Minify,
-		TestedPackage: options.TestedPackage,
+		GOOS:      s.xctx.GOOS(),
+		GOARCH:    "js",
+		GOROOT:    options.GOROOT,
+		GOPATH:    options.GOPATH,
+		BuildTags: options.BuildTags,
+		Minify:    options.Minify,
 	}
 	s.Types = make(map[string]*types.Package)
 	if options.Watch {
@@ -608,7 +607,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 	}
 
 	if !s.options.NoCache {
-		archive := s.buildCache.LoadArchive(pkg.ImportPath)
+		archive := s.buildCache.LoadArchive(pkg.ImportPath, s.options.TestedPackage)
 		if archive != nil && !pkg.SrcModTime.After(archive.BuildTime) {
 			if err := archive.RegisterTypes(s.Types); err != nil {
 				panic(fmt.Errorf("Failed to load type information from %v: %w", archive, err))
@@ -649,7 +648,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 		fmt.Println(pkg.ImportPath)
 	}
 
-	s.buildCache.StoreArchive(archive)
+	s.buildCache.StoreArchive(archive, s.options.TestedPackage)
 	s.UpToDateArchives[pkg.ImportPath] = archive
 
 	return archive, nil


### PR DESCRIPTION
When using latest gopherjs master, we noticed that the time to run `gopherjs test` in CI for our package increased from ~3m13s (on [1.17.1+go1.17.3](https://github.com/gopherjs/gopherjs/releases/tag/1.17.1%2Bgo1.17.3)) to ~14m36s - This appears to have started occurring after https://github.com/gopherjs/gopherjs/pull/1105

After turning on info level logs, we noticed that we were consistently getting cache misses for packages that were shared. 

Example:
```
2022-03-22T16:46:07.273977954Z time="2022-03-22T16:46:07Z" level=info msg="No cached package archive for \"testing\"."
2022-03-22T16:46:07.312493246Z time="2022-03-22T16:46:07Z" level=info msg="Successfully stored build archive \"compiler.Archive{testing}\" as \"/root/.cache/gopherjs/build_cache/f9/f9ec20f1c4472f467363b634f5f3e8ba88680c83c5545804c8159daa58a51c7d\"."
...
2022-03-22T16:46:14.025498059Z PASS
2022-03-22T16:46:14.025502425Z ok  	github.com/Workiva/library_name/pkg_1	1.156s
...
2022-03-22T16:46:17.948303901Z time="2022-03-22T16:46:17Z" level=info msg="No cached package archive for \"testing\"."
2022-03-22T16:46:17.982488945Z time="2022-03-22T16:46:17Z" level=info msg="Successfully stored build archive \"compiler.Archive{testing}\" as \"/root/.cache/gopherjs/build_cache/78/787f945b5c7a4c7b698fd4325452682aab49c613813d9fbbea17f4b8a317587a\"."
...
2022-03-22T16:46:24.437850143Z PASS
2022-03-22T16:46:24.437852433Z ok  	github.com/Workiva/library_name/pkg_2	1.910s
```

Further investigation showed that the build cache [generates a cache key](https://github.com/gopherjs/gopherjs/blob/0b2280d3ff9688cca64f090ccd7aeeed06ab7a97/build/cache/cache.go#L152-L161) based on [the package being tested](https://github.com/gopherjs/gopherjs/blob/0b2280d3ff9688cca64f090ccd7aeeed06ab7a97/build/cache/cache.go#L80-L84).

This means that if 2 packages share a dependency, they will not share the cache for that dependency.

I updated the cache key to:
1) Stop including the package under test
2) Start including a boolean that represents whether `*_test.go` sources are compiled into that cache.

By doing this, our `gopherjs test` CI time is back down to ~3m11s
