### PR TITLE
Propagate blocking function information through function literal calls.

### DIFF
--- a/compiler/analysis/info_test.go
+++ b/compiler/analysis/info_test.go
@@ -1,0 +1,79 @@
+package analysis
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/gopherjs/gopherjs/internal/srctesting"
+)
+
+// See: https://github.com/gopherjs/gopherjs/issues/955.
+func TestBlockingFunctionLiteral(t *testing.T) {
+	src := `
+package test
+
+func blocking() {
+	c := make(chan bool)
+	<-c
+}
+
+func indirectlyBlocking() {
+	func() { blocking() }()
+}
+
+func directlyBlocking() {
+	func() {
+		c := make(chan bool)
+		<-c
+	}()
+}
+
+func notBlocking() {
+	func() { println() } ()
+}
+`
+	fset := token.NewFileSet()
+	file := srctesting.Parse(t, fset, src)
+	typesInfo, typesPkg := srctesting.Check(t, fset, file)
+
+	pkgInfo := AnalyzePkg([]*ast.File{file}, fset, typesInfo, typesPkg, func(f *types.Func) bool {
+		panic("isBlocking() should be never called for imported functions in this test.")
+	})
+
+	assertBlocking(t, file, pkgInfo, "blocking")
+	assertBlocking(t, file, pkgInfo, "indirectlyBlocking")
+	assertBlocking(t, file, pkgInfo, "directlyBlocking")
+	assertNotBlocking(t, file, pkgInfo, "notBlocking")
+}
+
+func assertBlocking(t *testing.T, file *ast.File, pkgInfo *Info, funcName string) {
+	typesFunc := getTypesFunc(t, file, pkgInfo, funcName)
+	if !pkgInfo.IsBlocking(typesFunc) {
+		t.Errorf("Got: %q is not blocking. Want: %q is blocking.", typesFunc, typesFunc)
+	}
+}
+
+func assertNotBlocking(t *testing.T, file *ast.File, pkgInfo *Info, funcName string) {
+	typesFunc := getTypesFunc(t, file, pkgInfo, funcName)
+	if pkgInfo.IsBlocking(typesFunc) {
+		t.Errorf("Got: %q is blocking. Want: %q is not blocking.", typesFunc, typesFunc)
+	}
+}
+
+func getTypesFunc(t *testing.T, file *ast.File, pkgInfo *Info, funcName string) *types.Func {
+	obj := file.Scope.Lookup(funcName)
+	if obj == nil {
+		t.Fatalf("Declaration of %q is not found in the AST.", funcName)
+	}
+	decl, ok := obj.Decl.(*ast.FuncDecl)
+	if !ok {
+		t.Fatalf("Got: %q is %v. Want: a function declaration.", funcName, obj.Kind)
+	}
+	blockingType, ok := pkgInfo.Defs[decl.Name]
+	if !ok {
+		t.Fatalf("No type information is found for %v.", decl.Name)
+	}
+	return blockingType.(*types.Func)
+}

