### PR TITLE
compiler: factor out utility types for processing Go sources and errors.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -30,22 +30,6 @@ func init() {
 	}
 }
 
-type ErrorList []error
-
-func (err ErrorList) Error() string {
-	if len(err) == 0 {
-		return "<no errors>"
-	}
-	return fmt.Sprintf("%s (and %d more errors)", err[0].Error(), len(err[1:]))
-}
-
-func (err ErrorList) Normalize() error {
-	if len(err) == 0 {
-		return nil
-	}
-	return err
-}
-
 // Archive contains intermediate build outputs of a single package.
 //
 // This is a logical equivalent of an object file in traditional compilers.

--- a/compiler/errors.go
+++ b/compiler/errors.go
@@ -1,0 +1,68 @@
+package compiler
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrTooManyErrors is added to the ErrorList by the Trim method.
+var ErrTooManyErrors = errors.New("too many errors")
+
+// ErrorList wraps multiple errors as a single error.
+type ErrorList []error
+
+func (errs ErrorList) Error() string {
+	if len(errs) == 0 {
+		return "<no errors>"
+	}
+	return fmt.Sprintf("%s (and %d more errors)", errs[0].Error(), len(errs[1:]))
+}
+
+// ErrOrNil returns nil if ErrorList is empty, or the error otherwise.
+func (errs ErrorList) ErrOrNil() error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs
+}
+
+// Append an error to the list.
+//
+// If err is an instance of ErrorList, the lists are concatenated together,
+// otherwise err is appended at the end of the list. If err is nil, the list is
+// returned unmodified.
+//
+// 	err := DoStuff()
+// 	errList := errList.Append(err)
+func (errs ErrorList) Append(err error) ErrorList {
+	if err == nil {
+		return errs
+	}
+	if err, ok := err.(ErrorList); ok {
+		return append(errs, err...)
+	}
+	return append(errs, err)
+}
+
+// AppendDistinct is similar to Append, but doesn't append the error if it has
+// the same message as the last error on the list.
+func (errs ErrorList) AppendDistinct(err error) ErrorList {
+	if l := len(errs); l > 0 {
+		if prev := errs[l-1]; prev != nil && err.Error() == prev.Error() {
+			return errs // The new error is the same as the last one, skip it.
+		}
+	}
+
+	return errs.Append(err)
+}
+
+// Trim the error list if it has more than limit errors. If the list is trimmed,
+// all extraneous errors are replaced with a single ErrTooManyErrors, making the
+// returned ErrorList length of limit+1.
+func (errs ErrorList) Trim(limit int) ErrorList {
+	if len(errs) <= limit {
+		return errs
+	}
+
+	return append(errs[:limit], ErrTooManyErrors)
+}

--- a/compiler/linkname.go
+++ b/compiler/linkname.go
@@ -166,7 +166,7 @@ func parseGoLinknames(fset *token.FileSet, pkgPath string, file *ast.File) ([]Go
 		}
 	}
 
-	return directives, errs.Normalize()
+	return directives, errs.ErrOrNil()
 }
 
 // goLinknameSet is a utility that enables quick lookup of whether a decl is

--- a/compiler/sources.go
+++ b/compiler/sources.go
@@ -1,0 +1,122 @@
+package compiler
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+
+	"github.com/neelance/astrewrite"
+)
+
+// sources is a slice of parsed Go sources.
+//
+// Note that the sources would normally belong to a single logical Go package,
+// but they don't have to be a real Go package (i.e. found on the file system)
+// or represent a complete package (i.e. it could be only a few source files
+// compiled by `gopherjs build foo.go bar.go`).
+type sources struct {
+	// ImportPath representing the sources, if exists. May be empty for "virtual"
+	// packages like testmain or playground-generated package.
+	ImportPath string
+	Files      []*ast.File
+	FileSet    *token.FileSet
+}
+
+// Sort the Files slice by the original source name to ensure consistent order
+// of processing. This is required for reproducible JavaScript output.
+//
+// Note this function mutates the original slice.
+func (s sources) Sort() sources {
+	sort.Slice(s.Files, func(i, j int) bool {
+		return s.FileSet.File(s.Files[i].Pos()).Name() > s.FileSet.File(s.Files[j].Pos()).Name()
+	})
+	return s
+}
+
+// Simplify returns a new sources instance with each Files entry processed by
+// astrewrite.Simplify.
+func (s sources) Simplified(typesInfo *types.Info) sources {
+	simplified := sources{
+		ImportPath: s.ImportPath,
+		FileSet:    s.FileSet,
+	}
+	for _, file := range s.Files {
+		simplified.Files = append(simplified.Files, astrewrite.Simplify(file, typesInfo, false))
+	}
+	return simplified
+}
+
+// TypeCheck the sources. Returns information about declared package types and
+// type information for the supplied AST.
+func (s sources) TypeCheck(importContext *ImportContext) (*types.Info, *types.Package, error) {
+	const errLimit = 10 // Max number of type checking errors to return.
+
+	typesInfo := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Instances:  make(map[*ast.Ident]types.Instance),
+	}
+
+	var typeErrs ErrorList
+
+	importer := packageImporter{ImportContext: importContext}
+
+	config := &types.Config{
+		Importer: &importer,
+		Sizes:    sizes32,
+		Error:    func(err error) { typeErrs = typeErrs.AppendDistinct(err) },
+	}
+	typesPkg, err := config.Check(s.ImportPath, s.FileSet, s.Files, typesInfo)
+	// If we encountered any import errors, it is likely that the other type errors
+	// are not meaningful and would be resolved by fixing imports. Return them
+	// separately, if any. https://github.com/gopherjs/gopherjs/issues/119.
+	if importer.Errors.ErrOrNil() != nil {
+		return nil, nil, importer.Errors.Trim(errLimit).ErrOrNil()
+	}
+	// Return any other type errors.
+	if typeErrs.ErrOrNil() != nil {
+		return nil, nil, typeErrs.Trim(errLimit).ErrOrNil()
+	}
+	// Any general errors that may have occurred during type checking.
+	if err != nil {
+		return nil, nil, err
+	}
+	return typesInfo, typesPkg, nil
+}
+
+// ParseGoLinknames extracts all //go:linkname compiler directive from the sources.
+func (s sources) ParseGoLinknames() ([]GoLinkname, error) {
+	goLinknames := []GoLinkname{}
+	var errs ErrorList
+	for _, file := range s.Files {
+		found, err := parseGoLinknames(s.FileSet, s.ImportPath, file)
+		errs = errs.Append(err)
+		goLinknames = append(goLinknames, found...)
+	}
+	return goLinknames, errs.ErrOrNil()
+}
+
+// packageImporter implements go/types.Importer interface.
+type packageImporter struct {
+	ImportContext *ImportContext
+	Errors        ErrorList
+}
+
+func (pi *packageImporter) Import(path string) (*types.Package, error) {
+	if path == "unsafe" {
+		return types.Unsafe, nil
+	}
+
+	a, err := pi.ImportContext.Import(path)
+	if err != nil {
+		pi.Errors = pi.Errors.AppendDistinct(err)
+		return nil, err
+	}
+
+	return pi.ImportContext.Packages[a.ImportPath], nil
+}


### PR DESCRIPTION
This is the first step in reducing complexity of the compiler.Compile function.

The new `sources` type represents all inputs into the package compilation and simplifies extracting useful information out of them. It is designed to have little business logic of its own and serves as a convenient bridge to other packages like go/types or astrewrite.

The ErrorList type is extended with utility methods that reduce verbosity of the calling code.

/cc @paralin 