### PR TITLE
compiler/natives/src/reflect: fix reflect.Value.Set kind Struct by flagIndir

### DIFF
--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1436,12 +1436,10 @@ func (v Value) Set(x Value) {
 	x = x.assignTo("reflect.Set", v.typ, nil)
 	if v.flag&flagIndir != 0 {
 		switch v.typ.Kind() {
-		case Array:
+		case Array, Struct:
 			jsType(v.typ).Call("copy", js.InternalObject(v.ptr), js.InternalObject(x.ptr))
 		case Interface:
 			js.InternalObject(v.ptr).Call("$set", js.InternalObject(valueInterface(x, false)))
-		case Struct:
-			copyStruct(js.InternalObject(v.ptr), js.InternalObject(x.ptr), v.typ)
 		default:
 			js.InternalObject(v.ptr).Call("$set", x.object())
 		}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -862,3 +862,29 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("Got: runtime.Version() returned %q. Want: a valid Go version.", got)
 	}
 }
+
+// https://github.com/gopherjs/gopherjs/issues/1163
+func TestReflectSetForEmbed(t *testing.T) {
+	type Point struct {
+		x int
+		y int
+	}
+	type Embed struct {
+		value bool
+		point Point
+	}
+	type A struct {
+		Embed
+	}
+	c := &A{}
+	c.value = true
+	c.point = Point{100, 200}
+	in := reflect.ValueOf(c).Elem()
+	v := reflect.New(in.Type())
+	e := v.Elem()
+	f0 := e.Field(0)
+	e.Set(in)
+	if e.Field(0) != f0 {
+		t.Fatalf("relfect.Set got %v, want %v", f0, e.Field(0))
+	}
+}


### PR DESCRIPTION
fix https://github.com/gopherjs/gopherjs/issues/1163 reflect.Value.Set for struct by flagIndir