### PR TITLE
Fix compiler panic when handling composite literals representing named pointer types.

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -282,6 +282,12 @@ func (fc *funcContext) newIdent(name string, t types.Type) *ast.Ident {
 	return ident
 }
 
+func (fc *funcContext) newTypeIdent(name string, obj types.Object) *ast.Ident {
+	ident := ast.NewIdent(name)
+	fc.pkgCtx.Info.Uses[ident] = obj
+	return ident
+}
+
 func (fc *funcContext) setType(e ast.Expr, t types.Type) ast.Expr {
 	fc.pkgCtx.Types[e] = types.TypeAndValue{Type: t}
 	return e

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -920,3 +920,18 @@ func TestAssignImplicitConversion(t *testing.T) {
 		}
 	})
 }
+
+func TestCompositeLiterals(t *testing.T) {
+	type S struct{}
+	type SP *S
+
+	s1 := []*S{{}}
+	if got := reflect.TypeOf(s1[0]); got.String() != "*tests.S" {
+		t.Errorf("Got: reflect.TypeOf(s1[0]) = %v. Want: *tests.S", got)
+	}
+
+	s2 := []SP{{}}
+	if got := reflect.TypeOf(s2[0]); got.String() != "tests.SP" {
+		t.Errorf("Got: reflect.TypeOf(s2[0]) = %v. Want: tests.SP", got)
+	}
+}


### PR DESCRIPTION
Prior to this change, the following code would panic the compiler:

```go

type (
	S  struct{ f int }
	PS *[]S
)

var _ = []*S{{}} // This compiles, but potentially incorrectly.
var _ = []PS{{}} // Compiler panics here.
```

Prior to this change, GopherJS compiler didn't expect that a pointer type could be named in this context, and would panic. This is addressed by checking the underlying type, rather than the type itself.

However, there was a bigger correctness problem here too. According to the Go spec:

> Within a composite literal of array, slice, or map type T, elements or map keys that are themselves composite literals may elide the respective literal type if it is identical to the element or key type of T. Similarly, elements or keys that are addresses of composite literals may elide the &T when the element or key type is *T.

So in the example above, `[]PS{{}}` expression is equivalent to `[]PS{PS(*S{})}`. However, even with the first part of the fix, the code emitted by the compiler would have been equivalent to `[]PS{S{}}`. This mostly works because at runtime GopherJS represents a pointer to the struct and the struct type as the same JS object, but it would break down when it comes to methods and non-struct types. So the second part of the fix is to generate the explicit AST for taking an address of the value type and type conversion, and compiling that.