### PR TITLE
Refactoring and readability improvements to function/method generation code

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -177,7 +177,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		}
 
 	case *ast.FuncLit:
-		_, fun := translateFunction(e.Type, nil, e.Body, fc, exprType.(*types.Signature), fc.pkgCtx.FuncLitInfos[e], "")
+		fun := fc.nestedFunctionContext(fc.pkgCtx.FuncLitInfos[e], exprType.(*types.Signature)).translateFunctionBody(e.Type, nil, e.Body, "")
 		if len(fc.pkgCtx.escapingVars) != 0 {
 			names := make([]string, 0, len(fc.pkgCtx.escapingVars))
 			for obj := range fc.pkgCtx.escapingVars {

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -691,10 +691,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 					}
 				}
 
-				methodName := sel.Obj().Name()
-				if reservedKeywords[methodName] {
-					methodName += "$"
-				}
+				methodName := fc.methodName(sel.Obj().(*types.Func))
 				return fc.translateCall(e, sig, fc.formatExpr("%s.%s", recv, methodName))
 
 			case types.FieldVal:

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -128,11 +128,6 @@ func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl) []byte {
 	}
 
 	if isPointer {
-		if _, isArray := ptr.Elem().Underlying().(*types.Array); isArray {
-			code.Write(primaryFunction(prototypeVar))
-			code.Write(proxyFunction(ptrPrototypeVar, fmt.Sprintf("(new %s(this.$get()))", typeName)))
-			return code.Bytes()
-		}
 		return primaryFunction(ptrPrototypeVar)
 	}
 

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -1,0 +1,359 @@
+package compiler
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/analysis"
+	"github.com/gopherjs/gopherjs/compiler/astutil"
+	"github.com/gopherjs/gopherjs/compiler/typesutil"
+)
+
+// functions.go contains logic responsible for translating top-level functions
+// and function literals.
+
+// newFunctionContext creates a new nested context for a function corresponding
+// to the provided info.
+func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, sig *types.Signature) *funcContext {
+	if info == nil {
+		panic(fmt.Errorf("missing *analysis.FuncInfo"))
+	}
+	if sig == nil {
+		panic(fmt.Errorf("missing *types.Signature"))
+	}
+
+	c := &funcContext{
+		FuncInfo:    info,
+		pkgCtx:      fc.pkgCtx,
+		genericCtx:  fc.genericCtx,
+		parent:      fc,
+		sigTypes:    &signatureTypes{Sig: sig},
+		allVars:     make(map[string]int, len(fc.allVars)),
+		localVars:   []string{},
+		flowDatas:   map[*types.Label]*flowData{nil: {}},
+		caseCounter: 1,
+		labelCases:  make(map[*types.Label]int),
+	}
+	// Register all variables from the parent context to avoid shadowing.
+	for k, v := range fc.allVars {
+		c.allVars[k] = v
+	}
+
+	return c
+}
+
+// translateTopLevelFunction translates a top-level function declaration
+// (standalone function or method) into a corresponding JS function.
+//
+// Returns a string with a JavaScript statements that define the function or
+// method. For generic functions it returns a generic factory function, which
+// instantiates the actual function at runtime given type parameters. For
+// methods it returns declarations for both value- and pointer-receiver (if
+// appropriate).
+func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl) []byte {
+	if fun.Recv == nil {
+		return fc.translateStandaloneFunction(fun)
+	}
+
+	o := fc.pkgCtx.Defs[fun.Name].(*types.Func)
+	info := fc.pkgCtx.FuncDeclInfos[o]
+
+	sig := o.Type().(*types.Signature)
+	var recv *ast.Ident
+	if fun.Recv.List[0].Names != nil {
+		recv = fun.Recv.List[0].Names[0]
+	}
+	nestedFC := fc.nestedFunctionContext(info, sig)
+
+	// primaryFunction generates a JS function equivalent of the current Go function
+	// and assigns it to the JS variable defined by lvalue.
+	primaryFunction := func(lvalue string) []byte {
+		if fun.Body == nil {
+			return []byte(fmt.Sprintf("\t%s = function() {\n\t\t$throwRuntimeError(\"native function not implemented: %s\");\n\t};\n", lvalue, o.FullName()))
+		}
+
+		funDef := nestedFC.translateFunctionBody(fun.Type, recv, fun.Body, lvalue)
+		return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, funDef))
+	}
+
+	code := bytes.NewBuffer(nil)
+
+	recvType := sig.Recv().Type()
+	ptr, isPointer := recvType.(*types.Pointer)
+	namedRecvType, _ := recvType.(*types.Named)
+	if isPointer {
+		namedRecvType = ptr.Elem().(*types.Named)
+	}
+	typeName := fc.objectName(namedRecvType.Obj())
+	funName := fun.Name.Name
+	if reservedKeywords[funName] {
+		funName += "$"
+	}
+
+	// Objects the method should be assigned to.
+	prototypeVar := fmt.Sprintf("%s.prototype.%s", typeName, funName)
+	ptrPrototypeVar := fmt.Sprintf("$ptrType(%s).prototype.%s", typeName, funName)
+	isGeneric := signatureTypes{Sig: sig}.IsGeneric()
+	if isGeneric {
+		// Generic method factories are assigned to the generic type factory
+		// properties, to be invoked at type construction time rather than method
+		// call time.
+		prototypeVar = fmt.Sprintf("%s.methods.%s", typeName, funName)
+		ptrPrototypeVar = fmt.Sprintf("%s.ptrMethods.%s", typeName, funName)
+	}
+
+	// proxyFunction generates a JS function that forwards the call to the actual
+	// method implementation for the alternate receiver (e.g. pointer vs
+	// non-pointer).
+	proxyFunction := func(lvalue, receiver string) []byte {
+		params := strings.Join(nestedFC.funcParamVars(fun.Type), ", ")
+		fun := fmt.Sprintf("function(%s) { return %s.%s(%s); }", params, receiver, funName, params)
+		if isGeneric {
+			// For a generic function, we wrap the proxy function in a trivial generic
+			// factory function for consistency. It is the same for any possible type
+			// arguments, so we simply ignore them.
+			fun = fmt.Sprintf("function() { return %s; }", fun)
+		}
+		return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, fun))
+	}
+
+	if _, isStruct := namedRecvType.Underlying().(*types.Struct); isStruct {
+		code.Write(primaryFunction(ptrPrototypeVar))
+		code.Write(proxyFunction(prototypeVar, "this.$val"))
+		return code.Bytes()
+	}
+
+	if isPointer {
+		if _, isArray := ptr.Elem().Underlying().(*types.Array); isArray {
+			code.Write(primaryFunction(prototypeVar))
+			code.Write(proxyFunction(ptrPrototypeVar, fmt.Sprintf("(new %s(this.$get()))", typeName)))
+			return code.Bytes()
+		}
+		return primaryFunction(ptrPrototypeVar)
+	}
+
+	recvExpr := "this.$get()"
+	if typesutil.IsGeneric(recvType) {
+		recvExpr = fmt.Sprintf("%s.wrap(%s)", typeName, recvExpr)
+	} else if isWrapped(recvType) {
+		recvExpr = fmt.Sprintf("new %s(%s)", typeName, recvExpr)
+	}
+	code.Write(primaryFunction(prototypeVar))
+	code.Write(proxyFunction(ptrPrototypeVar, recvExpr))
+	return code.Bytes()
+}
+
+// translateStandaloneFunction translates a package-level function.
+//
+// It returns a JS statements which define the corresponding function in a
+// package context. Exported functions are also assigned to the `$pkg` object.
+func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl) []byte {
+	o := fc.pkgCtx.Defs[fun.Name].(*types.Func)
+	info := fc.pkgCtx.FuncDeclInfos[o]
+	sig := o.Type().(*types.Signature)
+
+	if fun.Recv != nil {
+		panic(fmt.Errorf("expected standalone function, got method: %s", o))
+	}
+
+	lvalue := fc.objectName(o)
+	if fun.Body == nil {
+		return []byte(fmt.Sprintf("\t%s = function() {\n\t\t$throwRuntimeError(\"native function not implemented: %s\");\n\t};\n", lvalue, o.FullName()))
+	}
+	body := fc.nestedFunctionContext(info, sig).translateFunctionBody(fun.Type, nil, fun.Body, lvalue)
+
+	code := &bytes.Buffer{}
+	fmt.Fprintf(code, "\t%s = %s;\n", lvalue, body)
+	if fun.Name.IsExported() {
+		fmt.Fprintf(code, "\t$pkg.%s = %s;\n", encodeIdent(fun.Name.Name), lvalue)
+	}
+	return code.Bytes()
+}
+
+func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt, funcRef string) string {
+	functionName := "" // Function object name, i.e. identifier after the "function" keyword.
+	if funcRef == "" {
+		// Assign a name for the anonymous function.
+		funcRef = "$b"
+		functionName = " $b"
+	}
+
+	// For regular functions instance is directly in the function variable name.
+	instanceVar := funcRef
+	if fc.sigTypes.IsGeneric() {
+		fc.genericCtx = &genericCtx{}
+		// For generic function, funcRef refers to the generic factory function,
+		// allocate a separate variable for a function instance.
+		instanceVar = fc.newVariable("instance", varGenericFactory)
+	}
+
+	prevEV := fc.pkgCtx.escapingVars
+
+	params := fc.funcParamVars(typ)
+
+	bodyOutput := string(fc.CatchOutput(fc.bodyIndent(), func() {
+		if len(fc.Blocking) != 0 {
+			fc.pkgCtx.Scopes[body] = fc.pkgCtx.Scopes[typ]
+			fc.handleEscapingVars(body)
+		}
+
+		if fc.sigTypes != nil && fc.sigTypes.HasNamedResults() {
+			fc.resultNames = make([]ast.Expr, fc.sigTypes.Sig.Results().Len())
+			for i := 0; i < fc.sigTypes.Sig.Results().Len(); i++ {
+				result := fc.sigTypes.Sig.Results().At(i)
+				fc.Printf("%s = %s;", fc.objectName(result), fc.translateExpr(fc.zeroValue(result.Type())).String())
+				id := ast.NewIdent("")
+				fc.pkgCtx.Uses[id] = result
+				fc.resultNames[i] = fc.setType(id, result.Type())
+			}
+		}
+
+		if recv != nil && !isBlank(recv) {
+			this := "this"
+			if isWrapped(fc.pkgCtx.TypeOf(recv)) {
+				this = "this.$val" // Unwrap receiver value.
+			}
+			fc.Printf("%s = %s;", fc.translateExpr(recv), this)
+		}
+
+		fc.translateStmtList(body.List)
+		if len(fc.Flattened) != 0 && !astutil.EndsWithReturn(body.List) {
+			fc.translateStmt(&ast.ReturnStmt{}, nil)
+		}
+	}))
+
+	sort.Strings(fc.localVars)
+
+	var prefix, suffix string
+
+	if len(fc.Flattened) != 0 {
+		fc.localVars = append(fc.localVars, "$s")
+		prefix = prefix + " $s = $s || 0;"
+	}
+
+	if fc.HasDefer {
+		fc.localVars = append(fc.localVars, "$deferred")
+		suffix = " }" + suffix
+		if len(fc.Blocking) != 0 {
+			suffix = " }" + suffix
+		}
+	}
+
+	localVarDefs := "" // Function-local var declaration at the top.
+
+	if len(fc.Blocking) != 0 {
+		localVars := append([]string{}, fc.localVars...)
+		// There are several special variables involved in handling blocking functions:
+		// $r is sometimes used as a temporary variable to store blocking call result.
+		// $c indicates that a function is being resumed after a blocking call when set to true.
+		// $f is an object used to save and restore function context for blocking calls.
+		localVars = append(localVars, "$r")
+		// If a blocking function is being resumed, initialize local variables from the saved context.
+		localVarDefs = fmt.Sprintf("var {%s, $c} = $restore(this, {%s});\n", strings.Join(localVars, ", "), strings.Join(params, ", "))
+		// If the function gets blocked, save local variables for future.
+		saveContext := fmt.Sprintf("var $f = {$blk: %s, $c: true, $r, %s};", instanceVar, strings.Join(fc.localVars, ", "))
+
+		suffix = " " + saveContext + "return $f;" + suffix
+	} else if len(fc.localVars) > 0 {
+		// Non-blocking functions simply declare local variables with no need for restore support.
+		localVarDefs = fmt.Sprintf("var %s;\n", strings.Join(fc.localVars, ", "))
+	}
+
+	if fc.HasDefer {
+		prefix = prefix + " var $err = null; try {"
+		deferSuffix := " } catch(err) { $err = err;"
+		if len(fc.Blocking) != 0 {
+			deferSuffix += " $s = -1;"
+		}
+		if fc.resultNames == nil && fc.sigTypes.HasResults() {
+			deferSuffix += fmt.Sprintf(" return%s;", fc.translateResults(nil))
+		}
+		deferSuffix += " } finally { $callDeferred($deferred, $err);"
+		if fc.resultNames != nil {
+			deferSuffix += fmt.Sprintf(" if (!$curGoroutine.asleep) { return %s; }", fc.translateResults(fc.resultNames))
+		}
+		if len(fc.Blocking) != 0 {
+			deferSuffix += " if($curGoroutine.asleep) {"
+		}
+		suffix = deferSuffix + suffix
+	}
+
+	if len(fc.Flattened) != 0 {
+		prefix = prefix + " s: while (true) { switch ($s) { case 0:"
+		suffix = " } return; }" + suffix
+	}
+
+	if fc.HasDefer {
+		prefix = prefix + " $deferred = []; $curGoroutine.deferStack.push($deferred);"
+	}
+
+	if prefix != "" {
+		bodyOutput = fc.Indentation(fc.bodyIndent()) + "/* */" + prefix + "\n" + bodyOutput
+	}
+	if suffix != "" {
+		bodyOutput = bodyOutput + fc.Indentation(fc.bodyIndent()) + "/* */" + suffix + "\n"
+	}
+	if localVarDefs != "" {
+		bodyOutput = fc.Indentation(fc.bodyIndent()) + localVarDefs + bodyOutput
+	}
+
+	fc.pkgCtx.escapingVars = prevEV
+
+	if !fc.sigTypes.IsGeneric() {
+		return fmt.Sprintf("function%s(%s) {\n%s%s}", functionName, strings.Join(params, ", "), bodyOutput, fc.Indentation(0))
+	}
+
+	// Generic functions are generated as factories to allow passing type parameters
+	// from the call site.
+	// TODO(nevkontakte): Cache function instances for a given combination of type
+	// parameters.
+	typeParams := fc.typeParamVars(fc.sigTypes.Sig.TypeParams())
+	typeParams = append(typeParams, fc.typeParamVars(fc.sigTypes.Sig.RecvTypeParams())...)
+
+	// anonymous types
+	typesInit := strings.Builder{}
+	for _, t := range fc.genericCtx.anonTypes.Ordered() {
+		fmt.Fprintf(&typesInit, "%svar %s = $%sType(%s);\n", fc.Indentation(1), t.Name(), strings.ToLower(typeKind(t.Type())[5:]), fc.initArgs(t.Type()))
+	}
+
+	code := &strings.Builder{}
+	fmt.Fprintf(code, "function%s(%s){\n", functionName, strings.Join(typeParams, ", "))
+	fmt.Fprintf(code, "%s", typesInit.String())
+	fmt.Fprintf(code, "%sconst %s = function(%s) {\n", fc.Indentation(1), instanceVar, strings.Join(params, ", "))
+	fmt.Fprintf(code, "%s", bodyOutput)
+	fmt.Fprintf(code, "%s};\n", fc.Indentation(1))
+	// meta, _ := fc.methodListEntry(fc.pkgCtx.Defs[typ.Name].(*types.Func))
+	// fmt.Fprintf(code, "%s%s.metadata = %s", fc.Indentation(1), instanceVar, meta)
+	fmt.Fprintf(code, "%sreturn %s;\n", fc.Indentation(1), instanceVar)
+	fmt.Fprintf(code, "%s}", fc.Indentation(0))
+	return code.String()
+}
+
+// funcParamVars returns a list of JS variables corresponding to the function
+// parameters in the order they are defined in the signature. Unnamed or blank
+// parameters are assigned unique synthetic names.
+//
+// Note that JS doesn't allow blank or repeating function argument names, so
+// we must assign unique names to all such blank variables.
+func (fc *funcContext) funcParamVars(typ *ast.FuncType) []string {
+	var params []string
+	for _, param := range typ.Params.List {
+		if len(param.Names) == 0 {
+			params = append(params, fc.newBlankVariable(param.Pos()))
+			continue
+		}
+		for _, ident := range param.Names {
+			if isBlank(ident) {
+				params = append(params, fc.newBlankVariable(ident.Pos()))
+				continue
+			}
+			params = append(params, fc.objectName(fc.pkgCtx.Defs[ident]))
+		}
+	}
+
+	return params
+}

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -488,6 +488,20 @@ func (fc *funcContext) objectName(o types.Object) string {
 	return name
 }
 
