### PR TITLE
Fix two bugs related to type conversion

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1183,7 +1183,7 @@ func (fc *funcContext) translateConversion(expr ast.Expr, desiredType types.Type
 			//
 			// TODO(nevkontakte): Should this only apply when exprType is a pointer to a
 			// struct as well?
-			return fc.formatExpr("$pointerOfStructConversion(%e, %s)", expr, fc.typeName(t))
+			return fc.formatExpr("$pointerOfStructConversion(%e, %s)", expr, fc.typeName(desiredType))
 		}
 
 		if types.Identical(exprType, types.Typ[types.UnsafePointer]) {

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -719,7 +719,7 @@ func (fc *funcContext) translateAssign(lhs, rhs ast.Expr, define bool) string {
 	}
 
 	lhsType := fc.pkgCtx.TypeOf(lhs)
-	rhsExpr := fc.translateImplicitConversion(rhs, lhsType)
+	rhsExpr := fc.translateConversion(rhs, lhsType)
 	if _, ok := rhs.(*ast.CompositeLit); ok && define {
 		return fmt.Sprintf("%s = %s;", fc.translateExpr(lhs), rhsExpr) // skip $copy
 	}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -187,6 +187,8 @@ func TestPointerOfStructConversion(t *testing.T) {
 
 	type B A
 
+	type AP *A
+
 	a1 := &A{Value: 1}
 	b1 := (*B)(a1)
 	b1.Value = 2
@@ -196,6 +198,10 @@ func TestPointerOfStructConversion(t *testing.T) {
 	b2.Value = 4
 	if a1 != a2 || b1 != b2 || a1.Value != 4 || a2.Value != 4 || b1.Value != 4 || b2.Value != 4 {
 		t.Fail()
+	}
+
+	if got := reflect.TypeOf((AP)(&A{Value: 1})); got.String() != "tests.AP" {
+		t.Errorf("Got: reflect.TypeOf((AP)(&A{Value: 1})) = %v. Want: tests.AP.", got)
 	}
 }
 

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -894,3 +894,29 @@ func TestReflectSetForEmbed(t *testing.T) {
 		t.Fatalf("relfect.Set got %v, want %v", f0, e.Field(0))
 	}
 }
+
+func TestAssignImplicitConversion(t *testing.T) {
+	type S struct{}
+	type SP *S
+
+	t.Run("Pointer to named type", func(t *testing.T) {
+		var sp SP = &S{}
+		if got := reflect.TypeOf(sp); got.String() != "tests.SP" {
+			t.Errorf("Got: reflect.TypeOf(sp) = %v. Want: tests.SP", got)
+		}
+	})
+
+	t.Run("Anonymous struct to named type", func(t *testing.T) {
+		var s S = struct{}{}
+		if got := reflect.TypeOf(s); got.String() != "tests.S" {
+			t.Errorf("Got: reflect.TypeOf(s) = %v. Want: tests.S", got)
+		}
+	})
+
+	t.Run("Named type to anonymous type", func(t *testing.T) {
+		var x struct{} = S{}
+		if got := reflect.TypeOf(x); got.String() != "struct {}" {
+			t.Errorf("Got: reflect.TypeOf(x) = %v. Want: struct {}", got)
+		}
+	})
+}


### PR DESCRIPTION
 - When converting between pointers to structs, gopherjs incorrectly used underlying type as a conversion target.
 - Assignment operator didn't handle implicit type conversion between named and anonymous types.