### PR TITLE
Fix jsFS callback-related crashes

### DIFF
--- a/compiler/natives/src/syscall/fs_js.go
+++ b/compiler/natives/src/syscall/fs_js.go
@@ -23,7 +23,7 @@ func fsCall(name string, args ...interface{}) (js.Value, error) {
 		var res callResult
 
 		if len(args) >= 1 {
-			if jsErr := args[0]; !jsErr.IsNull() {
+			if jsErr := args[0]; !jsErr.IsUndefined() && !jsErr.IsNull() {
 				res.err = mapJSError(jsErr)
 			}
 		}

--- a/compiler/natives/src/syscall/fs_js.go
+++ b/compiler/natives/src/syscall/fs_js.go
@@ -22,6 +22,9 @@ func fsCall(name string, args ...interface{}) (js.Value, error) {
 	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		var res callResult
 
+		// Check that args has at least one element, then check both IsUndefined() and IsNull() on
+		// that element. In some situations, BrowserFS calls the callback without arguments or with
+		// an undefined argument: https://github.com/gopherjs/gopherjs/pull/1118
 		if len(args) >= 1 {
 			if jsErr := args[0]; !jsErr.IsUndefined() && !jsErr.IsNull() {
 				res.err = mapJSError(jsErr)

--- a/compiler/natives/src/syscall/fs_js.go
+++ b/compiler/natives/src/syscall/fs_js.go
@@ -22,8 +22,10 @@ func fsCall(name string, args ...interface{}) (js.Value, error) {
 	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		var res callResult
 
-		if jsErr := args[0]; !jsErr.IsNull() {
-			res.err = mapJSError(jsErr)
+		if len(args) >= 1 {
+			if jsErr := args[0]; !jsErr.IsNull() {
+				res.err = mapJSError(jsErr)
+			}
 		}
 
 		res.val = js.Undefined()


### PR DESCRIPTION
The first fix is also present upstream: see [js_fs.go](https://github.com/golang/go/blob/master/src/syscall/fs_js.go#L504). According to the comment, it is here because Node.js 8 `fs.utimes()` can call the callback without arguments.

The first fix also protects against the [BrowserFS](https://github.com/jvilk/BrowserFS) project’s almost 50 code locations where a callback is called without arguments:
 - [SynchronousFileSystem.rename()](https://github.com/jvilk/BrowserFS/blob/master/src/core/file_system.ts#L806)
 - [PreloadFile.close()](https://github.com/jvilk/BrowserFS/blob/master/src/generic/preload_file.ts#L143)
 - [DropboxFileSystem.rename()](https://github.com/jvilk/BrowserFS/blob/master/src/backend/Dropbox.ts#L298)…

The second commit is an additional safety against the callback argument being `undefined` instead of `null`. Again, this happens in the BrowserFS project: [FS.close()](https://github.com/jvilk/BrowserFS/blob/master/src/core/FS.ts#L657) creates a callback that passes its argument to the GopherJS-provided callback, however since the underlying [NoSyncFile.close()](https://github.com/jvilk/BrowserFS/blob/master/src/generic/preload_file.ts#L399) calls `cb()` instead of `cb(null)`, this becomes `undefined` back in GopherJS’s `fsCall()` and the call to `mapJSError()` will throw.