### PR TITLE
Fix incorrect continuation callback for a blocking generic function.

### DIFF
--- a/compiler/package.go
+++ b/compiler/package.go
@@ -781,6 +781,7 @@ func translateFunction(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt, 
 	}
 	if c.sigTypes.IsGeneric() {
 		c.genericCtx = &genericCtx{}
+		funcRef = c.newVariable(funcRef, varGenericFactory)
 	}
 	prevEV := c.pkgCtx.escapingVars
 
@@ -935,8 +936,10 @@ func translateFunction(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt, 
 	code := &strings.Builder{}
 	fmt.Fprintf(code, "function%s(%s){\n", functionName, strings.Join(typeParams, ", "))
 	fmt.Fprintf(code, "%s", typesInit.String())
-	fmt.Fprintf(code, "%sreturn function(%s) {\n", c.Indentation(1), strings.Join(params, ", "))
+	fmt.Fprintf(code, "%sconst %s = function(%s) {\n", c.Indentation(1), funcRef, strings.Join(params, ", "))
 	fmt.Fprintf(code, "%s", bodyOutput)
-	fmt.Fprintf(code, "%s};\n%s}", c.Indentation(1), c.Indentation(0))
+	fmt.Fprintf(code, "%s};\n", c.Indentation(1))
+	fmt.Fprintf(code, "%sreturn %s;\n", c.Indentation(1), funcRef)
+	fmt.Fprintf(code, "%s}", c.Indentation(0))
 	return params, code.String()
 }

--- a/tests/typeparams/blocking_test.go
+++ b/tests/typeparams/blocking_test.go
@@ -1,0 +1,21 @@
+package typeparams_test
+
+import (
+	"runtime"
+	"testing"
+)
+
+func _GenericBlocking[T any]() string {
+	runtime.Gosched()
+	return "Hello, world."
+}
+
+// TestBlocking verifies that a generic function correctly resumes after a
+// blocking operation.
+func TestBlocking(t *testing.T) {
+	got := _GenericBlocking[any]()
+	want := "Hello, world."
+	if got != want {
+		t.Fatalf("Got: _GenericBlocking[any]() = %q. Want: %q.", got, want)
+	}
+}


### PR DESCRIPTION
Previously it was incorrectly returning a reference to the generic factory function. With this change it correctly returns a reference to the generic function instance.

Updates #1013

/cc @paralin 