### PR TITLE
Several small fixes to generics handling

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -768,6 +768,9 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 			if typesutil.IsJsObject(exprType) {
 				return fc.formatExpr("null")
 			}
+			if typesutil.IsGeneric(exprType) {
+				return fc.formatExpr("%s.zero()", fc.typeName(exprType))
+			}
 			switch t := exprType.Underlying().(type) {
 			case *types.Basic:
 				if t.Kind() != types.UnsafePointer {

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -531,7 +531,7 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 			d.DeclCode = funcCtx.CatchOutput(0, func() {
 				typeName := funcCtx.objectName(o)
 				lhs := typeName
-				if typeVarLevel(o) == varPackage {
+				if getVarLevel(o) == varPackage {
 					lhs += " = $pkg." + encodeIdent(o.Name())
 				}
 				size := int64(0)

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -700,7 +700,7 @@ func (t *test) run() {
 		supportedArgs := []string{}
 		for _, a := range args {
 			switch a {
-			case "-gcflags=-G=3":
+			case "-gcflags=-G=3", `-gcflags="-G=3"`:
 				continue
 			default:
 				supportedArgs = append(supportedArgs, a)


### PR DESCRIPTION
 - Fix gorepo test runner to handle another variant of the `-gcflags="-G=3"` flag.
 - Correctly return `varFuncLocal` declaration level for JS variables corresponding to local variables.
 - Correctly zero-initialize variables of generic types.

Updates #1013 