### PR TITLE
Initialize type param-dependent types in a generic factory function.

### DIFF
--- a/compiler/typesutil/typesutil.go
+++ b/compiler/typesutil/typesutil.go
@@ -1,11 +1,18 @@
 package typesutil
 
-import "go/types"
+import (
+	"fmt"
+	"go/types"
 
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+// IsJsPackage returns is the package is github.com/gopherjs/gopherjs/js.
 func IsJsPackage(pkg *types.Package) bool {
 	return pkg != nil && pkg.Path() == "github.com/gopherjs/gopherjs/js"
 }
 
+// IsJsObject returns true if the type represents a pointer to github.com/gopherjs/gopherjs/js.Object.
 func IsJsObject(t types.Type) bool {
 	ptr, isPtr := t.(*types.Pointer)
 	if !isPtr {
@@ -13,4 +20,93 @@ func IsJsObject(t types.Type) bool {
 	}
 	named, isNamed := ptr.Elem().(*types.Named)
 	return isNamed && IsJsPackage(named.Obj().Pkg()) && named.Obj().Name() == "Object"
+}
+
+// AnonymousTypes maintains a mapping between anonymous types encountered in a
+// Go program to equivalent synthetic names types GopherJS generated from them.
+//
+// This enables a runtime performance optimization where different instances of
+// the same anonymous type (e.g. in expression `x := map[int]string{}`) don't
+// need to initialize type information (e.g. `$mapType($Int, $String)`) every
+// time, but reuse the single synthesized type (e.g. `mapType$1`).
+type AnonymousTypes struct {
+	m     typeutil.Map
+	order []*types.TypeName
+}
+
+// Get returns the synthesized type name for the provided anonymous type or nil
+// if the type is not registered.
+func (at *AnonymousTypes) Get(t types.Type) *types.TypeName {
+	s, _ := at.m.At(t).(*types.TypeName)
+	return s
+}
+
+// Ordered returns synthesized type names for the registered anonymous types in
+// the order they were registered.
+func (at *AnonymousTypes) Ordered() []*types.TypeName {
+	return at.order
+}
+
+// Register a synthesized type name for an anonymous type.
+func (at *AnonymousTypes) Register(name *types.TypeName, anonType types.Type) {
+	at.m.Set(anonType, name)
+	at.order = append(at.order, name)
+}
+
+// IsGeneric returns true if the provided type is a type parameter or depends
+// on a type parameter.
+func IsGeneric(t types.Type) bool {
+	switch t := t.(type) {
+	case *types.Array:
+		return IsGeneric(t.Elem())
+	case *types.Basic:
+		return false
+	case *types.Chan:
+		return IsGeneric(t.Elem())
+	case *types.Interface:
+		for i := 0; i < t.NumMethods(); i++ {
+			if IsGeneric(t.Method(i).Type()) {
+				return true
+			}
+		}
+		for i := 0; i < t.NumEmbeddeds(); i++ {
+			if IsGeneric(t.Embedded(i)) {
+				return true
+			}
+		}
+		return false
+	case *types.Map:
+		return IsGeneric(t.Key()) || IsGeneric(t.Elem())
+	case *types.Named:
+		// Named type declarations dependent on a type param are currently not
+		// supported by the upstream Go compiler.
+		return false
+	case *types.Pointer:
+		return IsGeneric(t.Elem())
+	case *types.Slice:
+		return IsGeneric(t.Elem())
+	case *types.Signature:
+		for i := 0; i < t.Params().Len(); i++ {
+			if IsGeneric(t.Params().At(i).Type()) {
+				return true
+			}
+		}
+		for i := 0; i < t.Results().Len(); i++ {
+			if IsGeneric(t.Results().At(i).Type()) {
+				return true
+			}
+		}
+		return false
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			if IsGeneric(t.Field(i).Type()) {
+				return true
+			}
+		}
+		return false
+	case *types.TypeParam:
+		return true
+	default:
+		panic(fmt.Errorf("%v has unexpected type %T", t, t))
+	}
 }

--- a/compiler/typesutil/typesutil_test.go
+++ b/compiler/typesutil/typesutil_test.go
@@ -1,0 +1,168 @@
+package typesutil
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAnonymousTypes(t *testing.T) {
+	t1 := types.NewSlice(types.Typ[types.String])
+	t1Name := types.NewTypeName(token.NoPos, nil, "sliceType$1", t1)
+
+	t2 := types.NewMap(types.Typ[types.Int], t1)
+	t2Name := types.NewTypeName(token.NoPos, nil, "mapType$1", t2)
+
+	typs := []struct {
+		typ  types.Type
+		name *types.TypeName
+	}{
+		{typ: t1, name: t1Name},
+		{typ: t2, name: t2Name},
+	}
+
+	anonTypes := AnonymousTypes{}
+	for _, typ := range typs {
+		anonTypes.Register(typ.name, typ.typ)
+	}
+
+	for _, typ := range typs {
+		t.Run(typ.name.Name(), func(t *testing.T) {
+			got := anonTypes.Get(typ.typ)
+			if got != typ.name {
+				t.Errorf("Got: anonTypes.Get(%v) = %v. Want: %v.", typ.typ, typ.name, got)
+			}
+		})
+	}
+
+	gotNames := []string{}
+	for _, name := range anonTypes.Ordered() {
+		gotNames = append(gotNames, name.Name())
+	}
+	wantNames := []string{"sliceType$1", "mapType$1"}
+	if !cmp.Equal(wantNames, gotNames) {
+		t.Errorf("Got: anonTypes.Ordered() = %v. Want: %v (in the order of registration)", gotNames, wantNames)
+	}
+}
+
+func TestIsGeneric(t *testing.T) {
+	T := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "T", nil), types.NewInterface(nil, nil))
+
+	tests := []struct {
+		typ  types.Type
+		want bool
+	}{
+		{
+			typ:  T,
+			want: true,
+		}, {
+			typ:  types.Typ[types.Int],
+			want: false,
+		}, {
+			typ:  types.NewArray(types.Typ[types.Int], 1),
+			want: false,
+		}, {
+			typ:  types.NewArray(T, 1),
+			want: true,
+		}, {
+			typ:  types.NewChan(types.SendRecv, types.Typ[types.Int]),
+			want: false,
+		}, {
+			typ:  types.NewChan(types.SendRecv, T),
+			want: true,
+		}, {
+			typ: types.NewInterfaceType(
+				[]*types.Func{
+					types.NewFunc(token.NoPos, nil, "X", types.NewSignatureType(
+						nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int])), nil, false,
+					)),
+				},
+				[]types.Type{
+					types.NewNamed(types.NewTypeName(token.NoPos, nil, "myInt", nil), types.Typ[types.Int], nil),
+				},
+			),
+			want: false,
+		}, {
+			typ: types.NewInterfaceType(
+				[]*types.Func{
+					types.NewFunc(token.NoPos, nil, "X", types.NewSignatureType(
+						nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, nil, "x", T)), nil, false,
+					)),
+				},
+				[]types.Type{
+					types.NewNamed(types.NewTypeName(token.NoPos, nil, "myInt", nil), types.Typ[types.Int], nil),
+				},
+			),
+			want: true,
+		}, {
+			typ:  types.NewMap(types.Typ[types.Int], types.Typ[types.String]),
+			want: false,
+		}, {
+			typ:  types.NewMap(T, types.Typ[types.String]),
+			want: true,
+		}, {
+			typ:  types.NewMap(types.Typ[types.Int], T),
+			want: true,
+		}, {
+			typ:  types.NewNamed(types.NewTypeName(token.NoPos, nil, "myInt", nil), types.Typ[types.Int], nil),
+			want: false,
+		}, {
+			typ:  types.NewPointer(types.Typ[types.Int]),
+			want: false,
+		}, {
+			typ:  types.NewPointer(T),
+			want: true,
+		}, {
+			typ:  types.NewSlice(types.Typ[types.Int]),
+			want: false,
+		}, {
+			typ:  types.NewSlice(T),
+			want: true,
+		}, {
+			typ: types.NewSignatureType(
+				nil, nil, nil,
+				types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int])),   // params
+				types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String])), // results
+				false,
+			),
+			want: false,
+		}, {
+			typ: types.NewSignatureType(
+				nil, nil, nil,
+				types.NewTuple(types.NewVar(token.NoPos, nil, "x", T)),                      // params
+				types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String])), // results
+				false,
+			),
+			want: true,
+		}, {
+			typ: types.NewSignatureType(
+				nil, nil, nil,
+				types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int])), // params
+				types.NewTuple(types.NewVar(token.NoPos, nil, "", T)),                     // results
+				false,
+			),
+			want: true,
+		}, {
+			typ: types.NewStruct([]*types.Var{
+				types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int]),
+			}, nil),
+			want: false,
+		}, {
+			typ: types.NewStruct([]*types.Var{
+				types.NewVar(token.NoPos, nil, "x", T),
+			}, nil),
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.typ.String(), func(t *testing.T) {
+			got := IsGeneric(test.typ)
+			if got != test.want {
+				t.Errorf("Got: IsGeneric(%v) = %v. Want: %v.", test.typ, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of being initialized at the package level, they are initialized inside a generic factory, where type params are available.

Example:

```
// Go:
func _F[T any](t T) {
  _ = []T{}
}

// JS:
_F = function(T){
  var sliceType = $sliceType(T);
  return function(t) {
    $unused(new sliceType([]));
  };
};
```

Updates #1013.