### PR TITLE
Rudimentary support for passing type parameters into generic functions

### DIFF
--- a/compiler/package.go
+++ b/compiler/package.go
@@ -294,7 +294,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 			// but now we do it here to maintain previous behavior.
 			continue
 		}
-		funcCtx.pkgCtx.pkgVars[importedPkg.Path()] = funcCtx.newVariableWithLevel(importedPkg.Name(), true)
+		funcCtx.pkgCtx.pkgVars[importedPkg.Path()] = funcCtx.newVariable(importedPkg.Name(), true)
 		importedPaths = append(importedPaths, importedPkg.Path())
 	}
 	sort.Strings(importedPaths)
@@ -773,12 +773,12 @@ func translateFunction(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt, 
 	var params []string
 	for _, param := range typ.Params.List {
 		if len(param.Names) == 0 {
-			params = append(params, c.newVariable("param"))
+			params = append(params, c.newLocalVariable("param"))
 			continue
 		}
 		for _, ident := range param.Names {
 			if isBlank(ident) {
-				params = append(params, c.newVariable("param"))
+				params = append(params, c.newLocalVariable("param"))
 				continue
 			}
 			params = append(params, c.objectName(c.pkgCtx.Defs[ident]))

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -444,7 +444,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			for _, spec := range decl.Specs {
 				o := fc.pkgCtx.Defs[spec.(*ast.TypeSpec).Name].(*types.TypeName)
 				fc.pkgCtx.typeNames = append(fc.pkgCtx.typeNames, o)
-				fc.pkgCtx.objectNames[o] = fc.newVariable(o.Name(), true)
+				fc.pkgCtx.objectNames[o] = fc.newVariable(o.Name(), varPackage)
 				fc.pkgCtx.dependencies[o] = true
 			}
 		case token.CONST:

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -125,7 +125,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		if s.Init != nil {
 			fc.translateStmt(s.Init, nil)
 		}
-		refVar := fc.newVariable("_ref")
+		refVar := fc.newLocalVariable("_ref")
 		var expr ast.Expr
 		switch a := s.Assign.(type) {
 		case *ast.AssignStmt:
@@ -187,14 +187,14 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		}, label, fc.Flattened[s])
 
 	case *ast.RangeStmt:
-		refVar := fc.newVariable("_ref")
+		refVar := fc.newLocalVariable("_ref")
 		fc.Printf("%s = %s;", refVar, fc.translateExpr(s.X))
 
 		switch t := fc.pkgCtx.TypeOf(s.X).Underlying().(type) {
 		case *types.Basic:
-			iVar := fc.newVariable("_i")
+			iVar := fc.newLocalVariable("_i")
 			fc.Printf("%s = 0;", iVar)
-			runeVar := fc.newVariable("_rune")
+			runeVar := fc.newLocalVariable("_rune")
 			fc.translateLoopingStmt(func() string { return iVar + " < " + refVar + ".length" }, s.Body, func() {
 				fc.Printf("%s = $decodeRune(%s, %s);", runeVar, refVar, iVar)
 				if !isBlank(s.Key) {
@@ -208,16 +208,16 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			}, label, fc.Flattened[s])
 
 		case *types.Map:
-			iVar := fc.newVariable("_i")
+			iVar := fc.newLocalVariable("_i")
 			fc.Printf("%s = 0;", iVar)
-			keysVar := fc.newVariable("_keys")
+			keysVar := fc.newLocalVariable("_keys")
 			fc.Printf("%s = %s ? %s.keys() : undefined;", keysVar, refVar, refVar)
 
-			sizeVar := fc.newVariable("_size")
+			sizeVar := fc.newLocalVariable("_size")
 			fc.Printf("%s = %s ? %s.size : 0;", sizeVar, refVar, refVar)
 			fc.translateLoopingStmt(func() string { return iVar + " < " + sizeVar }, s.Body, func() {
-				keyVar := fc.newVariable("_key")
-				entryVar := fc.newVariable("_entry")
+				keyVar := fc.newLocalVariable("_key")
+				entryVar := fc.newLocalVariable("_entry")
 				fc.Printf("%s = %s.next().value;", keyVar, keysVar)
 				fc.Printf("%s = %s.get(%s);", entryVar, refVar, keyVar)
 				fc.translateStmt(&ast.IfStmt{
@@ -248,7 +248,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 				length = refVar + ".$length"
 				elemType = t2.Elem()
 			}
-			iVar := fc.newVariable("_i")
+			iVar := fc.newLocalVariable("_i")
 			fc.Printf("%s = 0;", iVar)
 			fc.translateLoopingStmt(func() string { return iVar + " < " + length }, s.Body, func() {
 				if !isBlank(s.Key) {
@@ -265,7 +265,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			}, label, fc.Flattened[s])
 
 		case *types.Chan:
-			okVar := fc.newIdent(fc.newVariable("_ok"), types.Typ[types.Bool])
+			okVar := fc.newIdent(fc.newLocalVariable("_ok"), types.Typ[types.Bool])
 			key := s.Key
 			tok := s.Tok
 			if key == nil {
@@ -354,7 +354,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		if rVal != "" {
 			// If returned expression is non empty, evaluate and store it in a
 			// variable to avoid double-execution in case a deferred function blocks.
-			rVar := fc.newVariable("$r")
+			rVar := fc.newLocalVariable("$r")
 			fc.Printf("%s =%s;", rVar, rVal)
 			rVal = " " + rVar
 		}
@@ -386,7 +386,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			fc.Printf("%s", fc.translateAssign(lhs, s.Rhs[0], s.Tok == token.DEFINE))
 
 		case len(s.Lhs) > 1 && len(s.Rhs) == 1:
-			tupleVar := fc.newVariable("_tuple")
+			tupleVar := fc.newLocalVariable("_tuple")
 			fc.Printf("%s = %s;", tupleVar, fc.translateExpr(s.Rhs[0]))
 			tuple := fc.pkgCtx.TypeOf(s.Rhs[0]).(*types.Tuple)
 			for i, lhs := range s.Lhs {
@@ -398,7 +398,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		case len(s.Lhs) == len(s.Rhs):
 			tmpVars := make([]string, len(s.Rhs))
 			for i, rhs := range s.Rhs {
-				tmpVars[i] = fc.newVariable("_tmp")
+				tmpVars[i] = fc.newLocalVariable("_tmp")
 				if isBlank(astutil.RemoveParens(s.Lhs[i])) {
 					fc.Printf("$unused(%s);", fc.translateExpr(rhs))
 					continue
@@ -444,7 +444,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			for _, spec := range decl.Specs {
 				o := fc.pkgCtx.Defs[spec.(*ast.TypeSpec).Name].(*types.TypeName)
 				fc.pkgCtx.typeNames = append(fc.pkgCtx.typeNames, o)
-				fc.pkgCtx.objectNames[o] = fc.newVariableWithLevel(o.Name(), true)
+				fc.pkgCtx.objectNames[o] = fc.newVariable(o.Name(), true)
 				fc.pkgCtx.dependencies[o] = true
 			}
 		case token.CONST:
@@ -478,7 +478,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		fc.translateStmt(&ast.ExprStmt{X: call}, label)
 
 	case *ast.SelectStmt:
-		selectionVar := fc.newVariable("_selection")
+		selectionVar := fc.newLocalVariable("_selection")
 		var channels []string
 		var caseClauses []*ast.CaseClause
 		flattened := false
@@ -704,7 +704,7 @@ func (fc *funcContext) translateAssign(lhs, rhs ast.Expr, define bool) string {
 			if typesutil.IsJsObject(fc.pkgCtx.TypeOf(l.Index)) {
 				fc.pkgCtx.errList = append(fc.pkgCtx.errList, types.Error{Fset: fc.pkgCtx.fileSet, Pos: l.Index.Pos(), Msg: "cannot use js.Object as map key"})
 			}
-			keyVar := fc.newVariable("_key")
+			keyVar := fc.newLocalVariable("_key")
 			return fmt.Sprintf(
 				`%s = %s; (%s || $throwRuntimeError("assignment to entry in nil map")).set(%s.keyFor(%s), { k: %s, v: %s });`,
 				keyVar,
@@ -799,7 +799,7 @@ func (fc *funcContext) translateResults(results []ast.Expr) string {
 				return " " + resultExpr
 			}
 
-			tmpVar := fc.newVariable("_returncast")
+			tmpVar := fc.newLocalVariable("_returncast")
 			fc.Printf("%s = %s;", tmpVar, resultExpr)
 
 			// Not all the return types matched, map everything out for implicit casting

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -110,7 +110,7 @@ func (fc *funcContext) expandTupleArgs(argExprs []ast.Expr) []ast.Expr {
 		return argExprs
 	}
 
-	tupleVar := fc.newVariable("_tuple")
+	tupleVar := fc.newLocalVariable("_tuple")
 	fc.Printf("%s = %s;", tupleVar, fc.translateExpr(argExprs[0]))
 	argExprs = make([]ast.Expr, tuple.Len())
 	for i := range argExprs {
@@ -138,7 +138,7 @@ func (fc *funcContext) translateArgs(sig *types.Signature, argExprs []ast.Expr, 
 		arg := fc.translateImplicitConversionWithCloning(argExpr, sigTypes.Param(i, ellipsis)).String()
 
 		if preserveOrder && fc.pkgCtx.Types[argExpr].Value == nil {
-			argVar := fc.newVariable("_arg")
+			argVar := fc.newLocalVariable("_arg")
 			fc.Printf("%s = %s;", argVar, arg)
 			arg = argVar
 		}
@@ -233,11 +233,26 @@ func (fc *funcContext) newConst(t types.Type, value constant.Value) ast.Expr {
 	return id
 }
 
-func (fc *funcContext) newVariable(name string) string {
-	return fc.newVariableWithLevel(name, false)
+// newLocalVariable assigns a new JavaScript variable name for the given Go
+// local variable name. In this context "local" means "in scope of the current"
+// functionContext.
+func (fc *funcContext) newLocalVariable(name string) string {
+	return fc.newVariable(name, false)
 }
 
-func (fc *funcContext) newVariableWithLevel(name string, pkgLevel bool) string {
+// newVariable assigns a new JavaScript variable name for the given Go variable
+// or type.
+//
+// If there is already a variable with the same name visible in the current
+// function context (e.g. due to shadowing), the returned name will be suffixed
+// with a number to prevent conflict. This is necessary because Go name
+// resolution scopes differ from var declarations in JS.
+//
+// If pkgLevel is true, the variable is declared at the package level and added
+// to this functionContext, as well as all parents, but not to the list of local
+// variables. If false, it is added to this context only, as well as the list of
+// local vars.
+func (fc *funcContext) newVariable(name string, pkgLevel bool) string {
 	if name == "" {
 		panic("newVariable: empty name")
 	}
@@ -320,6 +335,8 @@ func isPkgLevel(o types.Object) bool {
 	return o.Parent() != nil && o.Parent().Parent() == types.Universe
 }
 
+// objectName returns a JS identifier corresponding to the given types.Object.
+// Repeated calls for the same object will return the same name.
 func (fc *funcContext) objectName(o types.Object) string {
 	if isPkgLevel(o) {
 		fc.pkgCtx.dependencies[o] = true
@@ -331,7 +348,7 @@ func (fc *funcContext) objectName(o types.Object) string {
 
 	name, ok := fc.pkgCtx.objectNames[o]
 	if !ok {
-		name = fc.newVariableWithLevel(o.Name(), isPkgLevel(o))
+		name = fc.newVariable(o.Name(), isPkgLevel(o))
 		fc.pkgCtx.objectNames[o] = name
 	}
 
@@ -348,12 +365,17 @@ func (fc *funcContext) varPtrName(o *types.Var) string {
 
 	name, ok := fc.pkgCtx.varPtrNames[o]
 	if !ok {
-		name = fc.newVariableWithLevel(o.Name()+"$ptr", isPkgLevel(o))
+		name = fc.newVariable(o.Name()+"$ptr", isPkgLevel(o))
 		fc.pkgCtx.varPtrNames[o] = name
 	}
 	return name
 }
 
+// typeName returns a JS identifier name for the given Go type.
+//
+// For the built-in types it returns identifiers declared in the prelude. For
+// all user-defined or composite types it creates a unique JS identifier and
+// will return it on all subsequent calls for the type.
 func (fc *funcContext) typeName(ty types.Type) string {
 	switch t := ty.(type) {
 	case *types.Basic:
@@ -369,10 +391,14 @@ func (fc *funcContext) typeName(ty types.Type) string {
 		}
 	}
 
+	// For anonymous composite types, generate a synthetic package-level type
+	// declaration, which will be reused for all instances of this time. This
+	// improves performance, since runtime won't have to synthesize the same type
+	// repeatedly.
 	anonType, ok := fc.pkgCtx.anonTypeMap.At(ty).(*types.TypeName)
 	if !ok {
 		fc.initArgs(ty) // cause all embedded types to be registered
-		varName := fc.newVariableWithLevel(strings.ToLower(typeKind(ty)[5:])+"Type", true)
+		varName := fc.newVariable(strings.ToLower(typeKind(ty)[5:])+"Type", true)
 		anonType = types.NewTypeName(token.NoPos, fc.pkgCtx.Pkg, varName, ty) // fake types.TypeName
 		fc.pkgCtx.anonTypes = append(fc.pkgCtx.anonTypes, anonType)
 		fc.pkgCtx.anonTypeMap.Set(ty, anonType)


### PR DESCRIPTION
Instead of generating an independent function instance for every combination of type parameters at compile time we construct generic function instances at runtime using "generic factory functions". Such a factory takes type params as arguments and returns a concrete instance of the function for the given type params (type param values are captured by the returned function as a closure and can be used as necessary).

Here is an abbreviated example of how a generic function is compiled and called:

```
// Go:
func F[T any](t T) {}
f(1)

// JS:
F = function(T){ return function(t) {}; };
F($Int)(1);
```

This approach minimizes the size of the generated JS source, which is critical for the client-side use case, at the cost of runtime
performance. See https://github.com/gopherjs/gopherjs/issues/1013#issuecomment-1217237123 for the detailed description.

Note that the implementation in this commit is far from complete:

  - Generic function instances are not cached.
  - Generic types are not supported.
  - Declaring types dependent on type parameters doesn't work correctly.
  - Operators (such as `+`) do not work correctly with generic arguments.

Updates #1013.