### PR TITLE
Replacing eval() calls in syscall/js

### DIFF
--- a/compiler/natives/src/syscall/js/js.go
+++ b/compiler/natives/src/syscall/js/js.go
@@ -117,9 +117,9 @@ var (
 
 func init() {
 	if js.Global != nil {
-		id = js.Global.Call("eval", "(function(x) { return x; })")
-		instanceOf = js.Global.Call("eval", "(function(x, y) { return x instanceof y; })")
-		getValueType = js.Global.Call("eval", `(function(x) {
+		id = js.Global.Call("Function", "x", "return x")
+		instanceOf = js.Global.Call("Function", "x", "y", "return x instanceof y")
+		getValueType = js.Global.Call("Function", "x", `
   if (typeof(x) === "undefined") {
     return 0; // TypeUndefined
   }
@@ -142,7 +142,7 @@ func init() {
     return 7; // TypeFunction
   }
   return 6; // TypeObject
-})`)
+`)
 	}
 }
 


### PR DESCRIPTION
Minor tweak to `syscall/js` to follow a security best practice as advised by MDN:

[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!)

> Additionally, modern JavaScript interpreters convert JavaScript to machine code. This means that any concept of variable naming gets obliterated. Thus, any use of eval() will force the browser to do long expensive variable name lookups to figure out where the variable exists in the machine code and set its value. Additionally, new things can be introduced to that variable through eval() such as changing the type of that variable, forcing the browser to re-evaluate all of the generated machine code to compensate.
> 
> Fortunately, there's a very good alternative to eval(): using the [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) constructor. Bad code with eval():

In addition to the security benefits, this means that gopherjs can now be used in environments with a CSP that doesn't allow `scritp-src: 'unsafe-eval'`.