### PR TITLE
Pass nil slice when variadic arguments are omitted after regular args.

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -140,8 +140,15 @@ func (fc *funcContext) translateArgs(sig *types.Signature, argExprs []ast.Expr, 
 	// If variadic arguments were passed in as individual elements, regroup them
 	// into a slice and pass it as a single argument.
 	if sig.Variadic() && !ellipsis {
-		return append(args[:sigTypes.RequiredParams()],
-			fmt.Sprintf("new %s([%s])", fc.typeName(sigTypes.VariadicType()), strings.Join(args[sigTypes.RequiredParams():], ", ")))
+		required := args[:sigTypes.RequiredParams()]
+		var variadic string
+		if len(args) == sigTypes.RequiredParams() {
+			// If no variadic parameters were passed, the slice value defaults to nil.
+			variadic = fmt.Sprintf("%s.nil", fc.typeName(sigTypes.VariadicType()))
+		} else {
+			variadic = fmt.Sprintf("new %s([%s])", fc.typeName(sigTypes.VariadicType()), strings.Join(args[sigTypes.RequiredParams():], ", "))
+		}
+		return append(required, variadic)
 	}
 	return args
 }

--- a/tests/compiler_test.go
+++ b/tests/compiler_test.go
@@ -5,25 +5,50 @@ import (
 )
 
 func TestVariadicNil(t *testing.T) {
-	printVari := func(strs ...string) []string {
-		return strs
-	}
-
-	if got := printVari(); got != nil {
-		t.Errorf("printVari(): got: %#v; want %#v.", got, nil)
-	}
-
-	{
-		var want []string
-		if got := printVari(want...); got != nil {
-			t.Errorf("printVari(want...): got: %#v; want %#v.", got, nil)
+	t.Run("only variadic", func(t *testing.T) {
+		printVari := func(strs ...string) []string {
+			return strs
 		}
-	}
 
-	{
-		want := []string{}
-		if got := printVari(want...); got == nil || len(got) != len(want) {
-			t.Errorf("printVari(want...): got: %#v; want %#v.", got, want)
+		if got := printVari(); got != nil {
+			t.Errorf("printVari(): got: %#v; want %#v.", got, nil)
 		}
-	}
+
+		{
+			var want []string
+			if got := printVari(want...); got != nil {
+				t.Errorf("printVari(want...): got: %#v; want %#v.", got, nil)
+			}
+		}
+
+		{
+			want := []string{}
+			if got := printVari(want...); got == nil || len(got) != len(want) {
+				t.Errorf("printVari(want...): got: %#v; want %#v.", got, want)
+			}
+		}
+	})
+	t.Run("mixed", func(t *testing.T) {
+		printVari := func(_ int, strs ...string) []string {
+			return strs
+		}
+
+		if got := printVari(0); got != nil {
+			t.Errorf("printVari(): got: %#v; want %#v.", got, nil)
+		}
+
+		{
+			var want []string
+			if got := printVari(0, want...); got != nil {
+				t.Errorf("printVari(want...): got: %#v; want %#v.", got, nil)
+			}
+		}
+
+		{
+			want := []string{}
+			if got := printVari(0, want...); got == nil || len(got) != len(want) {
+				t.Errorf("printVari(want...): got: %#v; want %#v.", got, want)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Previously we would pass an empty slice, which is against the Go spec:

> If f is invoked with no actual arguments for p, the value passed to p is nil.

Source: https://go.dev/ref/spec#Passing_arguments_to_..._parameters

Fixes https://github.com/gopherjs/gopherjs/issues/1147