### PR TITLE
Perform a few automated ES6 transformations to our prelude

### DIFF
--- a/compiler/prelude/goroutines.js
+++ b/compiler/prelude/goroutines.js
@@ -131,7 +131,7 @@ var $go = function (fun, args) {
     var $goroutine = function () {
         try {
             $curGoroutine = $goroutine;
-            var r = fun.apply(undefined, args);
+            var r = fun(...args);
             if (r && r.$blk !== undefined) {
                 fun = function () { return r.$blk(); };
                 args = [];

--- a/compiler/prelude/goroutines.js
+++ b/compiler/prelude/goroutines.js
@@ -250,7 +250,7 @@ var $send = (chan, value) => {
     });
     $block();
     return {
-        $blk: function () {
+        $blk() {
             if (closedDuringSend) {
                 $throwRuntimeError("send on closed channel");
             }
@@ -271,7 +271,7 @@ var $recv = chan => {
     }
 
     var thisGoroutine = $curGoroutine;
-    var f = { $blk: function () { return this.value; } };
+    var f = { $blk() { return this.value; } };
     var queueEntry = v => {
         f.value = v;
         $schedule(thisGoroutine);
@@ -344,7 +344,7 @@ var $select = comms => {
 
     var entries = [];
     var thisGoroutine = $curGoroutine;
-    var f = { $blk: function () { return this.selection; } };
+    var f = { $blk() { return this.selection; } };
     var removeFromQueues = () => {
         for (var i = 0; i < entries.length; i++) {
             var entry = entries[i];

--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -1,6 +1,6 @@
 var $jsObjectPtr, $jsErrorPtr;
 
-var $needsExternalization = function (t) {
+var $needsExternalization = t => {
     switch (t.kind) {
         case $kindBool:
         case $kindInt:
@@ -20,7 +20,7 @@ var $needsExternalization = function (t) {
     }
 };
 
-var $externalize = function (v, t, makeWrapper) {
+var $externalize = (v, t, makeWrapper) => {
     if (t === $jsObjectPtr) {
         return v;
     }
@@ -43,7 +43,7 @@ var $externalize = function (v, t, makeWrapper) {
             return $flatten64(v);
         case $kindArray:
             if ($needsExternalization(t.elem)) {
-                return $mapArray(v, function (e) { return $externalize(e, t.elem, makeWrapper); });
+                return $mapArray(v, e => { return $externalize(e, t.elem, makeWrapper); });
             }
             return v;
         case $kindFunc:
@@ -77,7 +77,7 @@ var $externalize = function (v, t, makeWrapper) {
                 return null;
             }
             if ($needsExternalization(t.elem)) {
-                return $mapArray($sliceToNativeArray(v), function (e) { return $externalize(e, t.elem, makeWrapper); });
+                return $mapArray($sliceToNativeArray(v), e => { return $externalize(e, t.elem, makeWrapper); });
             }
             return $sliceToNativeArray(v);
         case $kindString:
@@ -105,7 +105,7 @@ var $externalize = function (v, t, makeWrapper) {
             }
 
             var noJsObject = {};
-            var searchJsObject = function (v, t) {
+            var searchJsObject = (v, t) => {
                 if (t === $jsObjectPtr) {
                     return v;
                 }
@@ -149,7 +149,7 @@ var $externalize = function (v, t, makeWrapper) {
     $throwRuntimeError("cannot externalize " + t.string);
 };
 
-var $externalizeFunction = function (v, t, passThis, makeWrapper) {
+var $externalizeFunction = (v, t, passThis, makeWrapper) => {
     if (v === $throwNilPointerError) {
         return null;
     }
@@ -185,7 +185,7 @@ var $externalizeFunction = function (v, t, passThis, makeWrapper) {
     return v.$externalizeWrapper;
 };
 
-var $internalize = function (v, t, recv, seen, makeWrapper) {
+var $internalize = (v, t, recv, seen, makeWrapper) => {
     if (t === $jsObjectPtr) {
         return v;
     }
@@ -239,7 +239,7 @@ var $internalize = function (v, t, recv, seen, makeWrapper) {
             if (v.length !== t.len) {
                 $throwRuntimeError("got array with wrong size from JavaScript native");
             }
-            return $mapArray(v, function (e) { return $internalize(e, t.elem, makeWrapper); });
+            return $mapArray(v, e => { return $internalize(e, t.elem, makeWrapper); });
         case $kindFunc:
             return function () {
                 var args = [];
@@ -303,7 +303,7 @@ var $internalize = function (v, t, recv, seen, makeWrapper) {
                         return new $jsObjectPtr(v);
                     }
                     return new timePkg.Time($internalize(v, timePkg.Time, makeWrapper));
-                case (function () { }).constructor: // is usually Function, but in Chrome extensions it is something else
+                case ((() => { })).constructor: // is usually Function, but in Chrome extensions it is something else
                     var funcType = $funcType([$sliceType($emptyInterface)], [$jsObjectPtr], true);
                     return new funcType($internalize(v, funcType, makeWrapper));
                 case Number:
@@ -331,7 +331,7 @@ var $internalize = function (v, t, recv, seen, makeWrapper) {
                 return $internalize(v, t.elem, makeWrapper);
             }
         case $kindSlice:
-            return new t($mapArray(v, function (e) { return $internalize(e, t.elem, makeWrapper); }));
+            return new t($mapArray(v, e => { return $internalize(e, t.elem, makeWrapper); }));
         case $kindString:
             v = String(v);
             if ($isASCII(v)) {
@@ -354,7 +354,7 @@ var $internalize = function (v, t, recv, seen, makeWrapper) {
             return s;
         case $kindStruct:
             var noJsObject = {};
-            var searchJsObject = function (t) {
+            var searchJsObject = t => {
                 if (t === $jsObjectPtr) {
                     return v;
                 }
@@ -388,7 +388,7 @@ var $internalize = function (v, t, recv, seen, makeWrapper) {
     $throwRuntimeError("cannot internalize " + t.string);
 };
 
-var $copyIfRequired = function (v, typ) {
+var $copyIfRequired = (v, typ) => {
     // interface values
     if (v && v.constructor && v.constructor.copy) {
         return new v.constructor($clone(v.$val, v.constructor))
@@ -403,7 +403,7 @@ var $copyIfRequired = function (v, typ) {
 }
 
 /* $isASCII reports whether string s contains only ASCII characters. */
-var $isASCII = function (s) {
+var $isASCII = s => {
     for (var i = 0; i < s.length; i++) {
         if (s.charCodeAt(i) >= 128) {
             return false;

--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -323,7 +323,7 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
             var keys = $keys(v);
             for (var i = 0; i < keys.length; i++) {
                 var k = $internalize(keys[i], t.key, recv, seen, makeWrapper);
-                m.set(t.key.keyFor(k), { k: k, v: $internalize(v[keys[i]], t.elem, recv, seen, makeWrapper) });
+                m.set(t.key.keyFor(k), { k, v: $internalize(v[keys[i]], t.elem, recv, seen, makeWrapper) });
             }
             return m;
         case $kindPtr:

--- a/compiler/prelude/numeric.js
+++ b/compiler/prelude/numeric.js
@@ -1,7 +1,7 @@
 var $min = Math.min;
-var $mod = function (x, y) { return x % y; };
+var $mod = (x, y) => { return x % y; };
 var $parseInt = parseInt;
-var $parseFloat = function (f) {
+var $parseFloat = f => {
     if (f !== undefined && f !== null && f.constructor === Number) {
         return f;
     }
@@ -9,20 +9,20 @@ var $parseFloat = function (f) {
 };
 
 var $froundBuf = new Float32Array(1);
-var $fround = Math.fround || function (f) {
+var $fround = Math.fround || (f => {
     $froundBuf[0] = f;
     return $froundBuf[0];
-};
+});
 
-var $imul = Math.imul || function (a, b) {
+var $imul = Math.imul || ((a, b) => {
     var ah = (a >>> 16) & 0xffff;
     var al = a & 0xffff;
     var bh = (b >>> 16) & 0xffff;
     var bl = b & 0xffff;
     return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) >> 0);
-};
+});
 
-var $floatKey = function (f) {
+var $floatKey = f => {
     if (f !== f) {
         $idCounter++;
         return "NaN$" + $idCounter;
@@ -30,11 +30,11 @@ var $floatKey = function (f) {
     return String(f);
 };
 
-var $flatten64 = function (x) {
+var $flatten64 = x => {
     return x.$high * 4294967296 + x.$low;
 };
 
-var $shiftLeft64 = function (x, y) {
+var $shiftLeft64 = (x, y) => {
     if (y === 0) {
         return x;
     }
@@ -47,7 +47,7 @@ var $shiftLeft64 = function (x, y) {
     return new x.constructor(0, 0);
 };
 
-var $shiftRightInt64 = function (x, y) {
+var $shiftRightInt64 = (x, y) => {
     if (y === 0) {
         return x;
     }
@@ -63,7 +63,7 @@ var $shiftRightInt64 = function (x, y) {
     return new x.constructor(0, 0);
 };
 
-var $shiftRightUint64 = function (x, y) {
+var $shiftRightUint64 = (x, y) => {
     if (y === 0) {
         return x;
     }
@@ -76,7 +76,7 @@ var $shiftRightUint64 = function (x, y) {
     return new x.constructor(0, 0);
 };
 
-var $mul64 = function (x, y) {
+var $mul64 = (x, y) => {
     var x48 = x.$high >>> 16;
     var x32 = x.$high & 0xFFFF;
     var x16 = x.$low >>> 16;
@@ -116,7 +116,7 @@ var $mul64 = function (x, y) {
     return r;
 };
 
-var $div64 = function (x, y, returnRemainder) {
+var $div64 = (x, y, returnRemainder) => {
     if (y.$high === 0 && y.$low === 0) {
         $throwRuntimeError("integer divide by zero");
     }
@@ -179,7 +179,7 @@ var $div64 = function (x, y, returnRemainder) {
     return new x.constructor(high * s, low * s);
 };
 
-var $divComplex = function (n, d) {
+var $divComplex = (n, d) => {
     var ninf = n.$real === Infinity || n.$real === -Infinity || n.$imag === Infinity || n.$imag === -Infinity;
     var dinf = d.$real === Infinity || d.$real === -Infinity || d.$imag === Infinity || d.$imag === -Infinity;
     var nnan = !ninf && (n.$real !== n.$real || n.$imag !== n.$imag);

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -56,13 +56,13 @@ if (!$global.fs) {
 
 var $linknames = {} // Collection of functions referenced by a go:linkname directive.
 var $packages = {}, $idCounter = 0;
-var $keys = function (m) { return m ? Object.keys(m) : []; };
-var $flushConsole = function () { };
+var $keys = m => { return m ? Object.keys(m) : []; };
+var $flushConsole = () => { };
 var $throwRuntimeError; /* set by package "runtime" */
-var $throwNilPointerError = function () { $throwRuntimeError("invalid memory address or nil pointer dereference"); };
-var $call = function (fn, rcvr, args) { return fn.apply(rcvr, args); };
-var $makeFunc = function (fn) { return function(...args) { return $externalize(fn(this, new ($sliceType($jsObjectPtr))($global.Array.prototype.slice.call(args, []))), $emptyInterface); }; };
-var $unused = function (v) { };
+var $throwNilPointerError = () => { $throwRuntimeError("invalid memory address or nil pointer dereference"); };
+var $call = (fn, rcvr, args) => { return fn.apply(rcvr, args); };
+var $makeFunc = fn => { return function(...args) { return $externalize(fn(this, new ($sliceType($jsObjectPtr))($global.Array.prototype.slice.call(args, []))), $emptyInterface); }; };
+var $unused = v => { };
 var $print = console.log;
 // Under Node we can emulate print() more closely by avoiding a newline.
 if (($global.process !== undefined) && $global.require) {
@@ -75,7 +75,7 @@ if (($global.process !== undefined) && $global.require) {
 }
 var $println = console.log
 
-var $initAllLinknames = function () {
+var $initAllLinknames = () => {
     var names = $keys($packages);
     for (var i = 0; i < names.length; i++) {
         var f = $packages[names[i]]["$initLinknames"];
@@ -85,7 +85,7 @@ var $initAllLinknames = function () {
     }
 }
 
-var $mapArray = function (array, f) {
+var $mapArray = (array, f) => {
     var newArray = new array.constructor(array.length);
     for (var i = 0; i < array.length; i++) {
         newArray[i] = f(array[i]);
@@ -94,16 +94,16 @@ var $mapArray = function (array, f) {
 };
 
 // $mapIndex returns the value of the given key in m, or undefined if m is nil/undefined or not a map
-var $mapIndex = function (m, key) {
+var $mapIndex = (m, key) => {
     return typeof m.get === "function" ? m.get(key) : undefined;
 };
 // $mapDelete deletes the key and associated value from m.  If m is nil/undefined or not a map, $mapDelete is a no-op
-var $mapDelete = function (m, key) {
+var $mapDelete = (m, key) => {
     typeof m.delete === "function" && m.delete(key)
 };
 // Returns a method bound to the receiver instance, safe to invoke as a 
 // standalone function. Bound function is cached for later reuse.
-var $methodVal = function (recv, name) {
+var $methodVal = (recv, name) => {
     var vals = recv.$methodVals || {};
     recv.$methodVals = vals; /* noop for primitives */
     var f = vals[name];
@@ -116,10 +116,10 @@ var $methodVal = function (recv, name) {
     return f;
 };
 
-var $methodExpr = function (typ, name) {
+var $methodExpr = (typ, name) => {
     var method = typ.prototype[name];
     if (method.$expr === undefined) {
-        method.$expr = function(...args) {
+        method.$expr = (...args) => {
             $stackDepthOffset--;
             try {
                 if (typ.wrapped) {
@@ -135,10 +135,10 @@ var $methodExpr = function (typ, name) {
 };
 
 var $ifaceMethodExprs = {};
-var $ifaceMethodExpr = function (name) {
+var $ifaceMethodExpr = name => {
     var expr = $ifaceMethodExprs["$" + name];
     if (expr === undefined) {
-        expr = $ifaceMethodExprs["$" + name] = function(...args) {
+        expr = $ifaceMethodExprs["$" + name] = (...args) => {
             $stackDepthOffset--;
             try {
                 return Function.call.apply(args[0][name], args);
@@ -150,7 +150,7 @@ var $ifaceMethodExpr = function (name) {
     return expr;
 };
 
-var $subslice = function (slice, low, high, max) {
+var $subslice = (slice, low, high, max) => {
     if (high === undefined) {
         high = slice.$length;
     }
@@ -170,7 +170,7 @@ var $subslice = function (slice, low, high, max) {
     return s;
 };
 
-var $substring = function (str, low, high) {
+var $substring = (str, low, high) => {
     if (low < 0 || high < low || high > str.length) {
         $throwRuntimeError("slice bounds out of range");
     }
@@ -178,7 +178,7 @@ var $substring = function (str, low, high) {
 };
 
 // Convert Go slice to an equivalent JS array type.
-var $sliceToNativeArray = function (slice) {
+var $sliceToNativeArray = slice => {
     if (slice.$array.constructor !== Array) {
         return slice.$array.subarray(slice.$offset, slice.$offset + slice.$length);
     }
@@ -189,7 +189,7 @@ var $sliceToNativeArray = function (slice) {
 // 
 // Note that an array pointer can be represented by an "unwrapped" native array
 // type, and it will be wrapped back into its Go type when necessary.
-var $sliceToGoArray = function (slice, arrayPtrType) {
+var $sliceToGoArray = (slice, arrayPtrType) => {
     var arrayType = arrayPtrType.elem;
     if (arrayType !== undefined && slice.$length < arrayType.len) {
         $throwRuntimeError("cannot convert slice with length " + slice.$length + " to pointer to array with length " + arrayType.len);
@@ -216,7 +216,7 @@ var $sliceToGoArray = function (slice, arrayPtrType) {
 };
 
 // Convert between compatible slice types (e.g. native and names).
-var $convertSliceType = function (slice, desiredType) {
+var $convertSliceType = (slice, desiredType) => {
     if (slice == slice.constructor.nil) {
         return desiredType.nil; // Preserve nil value.
     }
@@ -224,7 +224,7 @@ var $convertSliceType = function (slice, desiredType) {
     return $subslice(new desiredType(slice.$array), slice.$offset, slice.$offset + slice.$length);
 }
 
-var $decodeRune = function (str, pos) {
+var $decodeRune = (str, pos) => {
     var c0 = str.charCodeAt(pos);
 
     if (c0 < 0x80) {
@@ -280,7 +280,7 @@ var $decodeRune = function (str, pos) {
     return [0xFFFD, 1];
 };
 
-var $encodeRune = function (r) {
+var $encodeRune = r => {
     if (r < 0 || r > 0x10FFFF || (0xD800 <= r && r <= 0xDFFF)) {
         r = 0xFFFD;
     }
@@ -296,7 +296,7 @@ var $encodeRune = function (r) {
     return String.fromCharCode(0xF0 | r >> 18, 0x80 | (r >> 12 & 0x3F), 0x80 | (r >> 6 & 0x3F), 0x80 | (r & 0x3F));
 };
 
-var $stringToBytes = function (str) {
+var $stringToBytes = str => {
     var array = new Uint8Array(str.length);
     for (var i = 0; i < str.length; i++) {
         array[i] = str.charCodeAt(i);
@@ -304,7 +304,7 @@ var $stringToBytes = function (str) {
     return array;
 };
 
-var $bytesToString = function (slice) {
+var $bytesToString = slice => {
     if (slice.$length === 0) {
         return "";
     }
@@ -315,7 +315,7 @@ var $bytesToString = function (slice) {
     return str;
 };
 
-var $stringToRunes = function (str) {
+var $stringToRunes = str => {
     var array = new Int32Array(str.length);
     var rune, j = 0;
     for (var i = 0; i < str.length; i += rune[1], j++) {
@@ -325,7 +325,7 @@ var $stringToRunes = function (str) {
     return array.subarray(0, j);
 };
 
-var $runesToString = function (slice) {
+var $runesToString = slice => {
     if (slice.$length === 0) {
         return "";
     }
@@ -336,7 +336,7 @@ var $runesToString = function (slice) {
     return str;
 };
 
-var $copyString = function (dst, src) {
+var $copyString = (dst, src) => {
     var n = Math.min(src.length, dst.$length);
     for (var i = 0; i < n; i++) {
         dst.$array[dst.$offset + i] = src.charCodeAt(i);
@@ -344,13 +344,13 @@ var $copyString = function (dst, src) {
     return n;
 };
 
-var $copySlice = function (dst, src) {
+var $copySlice = (dst, src) => {
     var n = Math.min(src.$length, dst.$length);
     $copyArray(dst.$array, src.$array, dst.$offset, src.$offset, n, dst.constructor.elem);
     return n;
 };
 
-var $copyArray = function (dst, src, dstOffset, srcOffset, n, elem) {
+var $copyArray = (dst, src, dstOffset, srcOffset, n, elem) => {
     if (n === 0 || (dst === src && dstOffset === srcOffset)) {
         return;
     }
@@ -386,13 +386,13 @@ var $copyArray = function (dst, src, dstOffset, srcOffset, n, elem) {
     }
 };
 
-var $clone = function (src, type) {
+var $clone = (src, type) => {
     var clone = type.zero();
     type.copy(clone, src);
     return clone;
 };
 
-var $pointerOfStructConversion = function (obj, type) {
+var $pointerOfStructConversion = (obj, type) => {
     if (obj.$proxies === undefined) {
         obj.$proxies = {};
         obj.$proxies[obj.constructor.string] = obj;
@@ -401,7 +401,7 @@ var $pointerOfStructConversion = function (obj, type) {
     if (proxy === undefined) {
         var properties = {};
         for (var i = 0; i < type.elem.fields.length; i++) {
-            (function (fieldProp) {
+            (fieldProp => {
                 properties[fieldProp] = {
                     get: function () { return obj[fieldProp]; },
                     set: function (value) { obj[fieldProp] = value; }
@@ -420,7 +420,7 @@ var $append = function (slice) {
     return $internalAppend(slice, arguments, 1, arguments.length - 1);
 };
 
-var $appendSlice = function (slice, toAppend) {
+var $appendSlice = (slice, toAppend) => {
     if (toAppend.constructor === String) {
         var bytes = $stringToBytes(toAppend);
         return $internalAppend(slice, bytes, 0, bytes.length);
@@ -428,7 +428,7 @@ var $appendSlice = function (slice, toAppend) {
     return $internalAppend(slice, toAppend.$array, toAppend.$offset, toAppend.$length);
 };
 
-var $internalAppend = function (slice, array, offset, length) {
+var $internalAppend = (slice, array, offset, length) => {
     if (length === 0) {
         return slice;
     }
@@ -464,7 +464,7 @@ var $internalAppend = function (slice, array, offset, length) {
     return newSlice;
 };
 
-var $equal = function (a, b, type) {
+var $equal = (a, b, type) => {
     if (type === $jsObjectPtr) {
         return a === b;
     }
@@ -500,7 +500,7 @@ var $equal = function (a, b, type) {
     }
 };
 
-var $interfaceIsEqual = function (a, b) {
+var $interfaceIsEqual = (a, b) => {
     if (a === $ifaceNil || b === $ifaceNil) {
         return a === b;
     }
@@ -516,9 +516,9 @@ var $interfaceIsEqual = function (a, b) {
     return $equal(a.$val, b.$val, a.constructor);
 };
 
-var $unsafeMethodToFunction = function (typ, name, isPtr) {
+var $unsafeMethodToFunction = (typ, name, isPtr) => {
     if (isPtr) {
-        return function (r, ...args) {
+        return (r, ...args) => {
             var ptrType = $ptrType(typ);
             if (r.constructor != ptrType) {
                 switch (typ.kind) {
@@ -533,9 +533,9 @@ var $unsafeMethodToFunction = function (typ, name, isPtr) {
                 }
             }
             return r[name](...args);
-        }
+        };
     } else {
-        return function (r, ...args) {
+        return (r, ...args) => {
             var ptrType = $ptrType(typ);
             if (r.constructor != ptrType) {
                 switch (typ.kind) {
@@ -554,18 +554,18 @@ var $unsafeMethodToFunction = function (typ, name, isPtr) {
                 }
             }
             return r[name](...args);
-        }
+        };
     }
 };
 
-var $id = function (x) {
+var $id = x => {
     return x;
 };
 
-var $instanceOf = function (x, y) {
+var $instanceOf = (x, y) => {
     return x instanceof y;
 };
 
-var $typeOf = function (x) {
+var $typeOf = x => {
     return typeof (x);
 };

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -403,8 +403,8 @@ var $pointerOfStructConversion = (obj, type) => {
         for (var i = 0; i < type.elem.fields.length; i++) {
             (fieldProp => {
                 properties[fieldProp] = {
-                    get: function () { return obj[fieldProp]; },
-                    set: function (value) { obj[fieldProp] = value; }
+                    get() { return obj[fieldProp]; },
+                    set(value) { obj[fieldProp] = value; }
                 };
             })(type.elem.fields[i].prop);
         }

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -556,7 +556,7 @@ var $Chan = function (elem, capacity) {
     this.$closed = false;
 };
 var $chanNil = new $Chan(null, 0);
-$chanNil.$sendQueue = $chanNil.$recvQueue = { length: 0, push: function () { }, shift: function () { return undefined; }, indexOf: function () { return -1; } };
+$chanNil.$sendQueue = $chanNil.$recvQueue = { length: 0, push() { }, shift() { return undefined; }, indexOf() { return -1; } };
 
 var $funcTypes = {};
 var $funcType = (params, results, variadic) => {

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -288,7 +288,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                             if (v.$val === undefined) {
                                 v = new f.typ(v);
                             }
-                            return v[m.prop].apply(v, args);
+                            return v[m.prop](...args);
                         };
                     };
                     fields.forEach(function (f) {

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -662,8 +662,7 @@ var $sliceType = elem => {
     }
     return typ;
 };
-var $makeSlice = (typ, length, capacity) => {
-    capacity = capacity || length;
+var $makeSlice = (typ, length, capacity = length) => {
     if (length < 0 || length > 2147483647) {
         $throwRuntimeError("makeslice: len out of range");
     }

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -280,7 +280,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 $addMethodSynthesizer(function () {
                     var synthesizeMethod = function (target, m, f) {
                         if (target.prototype[m.prop] !== undefined) { return; }
-                        target.prototype[m.prop] = function () {
+                        target.prototype[m.prop] = function(...args) {
                             var v = this.$val[f.prop];
                             if (f.typ === $jsObjectPtr) {
                                 v = new $jsObjectPtr(v);
@@ -288,7 +288,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                             if (v.$val === undefined) {
                                 v = new f.typ(v);
                             }
-                            return v[m.prop].apply(v, arguments);
+                            return v[m.prop].apply(v, args);
                         };
                     };
                     fields.forEach(function (f) {
@@ -696,14 +696,14 @@ var $structType = function (pkgPath, fields) {
         if (fields.length === 0) {
             string = "struct {}";
         }
-        typ = $newType(0, $kindStruct, string, false, "", false, function () {
+        typ = $newType(0, $kindStruct, string, false, "", false, function(...args) {
             this.$val = this;
             for (var i = 0; i < fields.length; i++) {
                 var f = fields[i];
                 if (f.name == '_') {
                     continue;
                 }
-                var arg = arguments[i];
+                var arg = args[i];
                 this[f.prop] = arg !== undefined ? arg : f.typ.zero();
             }
         });

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -26,19 +26,19 @@ var $kindStruct = 25;
 var $kindUnsafePointer = 26;
 
 var $methodSynthesizers = [];
-var $addMethodSynthesizer = function (f) {
+var $addMethodSynthesizer = f => {
     if ($methodSynthesizers === null) {
         f();
         return;
     }
     $methodSynthesizers.push(f);
 };
-var $synthesizeMethods = function () {
-    $methodSynthesizers.forEach(function (f) { f(); });
+var $synthesizeMethods = () => {
+    $methodSynthesizers.forEach(f => { f(); });
     $methodSynthesizers = null;
 };
 
-var $ifaceKeyFor = function (x) {
+var $ifaceKeyFor = x => {
     if (x === $ifaceNil) {
         return 'nil';
     }
@@ -46,11 +46,11 @@ var $ifaceKeyFor = function (x) {
     return c.string + '$' + c.keyFor(x.$val);
 };
 
-var $identity = function (x) { return x; };
+var $identity = x => { return x; };
 
 var $typeIDCounter = 0;
 
-var $idKey = function (x) {
+var $idKey = x => {
     if (x.$id === undefined) {
         $idCounter++;
         x.$id = $idCounter;
@@ -60,15 +60,15 @@ var $idKey = function (x) {
 
 // Creates constructor functions for array pointer types. Returns a new function
 // instace each time to make sure each type is independent of the other.
-var $arrayPtrCtor = function () {
+var $arrayPtrCtor = () => {
     return function (array) {
-        this.$get = function () { return array; };
+        this.$get = () => { return array; };
         this.$set = function (v) { typ.copy(this, v); };
         this.$val = array;
-    }
+    };
 }
 
-var $newType = function (size, kind, string, named, pkg, exported, constructor) {
+var $newType = (size, kind, string, named, pkg, exported, constructor) => {
     var typ;
     switch (kind) {
         case $kindBool:
@@ -90,14 +90,14 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindString:
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
-            typ.keyFor = function (x) { return "$" + x; };
+            typ.keyFor = x => { return "$" + x; };
             break;
 
         case $kindFloat32:
         case $kindFloat64:
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
-            typ.keyFor = function (x) { return $floatKey(x); };
+            typ.keyFor = x => { return $floatKey(x); };
             break;
 
         case $kindInt64:
@@ -106,7 +106,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$low = low >>> 0;
                 this.$val = this;
             };
-            typ.keyFor = function (x) { return x.$high + "$" + x.$low; };
+            typ.keyFor = x => { return x.$high + "$" + x.$low; };
             break;
 
         case $kindUint64:
@@ -115,7 +115,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$low = low >>> 0;
                 this.$val = this;
             };
-            typ.keyFor = function (x) { return x.$high + "$" + x.$low; };
+            typ.keyFor = x => { return x.$high + "$" + x.$low; };
             break;
 
         case $kindComplex64:
@@ -124,7 +124,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$imag = $fround(imag);
                 this.$val = this;
             };
-            typ.keyFor = function (x) { return x.$real + "$" + x.$imag; };
+            typ.keyFor = x => { return x.$real + "$" + x.$imag; };
             break;
 
         case $kindComplex128:
@@ -133,23 +133,23 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$imag = imag;
                 this.$val = this;
             };
-            typ.keyFor = function (x) { return x.$real + "$" + x.$imag; };
+            typ.keyFor = x => { return x.$real + "$" + x.$imag; };
             break;
 
         case $kindArray:
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
             typ.ptr = $newType(4, $kindPtr, "*" + string, false, "", false, $arrayPtrCtor());
-            typ.init = function (elem, len) {
+            typ.init = (elem, len) => {
                 typ.elem = elem;
                 typ.len = len;
                 typ.comparable = elem.comparable;
-                typ.keyFor = function (x) {
-                    return Array.prototype.join.call($mapArray(x, function (e) {
+                typ.keyFor = x => {
+                    return Array.prototype.join.call($mapArray(x, e => {
                         return String(elem.keyFor(e)).replace(/\\/g, "\\\\").replace(/\$/g, "\\$");
                     }), "$");
                 };
-                typ.copy = function (dst, src) {
+                typ.copy = (dst, src) => {
                     $copyArray(dst, src, 0, 0, src.length, elem);
                 };
                 typ.ptr.init(typ);
@@ -161,7 +161,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
             typ.keyFor = $idKey;
-            typ.init = function (elem, sendOnly, recvOnly) {
+            typ.init = (elem, sendOnly, recvOnly) => {
                 typ.elem = elem;
                 typ.sendOnly = sendOnly;
                 typ.recvOnly = recvOnly;
@@ -171,7 +171,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindFunc:
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
-            typ.init = function (params, results, variadic) {
+            typ.init = (params, results, variadic) => {
                 typ.params = params;
                 typ.results = results;
                 typ.variadic = variadic;
@@ -182,9 +182,9 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindInterface:
             typ = { implementedBy: {}, missingMethodFor: {} };
             typ.keyFor = $ifaceKeyFor;
-            typ.init = function (methods) {
+            typ.init = methods => {
                 typ.methods = methods;
-                methods.forEach(function (m) {
+                methods.forEach(m => {
                     $ifaceNil[m.prop] = $throwNilPointerError;
                 });
             };
@@ -193,7 +193,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindMap:
             typ = function (v) { this.$val = v; };
             typ.wrapped = true;
-            typ.init = function (key, elem) {
+            typ.init = (key, elem) => {
                 typ.key = key;
                 typ.elem = elem;
                 typ.comparable = false;
@@ -208,7 +208,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$val = this;
             };
             typ.keyFor = $idKey;
-            typ.init = function (elem) {
+            typ.init = elem => {
                 typ.elem = elem;
                 typ.wrapped = (elem.kind === $kindArray);
                 typ.nil = new typ($throwNilPointerError, $throwNilPointerError);
@@ -226,7 +226,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 this.$capacity = array.length;
                 this.$val = this;
             };
-            typ.init = function (elem) {
+            typ.init = elem => {
                 typ.elem = elem;
                 typ.comparable = false;
                 typ.nativeArray = $nativeArray(elem.kind);
@@ -241,21 +241,21 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
             typ.ptr.elem = typ;
             typ.ptr.prototype.$get = function () { return this; };
             typ.ptr.prototype.$set = function (v) { typ.copy(this, v); };
-            typ.init = function (pkgPath, fields) {
+            typ.init = (pkgPath, fields) => {
                 typ.pkgPath = pkgPath;
                 typ.fields = fields;
-                fields.forEach(function (f) {
+                fields.forEach(f => {
                     if (!f.typ.comparable) {
                         typ.comparable = false;
                     }
                 });
-                typ.keyFor = function (x) {
+                typ.keyFor = x => {
                     var val = x.$val;
-                    return $mapArray(fields, function (f) {
+                    return $mapArray(fields, f => {
                         return String(f.typ.keyFor(val[f.prop])).replace(/\\/g, "\\\\").replace(/\$/g, "\\$");
                     }).join("$");
                 };
-                typ.copy = function (dst, src) {
+                typ.copy = (dst, src) => {
                     for (var i = 0; i < fields.length; i++) {
                         var f = fields[i];
                         switch (f.typ.kind) {
@@ -271,14 +271,14 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                 };
                 /* nil value */
                 var properties = {};
-                fields.forEach(function (f) {
+                fields.forEach(f => {
                     properties[f.prop] = { get: $throwNilPointerError, set: $throwNilPointerError };
                 });
                 typ.ptr.nil = Object.create(constructor.prototype, properties);
                 typ.ptr.nil.$val = typ.ptr.nil;
                 /* methods for embedded fields */
-                $addMethodSynthesizer(function () {
-                    var synthesizeMethod = function (target, m, f) {
+                $addMethodSynthesizer(() => {
+                    var synthesizeMethod = (target, m, f) => {
                         if (target.prototype[m.prop] !== undefined) { return; }
                         target.prototype[m.prop] = function(...args) {
                             var v = this.$val[f.prop];
@@ -291,13 +291,13 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
                             return v[m.prop](...args);
                         };
                     };
-                    fields.forEach(function (f) {
+                    fields.forEach(f => {
                         if (f.embedded) {
-                            $methodSet(f.typ).forEach(function (m) {
+                            $methodSet(f.typ).forEach(m => {
                                 synthesizeMethod(typ, m, f);
                                 synthesizeMethod(typ.ptr, m, f);
                             });
-                            $methodSet($ptrType(f.typ)).forEach(function (m) {
+                            $methodSet($ptrType(f.typ)).forEach(m => {
                                 synthesizeMethod(typ.ptr, m, f);
                             });
                         }
@@ -313,7 +313,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
     switch (kind) {
         case $kindBool:
         case $kindMap:
-            typ.zero = function () { return false; };
+            typ.zero = () => { return false; };
             break;
 
         case $kindInt:
@@ -328,11 +328,11 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindUnsafePointer:
         case $kindFloat32:
         case $kindFloat64:
-            typ.zero = function () { return 0; };
+            typ.zero = () => { return 0; };
             break;
 
         case $kindString:
-            typ.zero = function () { return ""; };
+            typ.zero = () => { return ""; };
             break;
 
         case $kindInt64:
@@ -340,28 +340,28 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
         case $kindComplex64:
         case $kindComplex128:
             var zero = new typ(0, 0);
-            typ.zero = function () { return zero; };
+            typ.zero = () => { return zero; };
             break;
 
         case $kindPtr:
         case $kindSlice:
-            typ.zero = function () { return typ.nil; };
+            typ.zero = () => { return typ.nil; };
             break;
 
         case $kindChan:
-            typ.zero = function () { return $chanNil; };
+            typ.zero = () => { return $chanNil; };
             break;
 
         case $kindFunc:
-            typ.zero = function () { return $throwNilPointerError; };
+            typ.zero = () => { return $throwNilPointerError; };
             break;
 
         case $kindInterface:
-            typ.zero = function () { return $ifaceNil; };
+            typ.zero = () => { return $ifaceNil; };
             break;
 
         case $kindArray:
-            typ.zero = function () {
+            typ.zero = () => {
                 var arrayClass = $nativeArray(typ.elem.kind);
                 if (arrayClass !== Array) {
                     return new arrayClass(typ.len);
@@ -375,7 +375,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
             break;
 
         case $kindStruct:
-            typ.zero = function () { return new typ.ptr(); };
+            typ.zero = () => { return new typ.ptr(); };
             break;
 
         default:
@@ -396,7 +396,7 @@ var $newType = function (size, kind, string, named, pkg, exported, constructor) 
     return typ;
 };
 
-var $methodSet = function (typ) {
+var $methodSet = typ => {
     if (typ.methodSetCache !== null) {
         return typ.methodSetCache;
     }
@@ -416,7 +416,7 @@ var $methodSet = function (typ) {
         var next = [];
         var mset = [];
 
-        current.forEach(function (e) {
+        current.forEach(e => {
             if (seen[e.typ.string]) {
                 return;
             }
@@ -431,7 +431,7 @@ var $methodSet = function (typ) {
 
             switch (e.typ.kind) {
                 case $kindStruct:
-                    e.typ.fields.forEach(function (f) {
+                    e.typ.fields.forEach(f => {
                         if (f.embedded) {
                             var fTyp = f.typ;
                             var fIsPtr = (fTyp.kind === $kindPtr);
@@ -446,7 +446,7 @@ var $methodSet = function (typ) {
             }
         });
 
-        mset.forEach(function (m) {
+        mset.forEach(m => {
             if (base[m.name] === undefined) {
                 base[m.name] = m;
             }
@@ -456,7 +456,7 @@ var $methodSet = function (typ) {
     }
 
     typ.methodSetCache = [];
-    Object.keys(base).sort().forEach(function (name) {
+    Object.keys(base).sort().forEach(name => {
         typ.methodSetCache.push(base[name]);
     });
     return typ.methodSetCache;
@@ -481,7 +481,7 @@ var $Complex128 = $newType(16, $kindComplex128, "complex128", true, "", false, n
 var $String = $newType(8, $kindString, "string", true, "", false, null);
 var $UnsafePointer = $newType(4, $kindUnsafePointer, "unsafe.Pointer", true, "unsafe", false, null);
 
-var $nativeArray = function (elemKind) {
+var $nativeArray = elemKind => {
     switch (elemKind) {
         case $kindInt:
             return Int32Array;
@@ -509,7 +509,7 @@ var $nativeArray = function (elemKind) {
             return Array;
     }
 };
-var $toNativeArray = function (elemKind, array) {
+var $toNativeArray = (elemKind, array) => {
     var nativeArray = $nativeArray(elemKind);
     if (nativeArray === Array) {
         return array;
@@ -517,7 +517,7 @@ var $toNativeArray = function (elemKind, array) {
     return new nativeArray(array);
 };
 var $arrayTypes = {};
-var $arrayType = function (elem, len) {
+var $arrayType = (elem, len) => {
     var typeKey = elem.id + "$" + len;
     var typ = $arrayTypes[typeKey];
     if (typ === undefined) {
@@ -528,7 +528,7 @@ var $arrayType = function (elem, len) {
     return typ;
 };
 
-var $chanType = function (elem, sendOnly, recvOnly) {
+var $chanType = (elem, sendOnly, recvOnly) => {
     var string = (recvOnly ? "<-" : "") + "chan" + (sendOnly ? "<- " : " ");
     if (!sendOnly && !recvOnly && (elem.string[0] == "<")) {
         string += "(" + elem.string + ")";
@@ -559,11 +559,11 @@ var $chanNil = new $Chan(null, 0);
 $chanNil.$sendQueue = $chanNil.$recvQueue = { length: 0, push: function () { }, shift: function () { return undefined; }, indexOf: function () { return -1; } };
 
 var $funcTypes = {};
-var $funcType = function (params, results, variadic) {
-    var typeKey = $mapArray(params, function (p) { return p.id; }).join(",") + "$" + $mapArray(results, function (r) { return r.id; }).join(",") + "$" + variadic;
+var $funcType = (params, results, variadic) => {
+    var typeKey = $mapArray(params, p => { return p.id; }).join(",") + "$" + $mapArray(results, r => { return r.id; }).join(",") + "$" + variadic;
     var typ = $funcTypes[typeKey];
     if (typ === undefined) {
-        var paramTypes = $mapArray(params, function (p) { return p.string; });
+        var paramTypes = $mapArray(params, p => { return p.string; });
         if (variadic) {
             paramTypes[paramTypes.length - 1] = "..." + paramTypes[paramTypes.length - 1].substr(2);
         }
@@ -571,7 +571,7 @@ var $funcType = function (params, results, variadic) {
         if (results.length === 1) {
             string += " " + results[0].string;
         } else if (results.length > 1) {
-            string += " (" + $mapArray(results, function (r) { return r.string; }).join(", ") + ")";
+            string += " (" + $mapArray(results, r => { return r.string; }).join(", ") + ")";
         }
         typ = $newType(4, $kindFunc, string, false, "", false, null);
         $funcTypes[typeKey] = typ;
@@ -581,13 +581,13 @@ var $funcType = function (params, results, variadic) {
 };
 
 var $interfaceTypes = {};
-var $interfaceType = function (methods) {
-    var typeKey = $mapArray(methods, function (m) { return m.pkg + "," + m.name + "," + m.typ.id; }).join("$");
+var $interfaceType = methods => {
+    var typeKey = $mapArray(methods, m => { return m.pkg + "," + m.name + "," + m.typ.id; }).join("$");
     var typ = $interfaceTypes[typeKey];
     if (typ === undefined) {
         var string = "interface {}";
         if (methods.length !== 0) {
-            string = "interface { " + $mapArray(methods, function (m) {
+            string = "interface { " + $mapArray(methods, m => {
                 return (m.pkg !== "" ? m.pkg + "." : "") + m.name + m.typ.string.substr(4);
             }).join("; ") + " }";
         }
@@ -603,7 +603,7 @@ var $error = $newType(8, $kindInterface, "error", true, "", false, null);
 $error.init([{ prop: "Error", name: "Error", pkg: "", typ: $funcType([], [$String], false) }]);
 
 var $mapTypes = {};
-var $mapType = function (key, elem) {
+var $mapType = (key, elem) => {
     var typeKey = key.id + "$" + elem.id;
     var typ = $mapTypes[typeKey];
     if (typ === undefined) {
@@ -613,7 +613,7 @@ var $mapType = function (key, elem) {
     }
     return typ;
 };
-var $makeMap = function (keyForFunc, entries) {
+var $makeMap = (keyForFunc, entries) => {
     var m = new Map();
     for (var i = 0; i < entries.length; i++) {
         var e = entries[i];
@@ -622,7 +622,7 @@ var $makeMap = function (keyForFunc, entries) {
     return m;
 };
 
-var $ptrType = function (elem) {
+var $ptrType = elem => {
     var typ = elem.ptr;
     if (typ === undefined) {
         typ = $newType(4, $kindPtr, "*" + elem.string, false, "", elem.exported, null);
@@ -632,28 +632,28 @@ var $ptrType = function (elem) {
     return typ;
 };
 
-var $newDataPointer = function (data, constructor) {
+var $newDataPointer = (data, constructor) => {
     if (constructor.elem.kind === $kindStruct) {
         return data;
     }
-    return new constructor(function () { return data; }, function (v) { data = v; });
+    return new constructor(() => { return data; }, v => { data = v; });
 };
 
-var $indexPtr = function (array, index, constructor) {
+var $indexPtr = (array, index, constructor) => {
     if (array.buffer) {
         // Pointers to the same underlying ArrayBuffer share cache.
         var cache = array.buffer.$ptr = array.buffer.$ptr || {};
         // Pointers of different primitive types are non-comparable and stored in different caches.
         var typeCache = cache[array.name] = cache[array.name] || {};
         var cacheIdx = array.BYTES_PER_ELEMENT * index + array.byteOffset;
-        return typeCache[cacheIdx] || (typeCache[cacheIdx] = new constructor(function () { return array[index]; }, function (v) { array[index] = v; }));
+        return typeCache[cacheIdx] || (typeCache[cacheIdx] = new constructor(() => { return array[index]; }, v => { array[index] = v; }));
     } else {
         array.$ptr = array.$ptr || {};
-        return array.$ptr[index] || (array.$ptr[index] = new constructor(function () { return array[index]; }, function (v) { array[index] = v; }));
+        return array.$ptr[index] || (array.$ptr[index] = new constructor(() => { return array[index]; }, v => { array[index] = v; }));
     }
 };
 
-var $sliceType = function (elem) {
+var $sliceType = elem => {
     var typ = elem.slice;
     if (typ === undefined) {
         typ = $newType(12, $kindSlice, "[]" + elem.string, false, "", false, null);
@@ -662,7 +662,7 @@ var $sliceType = function (elem) {
     }
     return typ;
 };
-var $makeSlice = function (typ, length, capacity) {
+var $makeSlice = (typ, length, capacity) => {
     capacity = capacity || length;
     if (length < 0 || length > 2147483647) {
         $throwRuntimeError("makeslice: len out of range");
@@ -682,11 +682,11 @@ var $makeSlice = function (typ, length, capacity) {
 };
 
 var $structTypes = {};
-var $structType = function (pkgPath, fields) {
-    var typeKey = $mapArray(fields, function (f) { return f.name + "," + f.typ.id + "," + f.tag; }).join("$");
+var $structType = (pkgPath, fields) => {
+    var typeKey = $mapArray(fields, f => { return f.name + "," + f.typ.id + "," + f.tag; }).join("$");
     var typ = $structTypes[typeKey];
     if (typ === undefined) {
-        var string = "struct { " + $mapArray(fields, function (f) {
+        var string = "struct { " + $mapArray(fields, f => {
             var str = f.typ.string + (f.tag !== "" ? (" \"" + f.tag.replace(/\\/g, "\\\\").replace(/"/g, "\\\"") + "\"") : "");
             if (f.embedded) {
                 return str;
@@ -713,7 +713,7 @@ var $structType = function (pkgPath, fields) {
     return typ;
 };
 
-var $assertType = function (value, type, returnTuple) {
+var $assertType = (value, type, returnTuple) => {
     var isInterface = (type.kind === $kindInterface), ok, missingMethod = "";
     if (value === $ifaceNil) {
         ok = false;


### PR DESCRIPTION
This is done with the help of [lebab](https://github.com/lebab/lebab).  More transformations could be done. In particular, by using `let` and `const`, instead of `var`, we can safely do a number of other conversions, however, this tool is not able to safely do the let/const conversion automatically, so we should probably do (or at least validate) that manually.