### PR TITLE
gofumpt the repo

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18.10"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53.3
+          only-new-issues: true
+
+      - name: Check go.mod
+        run: |
+          go mod tidy && git diff --exit-code

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,14 @@
+[run]
+timeout = "1m"
+
+[output]
+format = "colored-line-number"
+
+[linters]
+disable-all = true
+enable = [
+    "gofumpt",
+]
+
+[issues]
+exclude-use-default = false

--- a/build/build.go
+++ b/build/build.go
@@ -730,7 +730,7 @@ func (s *Session) SourceMappingCallback(m *sourcemap.Map) func(generatedLine, ge
 
 // WriteCommandPackage writes the final JavaScript output file at pkgObj path.
 func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) error {
-	if err := os.MkdirAll(filepath.Dir(pkgObj), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(pkgObj), 0o777); err != nil {
 		return err
 	}
 	codeFile, err := os.Create(pkgObj)

--- a/build/cache/cache.go
+++ b/build/cache/cache.go
@@ -95,7 +95,7 @@ func (bc *BuildCache) StoreArchive(a *compiler.Archive) {
 		return // Caching is disabled.
 	}
 	path := cachedPath(bc.archiveKey(a.ImportPath))
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		log.Warningf("Failed to create build cache directory: %v", err)
 		return
 	}

--- a/build/embed.go
+++ b/build/embed.go
@@ -55,17 +55,21 @@ func embedFiles(pkg *PackageData, fset *token.FileSet, files []*ast.File) (*ast.
 				&ast.CallExpr{
 					Fun: em.Spec.Type,
 					Args: []ast.Expr{
-						&ast.Ident{Name: buildIdent(fs[0].Name),
-							NamePos: em.Spec.Names[0].NamePos},
+						&ast.Ident{
+							Name:    buildIdent(fs[0].Name),
+							NamePos: em.Spec.Names[0].NamePos,
+						},
 					},
-				}}
+				},
+			}
 		case goembed.EmbedBytes:
 			// value = []byte(data)
 			em.Spec.Values = []ast.Expr{
 				&ast.CallExpr{
 					Fun:  em.Spec.Type,
 					Args: []ast.Expr{ast.NewIdent(buildIdent(fs[0].Name))},
-				}}
+				},
+			}
 		case goembed.EmbedString:
 			// value = data
 			em.Spec.Values = []ast.Expr{ast.NewIdent(buildIdent(fs[0].Name))}