+// methodName returns a JS identifier (specifically, object property name)
+// corresponding to the given method.
+func (fc *funcContext) methodName(fun *types.Func) string {
+	if fun.Type().(*types.Signature).Recv() == nil {
+		panic(fmt.Errorf("expected a method, got a standalone function %v", fun))
+	}
+	name := fun.Name()
+	// Method names are scoped to their receiver type and guaranteed to be
+	// unique within that, so we only need to make sure it's not a reserved keyword
+	if reservedKeywords[name] {
+		name += "$"
+	}
+	return name
+}
 func (fc *funcContext) varPtrName(o *types.Var) string {
 	if getVarLevel(o) == varPackage && o.Exported() {
 		return fc.pkgVar(o.Pkg()) + "." + o.Name() + "$ptr"

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -292,6 +292,23 @@ func (fc *funcContext) newLocalVariable(name string) string {
 	return fc.newVariable(name, varFuncLocal)
 }
 
+// newBlankVariable assigns a new JavaScript variable name for a blank Go
+// variable, such as a `_` variable or an unnamed function parameter.
+// Such variables can't be referenced by the Go code anywhere aside from where
+// it is defined, so position is a good key for it.
+func (fc *funcContext) newBlankVariable(pos token.Pos) string {
+	if !pos.IsValid() {
+		panic("valid position is required to assign a blank variable name")
+	}
+	if name, ok := fc.pkgCtx.blankVarNames[pos]; ok {
+		return name
+	}
+
+	name := fc.newLocalVariable("blank")
+	fc.pkgCtx.blankVarNames[pos] = name
+	return name
+}
+
 // varLevel specifies at which level a JavaScript variable should be declared.
 type varLevel int
 


### PR DESCRIPTION
This PR contains several commits that split up the two giant `translateTopLevelFunction()` and `translateFunction()` functions into more manageable pieces. Where possible I tried to add explanations for subtle and non-obvious aspects of the code - to the best of my ability to infer them (largely through breaking them and observing the results).

This refactoring should be functionally-neutral.

/cc @paralin 

Updates #1013.