--- a/compiler/astutil/astutil_test.go
+++ b/compiler/astutil/astutil_test.go
@@ -1,10 +1,10 @@
 package astutil
 
 import (
-	"go/ast"
-	"go/parser"
 	"go/token"
 	"testing"
+
+	"github.com/gopherjs/gopherjs/internal/srctesting"
 )
 
 func TestImportsUnsafe(t *testing.T) {
@@ -43,7 +43,7 @@ func TestImportsUnsafe(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			src := "package testpackage\n\n" + test.imports
 			fset := token.NewFileSet()
-			file := parse(t, fset, src)
+			file := srctesting.Parse(t, fset, src)
 			got := ImportsUnsafe(file)
 			if got != test.want {
 				t.Fatalf("ImportsUnsafe() returned %t, want %t", got, test.want)
@@ -74,7 +74,7 @@ func TestFuncKey(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			fdecl := parseFuncDecl(t, test.src)
+			fdecl := srctesting.ParseFuncDecl(t, test.src)
 			if got := FuncKey(fdecl); got != test.want {
 				t.Errorf("Got %q, want %q", got, test.want)
 			}
@@ -122,7 +122,7 @@ func TestPruneOriginal(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			fdecl := parseFuncDecl(t, test.src)
+			fdecl := srctesting.ParseFuncDecl(t, test.src)
 			if got := PruneOriginal(fdecl); got != test.want {
 				t.Errorf("PruneOriginal() returned %t, want %t", got, test.want)
 			}
@@ -173,34 +173,11 @@ func TestEndsWithReturn(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			fdecl := parseFuncDecl(t, "package testpackage\n"+test.src)
+			fdecl := srctesting.ParseFuncDecl(t, "package testpackage\n"+test.src)
 			got := EndsWithReturn(fdecl.Body.List)
 			if got != test.want {
 				t.Errorf("EndsWithReturn() returned %t, want %t", got, test.want)
 			}
 		})
 	}
-}
-
-func parse(t *testing.T, fset *token.FileSet, src string) *ast.File {
-	t.Helper()
-	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("Failed to parse test source: %s", err)
-	}
-	return f
-}
-
-func parseFuncDecl(t *testing.T, src string) *ast.FuncDecl {
-	t.Helper()
-	fset := token.NewFileSet()
-	file := parse(t, fset, src)
-	if l := len(file.Decls); l != 1 {
-		t.Fatalf("Got %d decls in the sources, expected exactly 1", l)
-	}
-	fdecl, ok := file.Decls[0].(*ast.FuncDecl)
-	if !ok {
-		t.Fatalf("Got %T decl, expected *ast.FuncDecl", file.Decls[0])
-	}
-	return fdecl
 }

--- a/internal/srctesting/srctesting.go
+++ b/internal/srctesting/srctesting.go
@@ -1,0 +1,65 @@
+// Package srctesting contains common helpers for unit testing source code
+// analysis and transformation.
+package srctesting
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+// Parse source from the string and return complete AST.
+//
+// Assumes source file name `test.go`. Fails the test on parsing error.
+func Parse(t *testing.T, fset *token.FileSet, src string) *ast.File {
+	t.Helper()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse test source: %s", err)
+	}
+	return f
+}
+
+// Check type correctness of the provided AST.
+//
+// Assumes "test" package import path. Fails the test if type checking fails.
+// Provided AST is expected not to have any imports.
+func Check(t *testing.T, fset *token.FileSet, files ...*ast.File) (*types.Info, *types.Package) {
+	t.Helper()
+	typesInfo := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:     make(map[ast.Node]*types.Scope),
+	}
+	config := &types.Config{
+		Sizes: &types.StdSizes{WordSize: 4, MaxAlign: 8},
+	}
+	typesPkg, err := config.Check("test", fset, files, typesInfo)
+	if err != nil {
+		t.Fatalf("Filed to type check test source: %s", err)
+	}
+	return typesInfo, typesPkg
+}
+
+// ParseFuncDecl parses source with a single function defined and returns the
+// function AST.
+//
+// Fails the test if there isn't exactly one function declared in the source.
+func ParseFuncDecl(t *testing.T, src string) *ast.FuncDecl {
+	t.Helper()
+	fset := token.NewFileSet()
+	file := Parse(t, fset, src)
+	if l := len(file.Decls); l != 1 {
+		t.Fatalf("Got %d decls in the sources, expected exactly 1", l)
+	}
+	fdecl, ok := file.Decls[0].(*ast.FuncDecl)
+	if !ok {
+		t.Fatalf("Got %T decl, expected *ast.FuncDecl", file.Decls[0])
+	}
+	return fdecl
+}


### PR DESCRIPTION
When a function literal is used that calls another function and that other function has yet to be analyzed, the call site for the function literal is not retained, so it's not processed later, so the function that was calling the function literal is not made blocking itself, when it should be.

This change makes blocking status propagate through any number of intermediate literal function calls.

This is a rebase of https://github.com/gopherjs/gopherjs/pull/956 with additional regression tests.

Fixes https://github.com/gopherjs/gopherjs/issues/955.