@@ -115,15 +119,15 @@ func embedFiles(pkg *PackageData, fset *token.FileSet, files []*ast.File) (*ast.
 							Elt: &ast.StructType{
 								Fields: &ast.FieldList{
 									List: []*ast.Field{
-										&ast.Field{
+										{
 											Names: []*ast.Ident{ast.NewIdent("name")},
 											Type:  ast.NewIdent("string"),
 										},
-										&ast.Field{
+										{
 											Names: []*ast.Ident{ast.NewIdent("data")},
 											Type:  ast.NewIdent("string"),
 										},
-										&ast.Field{
+										{
 											Names: []*ast.Ident{ast.NewIdent("hash")},
 											Type: &ast.ArrayType{
 												Len: &ast.BasicLit{Kind: token.INT, Value: "16"},

--- a/circle.yml
+++ b/circle.yml
@@ -73,9 +73,6 @@ jobs:
     steps:
     - setup_and_install_gopherjs
     - run:
-        name: Check gofmt
-        command: diff -u <(echo -n) <(gofmt -d .)
-    - run:
         name: Check go vet
         command: |
           set -e

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -21,8 +21,10 @@ import (
 	"golang.org/x/tools/go/gcexportdata"
 )
 
-var sizes32 = &types.StdSizes{WordSize: 4, MaxAlign: 8}
-var reservedKeywords = make(map[string]bool)
+var (
+	sizes32          = &types.StdSizes{WordSize: 4, MaxAlign: 8}
+	reservedKeywords = make(map[string]bool)
+)
 
 func init() {
 	for _, keyword := range []string{"abstract", "arguments", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "eval", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "let", "long", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "undefined", "var", "void", "volatile", "while", "with", "yield"} {

--- a/compiler/natives/src/embed/embed.go
+++ b/compiler/natives/src/embed/embed.go
@@ -7,7 +7,8 @@ func buildFS(list []struct {
 	name string
 	data string
 	hash [16]byte
-}) (f FS) {
+},
+) (f FS) {
 	n := len(list)
 	files := make([]file, n)
 	for i := 0; i < n; i++ {

--- a/compiler/natives/src/encoding/gob/gob_test.go
+++ b/compiler/natives/src/encoding/gob/gob_test.go
@@ -68,7 +68,7 @@ func TestEndToEnd(t *testing.T) {
 		// TODO: Fix this problem:
 		// 	TypeError: dst.$set is not a function
 		// 	    at typedmemmove (/github.com/gopherjs/gopherjs/reflect.go:487:3)
-		//Marr:     map[[2]string][2]*float64{arr1: floatArr1, arr2: floatArr2},
+		// Marr:     map[[2]string][2]*float64{arr1: floatArr1, arr2: floatArr2},
 		EmptyMap: make(map[string]int),
 		N:        &[3]float64{1.5, 2.5, 3.5},
 		Strs:     &[2]string{s1, s2},

--- a/compiler/natives/src/internal/reflectlite/all_test.go
+++ b/compiler/natives/src/internal/reflectlite/all_test.go
@@ -4,8 +4,9 @@
 package reflectlite_test
 
 import (
-	. "internal/reflectlite"
 	"testing"
+
+	. "internal/reflectlite"
 )
 
 func TestTypes(t *testing.T) {

--- a/compiler/natives/src/internal/reflectlite/reflectlite.go
+++ b/compiler/natives/src/internal/reflectlite/reflectlite.go
@@ -32,9 +32,7 @@ func init() {
 	uint8Type = TypeOf(uint8(0)).(*rtype) // set for real
 }
 
-var (
-	uint8Type *rtype
-)
+var uint8Type *rtype
 
 var (
 	idJsType      = "_jsType"
@@ -578,7 +576,7 @@ func maplen(m unsafe.Pointer) int {
 }
 
 func cvtDirect(v Value, typ Type) Value {
-	var srcVal = v.object()
+	srcVal := v.object()
 	if srcVal == jsType(v.typ).Get("nil") {
 		return makeValue(typ, jsType(typ).Get("nil"), v.flag)
 	}
@@ -914,7 +912,7 @@ func deepValueEqualJs(v1, v2 Value, visited [][2]unsafe.Pointer) bool {
 				return true
 			}
 		}
-		var n = v1.Len()
+		n := v1.Len()
 		if n != v2.Len() {
 			return false
 		}
@@ -932,7 +930,7 @@ func deepValueEqualJs(v1, v2 Value, visited [][2]unsafe.Pointer) bool {
 	case Ptr:
 		return deepValueEqualJs(v1.Elem(), v2.Elem(), visited)
 	case Struct:
-		var n = v1.NumField()
+		n := v1.NumField()
 		for i := 0; i < n; i++ {
 			if !deepValueEqualJs(v1.Field(i), v2.Field(i), visited) {
 				return false
@@ -946,7 +944,7 @@ func deepValueEqualJs(v1, v2 Value, visited [][2]unsafe.Pointer) bool {
 		if v1.object() == v2.object() {
 			return true
 		}
-		var keys = v1.MapKeys()
+		keys := v1.MapKeys()
 		if len(keys) != v2.Len() {
 			return false
 		}

--- a/compiler/natives/src/internal/reflectlite/utils.go
+++ b/compiler/natives/src/internal/reflectlite/utils.go
@@ -23,9 +23,7 @@ func (e *errorString) Error() string {
 	return e.s
 }
 
-var (
-	ErrSyntax = &errorString{"invalid syntax"}
-)
+var ErrSyntax = &errorString{"invalid syntax"}
 
 func unquote(s string) (string, error) {
 	if len(s) < 2 {

--- a/compiler/natives/src/math/math.go
+++ b/compiler/natives/src/math/math.go
@@ -7,10 +7,12 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-var math = js.Global.Get("Math")
-var _zero float64 = 0
-var posInf = 1 / _zero
-var negInf = -1 / _zero
+var (
+	math           = js.Global.Get("Math")
+	_zero  float64 = 0
+	posInf         = 1 / _zero
+	negInf         = -1 / _zero
+)
 
 // Usually, NaN can be obtained in JavaScript with `0 / 0` operation. However,
 // in V8, `0 / _zero` yields a bitwise-different value of NaN compared to the

--- a/compiler/natives/src/net/netip/export_test.go
+++ b/compiler/natives/src/net/netip/export_test.go
@@ -4,6 +4,7 @@ package netip
 
 import (
 	"fmt"
+
 	"internal/intern"
 )
 

--- a/compiler/natives/src/reflect/reflect_test.go
+++ b/compiler/natives/src/reflect/reflect_test.go
@@ -157,7 +157,7 @@ func TestIssue22073(t *testing.T) {
 	// 	TypeError: Cannot read property 'apply' of undefined
 
 	// Shouldn't panic.
-	//m.Call(nil)
+	// m.Call(nil)
 }
 
 func TestCallReturnsEmpty(t *testing.T) {

--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -7,9 +7,11 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-const GOOS = "js"
-const GOARCH = "ecmascript"
-const Compiler = "gopherjs"
+const (
+	GOOS     = "js"
+	GOARCH   = "ecmascript"
+	Compiler = "gopherjs"
+)
 
 // The Error interface identifies a run time error.
 type Error interface {

--- a/compiler/natives/src/sync/pool_test.go
+++ b/compiler/natives/src/sync/pool_test.go
@@ -24,7 +24,6 @@ func TestPool(t *testing.T) {
 			t.Fatalf("Got: p.Get() returned: %s. Want: %s.", got, want)
 		}
 	}
-
 }
 
 func TestPoolGC(t *testing.T) {

--- a/compiler/natives/src/syscall/legacy.go
+++ b/compiler/natives/src/syscall/legacy.go
@@ -6,9 +6,11 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-var syscallModule *js.Object
-var alreadyTriedToLoad = false
-var minusOne = -1
+var (
+	syscallModule      *js.Object
+	alreadyTriedToLoad = false
+	minusOne           = -1
+)
 
 var warningPrinted = false
 

--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -45,5 +45,4 @@ func Minified() string {
 		log.Fatalf("Prelude minification failed with %d errors", errCount)
 	}
 	return string(result.Code)
-
 }

--- a/tests/arrays_test.go
+++ b/tests/arrays_test.go
@@ -74,7 +74,6 @@ func TestArrayPointer(t *testing.T) {
 	})
 
 	t.Run("reflect.IsNil", func(t *testing.T) {
-
 	})
 }
 

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -125,7 +125,7 @@ func (t T) M() int {
 }
 
 func TestExplicitConversion(t *testing.T) {
-	var coolGuy = S{x: 42}
+	coolGuy := S{x: 42}
 	var i I
 	i = T(coolGuy)
 	if i.M() != 42 {
@@ -138,7 +138,7 @@ func TestCopyStructByReflect(t *testing.T) {
 	type Info struct {
 		name string
 	}
-	a := []Info{Info{"A"}, Info{"B"}, Info{"C"}}
+	a := []Info{{"A"}, {"B"}, {"C"}}
 	v := reflect.ValueOf(a)
 	i := v.Index(0).Interface()
 	a[0] = Info{"X"}

--- a/tests/deferblock_test.go
+++ b/tests/deferblock_test.go
@@ -45,7 +45,7 @@ func TestBlockingInDefer(t *testing.T) {
 
 func TestIssue1083(t *testing.T) {
 	// https://github.com/gopherjs/gopherjs/issues/1083
-	var block = make(chan bool)
+	block := make(chan bool)
 
 	recoverCompleted := false
 

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -683,7 +683,7 @@ func (t *test) run() {
 	t.makeTempDir()
 	defer os.RemoveAll(t.tempDir)
 
-	err = ioutil.WriteFile(filepath.Join(t.tempDir, t.gofile), srcBytes, 0644)
+	err = ioutil.WriteFile(filepath.Join(t.tempDir, t.gofile), srcBytes, 0o644)
 	check(err)
 
 	// A few tests (of things like the environment) require these to be set.
@@ -855,7 +855,7 @@ func (t *test) run() {
 			return
 		}
 		tfile := filepath.Join(t.tempDir, "tmp__.go")
-		if err := ioutil.WriteFile(tfile, out, 0666); err != nil {
+		if err := ioutil.WriteFile(tfile, out, 0o666); err != nil {
 			t.err = fmt.Errorf("write tempfile:%s", err)
 			return
 		}
@@ -876,7 +876,7 @@ func (t *test) run() {
 			return
 		}
 		tfile := filepath.Join(t.tempDir, "tmp__.go")
-		err = ioutil.WriteFile(tfile, out, 0666)
+		err = ioutil.WriteFile(tfile, out, 0o666)
 		if err != nil {
 			t.err = fmt.Errorf("write tempfile:%s", err)
 			return
@@ -1079,7 +1079,7 @@ func (t *test) updateErrors(out string, file string) {
 		}
 	}
 	// Write new file.
-	err = ioutil.WriteFile(file, []byte(strings.Join(lines, "\n")), 0640)
+	err = ioutil.WriteFile(file, []byte(strings.Join(lines, "\n")), 0o640)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -294,7 +294,7 @@ func TestDate(t *testing.T) {
 
 // https://github.com/gopherjs/gopherjs/issues/287
 func TestInternalizeDate(t *testing.T) {
-	var a = time.Unix(0, (123 * time.Millisecond).Nanoseconds())
+	a := time.Unix(0, (123 * time.Millisecond).Nanoseconds())
 	var b time.Time
 	js.Global.Set("internalizeDate", func(t time.Time) { b = t })
 	js.Global.Call("eval", "(internalizeDate(new Date(123)))")
@@ -478,7 +478,6 @@ func TestMakeWrapper(t *testing.T) {
 	if js.MakeWrapper(m).Interface() != m {
 		t.Fail()
 	}
-
 }
 
 func TestMakeFullWrapperType(t *testing.T) {
@@ -502,7 +501,7 @@ func TestMakeFullWrapperGettersAndSetters(t *testing.T) {
 		Name:    "Gopher",
 		Struct:  F{Field: 42},
 		Pointer: f,
-		Array:   [1]F{F{Field: 42}},
+		Array:   [1]F{{Field: 42}},
 		Slice:   []*F{f},
 	}
 
@@ -731,7 +730,6 @@ func TestExternalize(t *testing.T) {
 			if result != tt.want {
 				t.Errorf("Unexpected result %q != %q", result, tt.want)
 			}
-
 		})
 	}
 }

--- a/tests/linkname_test.go
+++ b/tests/linkname_test.go
@@ -38,9 +38,11 @@ func TestLinknameMethods(t *testing.T) {
 	method.TestLinkname(t)
 }
 
-type name struct{ bytes *byte }
-type nameOff int32
-type rtype struct{}
+type (
+	name    struct{ bytes *byte }
+	nameOff int32
+	rtype   struct{}
+)
 
 //go:linkname rtype_nameOff reflect.(*rtype).nameOff
 func rtype_nameOff(r *rtype, off nameOff) name

--- a/tests/map_js_test.go
+++ b/tests/map_js_test.go
@@ -4,8 +4,9 @@
 package tests
 
 import (
-	"github.com/gopherjs/gopherjs/js"
 	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
 )
 
 func Test_MapWrapper(t *testing.T) {
@@ -43,7 +44,6 @@ func Test_MapWrapper(t *testing.T) {
 	}
 	if got := swmWrapper.Get("DummyMap").Get("key").Get("Msg").String(); got != swm.DummyMap["key"].Msg {
 		t.Errorf("DummyMap Got: %s, Want: %s", got, swm.DummyMap["key"].Msg)
-
 	}
 	if got := swmWrapper.Call("MapFunc", mapFuncArg).Get("key2").String(); got != mapFuncArg["key2"] {
 		t.Errorf("MapFunc Got: %s, Want: %s", got, mapFuncArg["key2"])
@@ -111,5 +111,4 @@ func Test_MapEmbeddedObject(t *testing.T) {
 	if d.Props["two"] != 2 {
 		t.Errorf("key 'two' value Got: %d, Want: %d", d.Props["two"], 2)
 	}
-
 }

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -430,7 +430,7 @@ func TestEmptySelectCase(t *testing.T) {
 	ch := make(chan int, 1)
 	ch <- 42
 
-	var v = 0
+	v := 0
 	select {
 	case v = <-ch:
 	}
@@ -439,17 +439,21 @@ func TestEmptySelectCase(t *testing.T) {
 	}
 }
 
-var a int
-var b int
-var C int
-var D int
+var (
+	a int
+	b int
+	C int
+	D int
+)
 
-var a1 = &a
-var a2 = &a
-var b1 = &b
-var C1 = &C
-var C2 = &C
-var D1 = &D
+var (
+	a1 = &a
+	a2 = &a
+	b1 = &b
+	C1 = &C
+	C2 = &C
+	D1 = &D
+)
 
 func TestPkgVarPointers(t *testing.T) {
 	if a1 != a2 || a1 == b1 || C1 != C2 || C1 == D1 {
@@ -554,10 +558,12 @@ var tuple2called = 0
 func tuple1() (interface{}, error) {
 	return tuple2()
 }
+
 func tuple2() (int, error) {
 	tuple2called++
 	return 14, nil
 }
+
 func TestTupleReturnImplicitCast(t *testing.T) {
 	x, _ := tuple1()
 	if x != 14 || tuple2called != 1 {
@@ -664,7 +670,7 @@ func TestSlicingNilSlice(t *testing.T) {
 		s = s[5:10]
 	})
 	t.Run("DoesNotBecomeNil", func(t *testing.T) {
-		var s = []int{}
+		s := []int{}
 		s = s[:]
 		if s == nil {
 			t.Errorf("non-nil slice became nil after slicing: %#v, want []int{}", s)
@@ -815,12 +821,12 @@ func TestUntypedNil(t *testing.T) {
 			_ = x == nil
 		)
 	}
-	var _ = (*int)(nil)
-	var _ = (func())(nil)
-	var _ = ([]byte)(nil)
-	var _ = (map[int]int)(nil)
-	var _ = (chan int)(nil)
-	var _ = (interface{})(nil)
+	_ = (*int)(nil)
+	_ = (func())(nil)
+	_ = ([]byte)(nil)
+	_ = (map[int]int)(nil)
+	_ = (chan int)(nil)
+	_ = (interface{})(nil)
 	{
 		f := func(*int) {}
 		f(nil)

--- a/tests/syscall_test.go
+++ b/tests/syscall_test.go
@@ -26,7 +26,7 @@ func TestOpen(t *testing.T) {
 	}
 	f.Close()
 	defer os.Remove(f.Name())
-	fd, err := syscall.Open(f.Name(), syscall.O_RDONLY, 0600)
+	fd, err := syscall.Open(f.Name(), syscall.O_RDONLY, 0o600)
 	if err != nil {
 		t.Fatalf("syscall.Open() returned error: %s", err)
 	}

--- a/tests/testdata/defer_builtin.go
+++ b/tests/testdata/defer_builtin.go
@@ -1,7 +1,9 @@
 package main
 
-type set map[interface{}]struct{}
-type key struct{ a int }
+type (
+	set map[interface{}]struct{}
+	key struct{ a int }
+)
 
 var m = set{}
 

--- a/tests/testdata/linkname/three/three.go
+++ b/tests/testdata/linkname/three/three.go
@@ -7,7 +7,7 @@ func DoThree() string {
 func init() {
 	// Avoid dead-code elimination.
 	// TODO(nevkontakte): This should not be necessary.
-	var _ = doInternalThree
+	_ = doInternalThree
 }
 
 var threeSecret = "three secret"

--- a/tests/testdata/linkname/two/two.go
+++ b/tests/testdata/linkname/two/two.go
@@ -5,7 +5,7 @@ import _ "unsafe" // for go:linkname
 func init() {
 	// Avoid dead-code elimination.
 	// TODO(nevkontakte): This should not be necessary.
-	var _ = doInternalOne
+	_ = doInternalOne
 }
 
 func DoTwo() string {


### PR DESCRIPTION
This runs `gofumpt` on the entire repo.  This is the default formatter I tend to use, and it was reformatting every file as I changed it.  It seems cleaner to do it all in one fell swoop, assuming we agree to use this format.

https://github.com/mvdan/gofumpt