### PR TITLE
Replace type-switch with a sequence of ifs.

### DIFF
--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -72,14 +72,16 @@ func FuncKey(d *ast.FuncDecl) string {
 	if d.Recv == nil || len(d.Recv.List) == 0 {
 		return d.Name.Name
 	}
+	// Each if-statement progressively unwraps receiver type expression.
 	recv := d.Recv.List[0].Type
-	switch r := recv.(type) {
-	case *ast.StarExpr:
-		recv = r.X
-	case *ast.IndexExpr:
-		recv = r.X
-	case *ast.IndexListExpr:
-		recv = r.X
+	if star, ok := recv.(*ast.StarExpr); ok {
+		recv = star.X
+	}
+	if index, ok := recv.(*ast.IndexExpr); ok {
+		recv = index.X
+	}
+	if index, ok := recv.(*ast.IndexListExpr); ok {
+		recv = index.X
 	}
 	return recv.(*ast.Ident).Name + "." + d.Name.Name
 }


### PR DESCRIPTION
Turns out, for a method like `func (v *value[T]) get() T {...}` first `*ast.StarExpr` is unwrapped and then `*ast.IndexExpr`. Using a type-switch allows only one of them to be unwrapped.

I also enabled branch protection on the generics branch to catch this type of issue before merge.