### PR TITLE
Diagnose some of the typeparam test failures.

### DIFF
--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -111,9 +111,6 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue23188.go":  {desc: "incorrect order of evaluation of index operations"},
 	"fixedbugs/issue24547.go":  {desc: "incorrect computing method sets with shadowed methods"},
 
-	// These are new tests in Go 1.11.5
-	"fixedbugs/issue28688.go": {category: notApplicable, desc: "testing runtime optimisations"},
-
 	// These are new tests in Go 1.12.
 	"fixedbugs/issue23837.go":  {desc: "missing panic on nil pointer-to-empty-struct dereference"},
 	"fixedbugs/issue27201.go":  {desc: "incorrect stack trace for nil dereference in inlined function"},
@@ -123,7 +120,6 @@ var knownFails = map[string]failReason{
 	// These are new tests in Go 1.12.9.
 	"fixedbugs/issue30977.go": {category: neverTerminates, desc: "does for { runtime.GC() }"},
 	"fixedbugs/issue32477.go": {category: notApplicable, desc: "uses runtime.SetFinalizer and runtime.GC"},
-	"fixedbugs/issue32680.go": {category: notApplicable, desc: "uses -gcflags=-d=ssa/check/on flag"},
 
 	// These are new tests in Go 1.13-1.16.
 	"fixedbugs/issue19113.go":  {category: lowLevelRuntimeDifference, desc: "JavaScript bit shifts by negative amount don't cause an exception"},
@@ -136,7 +132,6 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue30116u.go": {desc: "GopherJS doesn't specify the array/slice index selector in the out-of-bounds message"},
 	"fixedbugs/issue34395.go":  {category: neverTerminates, desc: "https://github.com/gopherjs/gopherjs/issues/1007"},
 	"fixedbugs/issue35027.go":  {category: usesUnsupportedPackage, desc: "uses unsupported conversion to reflect.SliceHeader and -gcflags=-d=checkptr"},
-	"fixedbugs/issue35073.go":  {category: usesUnsupportedPackage, desc: "uses unsupported flag -gcflags=-d=checkptr"},
 	"fixedbugs/issue35576.go":  {category: lowLevelRuntimeDifference, desc: "GopherJS print/println format for floats differs from Go's"},
 	"fixedbugs/issue40917.go":  {category: notApplicable, desc: "uses pointer arithmetic and unsupported flag -gcflags=-d=checkptr"},
 
@@ -151,7 +146,6 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue50854.go": {category: lowLevelRuntimeDifference, desc: "negative int32 overflow behaves differently in JS"},
 
 	// These are new tests in Go 1.18
-	"fixedbugs/issue46938.go": {category: notApplicable, desc: "tests -d=checkptr compiler mode, which GopherJS doesn't support"},
 	"fixedbugs/issue47928.go": {category: notApplicable, desc: "//go:nointerface is a part of GOEXPERIMENT=fieldtrack and is not supported by GopherJS"},
 	"fixedbugs/issue48898.go": {category: other, desc: "https://github.com/gopherjs/gopherjs/issues/1128"},
 	"fixedbugs/issue48536.go": {category: usesUnsupportedPackage, desc: "https://github.com/gopherjs/gopherjs/issues/1130"},
@@ -160,44 +154,43 @@ var knownFails = map[string]failReason{
 	// Failures related to the lack of generics support. Ideally, this section
 	// should be emptied once https://github.com/gopherjs/gopherjs/issues/1013 is
 	// fixed.
-	"typeparam/absdiff.go":                    {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/absdiff2.go":                   {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/absdiff3.go":                   {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/boundmethod.go":                {category: generics, desc: "missing support for type conversion of a parameterized type"},
-	"typeparam/chans.go":                      {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/dictionaryCapture-noinline.go": {category: generics, desc: "attempts to pass -gcflags=\"-G=3\" flag, incorrectly parsed by run.go"},
-	"typeparam/dictionaryCapture.go":          {category: generics, desc: "missing support for conversion into a parameterized type"},
-	"typeparam/double.go":                     {category: generics, desc: "make() doesn't support generic slice types"},
-	"typeparam/equal.go":                      {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/fact.go":                       {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/graph.go":                      {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/index.go":                      {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/index2.go":                     {category: generics, desc: "missing index operator support for generic types"},
-	"typeparam/issue23536.go":                 {category: generics, desc: "missing support for generic byte/rune slice to string conversion"},
-	"typeparam/issue47258.go":                 {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/issue47716.go":                 {category: generics, desc: "unsafe.Sizeof() doesn't work with generic types"},
-	"typeparam/issue48276a.go":                {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/issue48453.go":                 {category: generics, desc: "make() doesn't support generic slice types"},
-	"typeparam/issue49295.go":                 {category: generics, desc: "len() doesn't support generic pointer to array types"},
-	"typeparam/issue50193.go":                 {category: generics, desc: "invalid print format for complex numbers"},
-	"typeparam/issue50833.go":                 {category: generics, desc: "undiagnosed: compiler panic triggered by a composite literal"},
-	"typeparam/issue51303.go":                 {category: generics, desc: "missing support for conversion into a parameterized type"},
-	"typeparam/issue51522a.go":                {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/issue51522b.go":                {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/issue51733.go":                 {category: generics, desc: "undiagnosed: unsafe.Pointer to struct pointer conversion"},
-	"typeparam/list.go":                       {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/maps.go":                       {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/metrics.go":                    {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/nested.go":                     {category: generics, desc: "missing comparison operator support for generic types"},
-	"typeparam/ordered.go":                    {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/orderedmap.go":                 {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/sets.go":                       {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/settable.go":                   {category: generics, desc: "undiagnosed: len() returns an invalid value on a generic function result"},
-	"typeparam/slices.go":                     {category: generics, desc: "missing operator support for generic types"},
-	"typeparam/subdict.go":                    {category: generics, desc: "undiagnosed: runtime error: comparing uncomparable type undefined"},
-	"typeparam/typeswitch2.go":                {category: generics, desc: "complex types have different print() format"},
-	"typeparam/typeswitch3.go":                {category: generics, desc: "missing support for type switching on generic types"},
-	"typeparam/typeswitch5.go":                {category: generics, desc: "different print() format for floating point types"},
+	"typeparam/absdiff.go":           {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/absdiff2.go":          {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/absdiff3.go":          {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/boundmethod.go":       {category: generics, desc: "missing support for type conversion of a parameterized type"},
+	"typeparam/chans.go":             {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/dictionaryCapture.go": {category: generics, desc: "missing support for conversion into a parameterized type"},
+	"typeparam/double.go":            {category: generics, desc: "make() doesn't support generic slice types"},
+	"typeparam/equal.go":             {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/fact.go":              {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/graph.go":             {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/index.go":             {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/index2.go":            {category: generics, desc: "missing index operator support for generic types"},
+	"typeparam/issue23536.go":        {category: generics, desc: "missing support for generic byte/rune slice to string conversion"},
+	"typeparam/issue47258.go":        {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/issue47716.go":        {category: generics, desc: "unsafe.Sizeof() doesn't work with generic types"},
+	"typeparam/issue48276a.go":       {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/issue48453.go":        {category: generics, desc: "make() doesn't support generic slice types"},
+	"typeparam/issue49295.go":        {category: generics, desc: "len() doesn't support generic pointer to array types"},
+	"typeparam/issue50193.go":        {category: generics, desc: "invalid print format for complex numbers"},
+	"typeparam/issue50833.go":        {category: generics, desc: "undiagnosed: compiler panic triggered by a composite literal"},
+	"typeparam/issue51303.go":        {category: generics, desc: "missing support for conversion into a parameterized type"},
+	"typeparam/issue51522a.go":       {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/issue51522b.go":       {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/issue51733.go":        {category: generics, desc: "undiagnosed: unsafe.Pointer to struct pointer conversion"},
+	"typeparam/list.go":              {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/maps.go":              {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/metrics.go":           {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/nested.go":            {category: generics, desc: "missing comparison operator support for generic types"},
+	"typeparam/ordered.go":           {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/orderedmap.go":        {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/sets.go":              {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/settable.go":          {category: generics, desc: "undiagnosed: len() returns an invalid value on a generic function result"},
+	"typeparam/slices.go":            {category: generics, desc: "missing operator support for generic types"},
+	"typeparam/subdict.go":           {category: generics, desc: "missing support for the comparable type constraint"},
+	"typeparam/typeswitch2.go":       {category: generics, desc: "complex types have different print() format"},
+	"typeparam/typeswitch3.go":       {category: generics, desc: "missing support for type switching on generic types"},
+	"typeparam/typeswitch5.go":       {category: generics, desc: "different print() format for floating point types"},
 }
 
 type failCategory uint8
@@ -677,7 +670,11 @@ func (t *test) run() {
 
 	var args, flags []string
 	wantError := false
-	f := strings.Fields(action)
+	f, err := splitQuoted(action)
+	if err != nil {
+		t.err = fmt.Errorf("invalid test recipe: %v", err)
+		return
+	}
 	if len(f) > 0 {
 		action = f[0]
 		args = f[1:]
@@ -737,16 +734,14 @@ func (t *test) run() {
 	}
 
 	{
-		// GopherJS: we don't support -gcflags=-G=3 flag, but it's the default
-		// behavior anyway.
+		// GopherJS: we don't support any of -gcflags, but for the most part they
+		// are not too relevant to the outcome of the test.
 		supportedArgs := []string{}
 		for _, a := range args {
-			switch a {
-			case "-gcflags=-G=3", `-gcflags="-G=3"`:
+			if strings.HasPrefix(a, "-gcflags") {
 				continue
-			default:
-				supportedArgs = append(supportedArgs, a)
 			}
+			supportedArgs = append(supportedArgs, a)
 		}
 		args = supportedArgs
 	}
@@ -1314,4 +1309,66 @@ func getenv(key, def string) string {
 		return value
 	}
 	return def
+}
+
+// splitQuoted splits the string s around each instance of one or more consecutive
+// white space characters while taking into account quotes and escaping, and
+// returns an array of substrings of s or an empty list if s contains only white space.
+// Single quotes and double quotes are recognized to prevent splitting within the
+// quoted region, and are removed from the resulting substrings. If a quote in s
+// isn't closed err will be set and r will have the unclosed argument as the
+// last element. The backslash is used for escaping.
+//
+// For example, the following string:
+//
+//	a b:"c d" 'e''f'  "g\""
+//
+// Would be parsed as:
+//
+//	[]string{"a", "b:c d", "ef", `g"`}
+//
+// [copied from src/go/build/build.go]
+func splitQuoted(s string) (r []string, err error) {
+	var args []string
+	arg := make([]rune, len(s))
+	escaped := false
+	quoted := false
+	quote := '\x00'
+	i := 0
+	for _, rune := range s {
+		switch {
+		case escaped:
+			escaped = false
+		case rune == '\\':
+			escaped = true
+			continue
+		case quote != '\x00':
+			if rune == quote {
+				quote = '\x00'
+				continue
+			}
+		case rune == '"' || rune == '\'':
+			quoted = true
+			quote = rune
+			continue
+		case unicode.IsSpace(rune):
+			if quoted || i > 0 {
+				quoted = false
+				args = append(args, string(arg[:i]))
+				i = 0
+			}
+			continue
+		}
+		arg[i] = rune
+		i++
+	}
+	if quoted || i > 0 {
+		args = append(args, string(arg[:i]))
+	}
+	if quote != 0 {
+		err = errors.New("unclosed quote")
+	} else if escaped {
+		err = errors.New("unfinished escaping")
+	}
+	return args, err
 }


### PR DESCRIPTION
Also pick up more advanced run args parsing from the upstream to better deal with -gcflags flag.