### PR TITLE
Additional nil checks around NodeJS APIs.

### DIFF
--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -80,7 +80,7 @@ func init() {
 
 func GOROOT() string {
 	process := js.Global.Get("process")
-	if process == js.Undefined {
+	if process == js.Undefined || process.Get("env") == js.Undefined {
 		return "/"
 	}
 	if v := process.Get("env").Get("GOPHERJS_GOROOT"); v != js.Undefined && v.String() != "" {

--- a/compiler/natives/src/syscall/syscall_js_wasm.go
+++ b/compiler/natives/src/syscall/syscall_js_wasm.go
@@ -10,6 +10,9 @@ func runtime_envs() []string {
 		return nil
 	}
 	jsEnv := process.Get("env")
+	if jsEnv.IsUndefined() {
+		return nil
+	}
 	envkeys := js.Global().Get("Object").Call("keys", jsEnv)
 	envs := make([]string, envkeys.Length())
 	for i := 0; i < envkeys.Length(); i++ {


### PR DESCRIPTION
These changes make gopherjs work correctly in environments with fake `$global.process` object, which may be missing some of the properties. Specifically, when Go's `wasm_exec.js` is used, it fakes that object, but only partially. So if a gopherjs program was loaded in the same context as a Go wasm program, gopherjs would throw an undefined property exception.