### PR TITLE
Assign identity to all function literals and use them as funcRefs.

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -177,7 +177,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		}
 
 	case *ast.FuncLit:
-		fun := fc.nestedFunctionContext(fc.pkgCtx.FuncLitInfos[e], exprType.(*types.Signature)).translateFunctionBody(e.Type, nil, e.Body, "")
+		fun := fc.literalFuncContext(e).translateFunctionBody(e.Type, nil, e.Body)
 		if len(fc.pkgCtx.escapingVars) != 0 {
 			names := make([]string, 0, len(fc.pkgCtx.escapingVars))
 			for obj := range fc.pkgCtx.escapingVars {

--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1734,13 +1734,14 @@ func methodNameSkip() string {
 	}
 	// Function name extracted from the call stack can be different from vanilla
 	// Go. Here we try to fix stuff like "Object.$packages.reflect.Q.ptr.SetIterKey"
-	// into "Value.SetIterKey".
+	// or plain "SetIterKey" into "Value.SetIterKey".
 	// This workaround may become obsolete after https://github.com/gopherjs/gopherjs/issues/1085
 	// is resolved.
 	name := f.Name()
 	idx := len(name) - 1
 	for idx > 0 {
 		if name[idx] == '.' {
+			idx++
 			break
 		}
 		idx--
@@ -1748,7 +1749,7 @@ func methodNameSkip() string {
 	if idx < 0 {
 		return name
 	}
-	return "Value" + name[idx:]
+	return "Value." + name[idx:]
 }
 
 func verifyNotInHeapPtr(p uintptr) bool {

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -94,6 +94,15 @@ func (sel *fakeSelection) Type() types.Type          { return sel.typ }
 // JavaScript code (as defined for `var` declarations).
 type funcContext struct {
 	*analysis.FuncInfo
+	// Function object this context corresponds to, or nil if the context is
+	// top-level or doesn't correspond to a function. For function literals, this
+	// is a synthetic object that assigns a unique identity to the function.
+	funcObject *types.Func
+	// JavaScript identifier assigned to the function object (the word after the
+	// "function" keyword in the generated code). This identifier can be used
+	// within the function scope to reference the function object. It will also
+	// appear in the stack trace.
+	funcRef string
 	// Surrounding package context.
 	pkgCtx *pkgContext
 	// Surrounding generic function context. nil if non-generic code.
@@ -137,6 +146,8 @@ type funcContext struct {
 	posAvailable bool
 	// Current position in the Go source code.
 	pos token.Pos
+	// Number of function literals encountered within the current function context.
+	funcLitCounter int
 }
 
 // newRootCtx creates a new package-level instance of a functionContext object.


### PR DESCRIPTION
The main change is that we assign explicit names to all function objects that correspond to Go functions (named and literals). Function name is declared as `var f = function nameHere() { ... }` and is visible inside the function scope only. Doing so serves two purposes:

 - It is an identifier which we can use when saving state of a blocked function to know which function to call upon resumption.
 - It shows up in the stack trace, which helps distinguish similarly-named functions. For methods, we include the receiver type in the identifier to make A.String and B.String easily distinguishable.

The main trick is that we synthesize names for the function literals, which are anonymous as far as go/types is concerned. The upstream Go compiler does something very similar.

Lest but not least, with this change the generic-related code path in the funcContext.translateFunctionBody becomes more self-contained, which will become handy in the upcoming commits.

Updates #1013 

/cc @paralin 