### PR TITLE
Ability to call overridden functions from the std library

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -117,7 +117,7 @@ func ImportDir(dir string, mode build.ImportMode, installSuffix string, buildTag
 	return pkg, nil
 }
 
-// Test if we find the '//gopherjs:keep_overridden' comment
+// Test if we find the '//gopherjs:keep-original' comment
 func findKeepOverriddenComment(doc *ast.CommentGroup) bool {
 	if doc == nil {
 		return false
@@ -127,7 +127,7 @@ func findKeepOverriddenComment(doc *ast.CommentGroup) bool {
 		if i := strings.Index(text, " "); i >= 0 {
 			text = text[:i]
 		}
-		if text == "//gopherjs:keep_overridden" {
+		if text == "//gopherjs:keep-original" {
 			return true
 		}
 	}
@@ -144,7 +144,7 @@ func findKeepOverriddenComment(doc *ast.CommentGroup) bool {
 // native overrides get added to the package (even if they have the same name
 // as an existing file from the standard library). For function identifiers that exist
 // in the original AND the overrides AND that include the following directive in their comment:
-// //gopherjs:keep_overridden, the original identifier in the AST gets prefixed by
+// //gopherjs:keep-original, the original identifier in the AST gets prefixed by
 // `_gopherjs_overridden_`. For other identifiers that exist in the original AND the overrides,
 // the original identifier gets replaced by `_`. New identifiers that don't exist in original
 // package get added.

--- a/build/build.go
+++ b/build/build.go
@@ -128,7 +128,7 @@ func ImportDir(dir string, mode build.ImportMode, installSuffix string, buildTag
 // as an existing file from the standard library). For function identifiers that exist
 // in the original AND the overrides AND that include the following directive in their comment:
 // //gopherjs:keep-original, the original identifier in the AST gets prefixed by
-// `_gopherjs_overridden_`. For other identifiers that exist in the original AND the overrides,
+// `_gopherjs_original_`. For other identifiers that exist in the original AND the overrides,
 // the original identifier gets replaced by `_`. New identifiers that don't exist in original
 // package get added.
 func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *token.FileSet) ([]*ast.File, []JSFile, error) {
@@ -251,8 +251,8 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 					}
 					if info.keepOriginal {
 						// Allow overridden function calls
-						// The standard library implementation of foo() becomes _gopherjs_overridden_foo()
-						d.Name.Name = "_gopherjs_overridden_" + d.Name.Name
+						// The standard library implementation of foo() becomes _gopherjs_original_foo()
+						d.Name.Name = "_gopherjs_original_" + d.Name.Name
 					} else {
 						d.Name = ast.NewIdent("_")
 					}

--- a/build/build.go
+++ b/build/build.go
@@ -118,7 +118,7 @@ func ImportDir(dir string, mode build.ImportMode, installSuffix string, buildTag
 }
 
 // Test if we find the '//gopherjs:keep_overridden' comment
-func findKeepOverridenComment(doc *ast.CommentGroup) bool {
+func findKeepOverriddenComment(doc *ast.CommentGroup) bool {
 	if doc == nil {
 		return false
 	}
@@ -152,7 +152,7 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 	var files []*ast.File
 
 	type overrideInfo struct {
-		keepOverriden bool
+		keepOverridden bool
 	}
 	replacedDeclNames := make(map[string]overrideInfo)
 	pruneOriginalFuncs := make(map[string]bool)
@@ -194,7 +194,7 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 				switch d := decl.(type) {
 				case *ast.FuncDecl:
 					k := astutil.FuncKey(d)
-					replacedDeclNames[k] = overrideInfo{keepOverriden: findKeepOverridenComment(d.Doc)}
+					replacedDeclNames[k] = overrideInfo{keepOverridden: findKeepOverriddenComment(d.Doc)}
 					pruneOriginalFuncs[k] = astutil.PruneOriginal(d)
 				case *ast.GenDecl:
 					switch d.Tok {
@@ -264,7 +264,7 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 						// GopherJS and pin unwanted imports.
 						d.Body = nil
 					}
-					if info.keepOverriden {
+					if info.keepOverridden {
 						// Allow overridden function calls
 						// The standard library implementation of foo() becomes _gopherjs_overridden_foo()
 						d.Name.Name = "_gopherjs_overridden_" + d.Name.Name

--- a/build/build.go
+++ b/build/build.go
@@ -117,23 +117,6 @@ func ImportDir(dir string, mode build.ImportMode, installSuffix string, buildTag
 	return pkg, nil
 }
 
-// Test if we find the '//gopherjs:keep-original' comment
-func findKeepOverriddenComment(doc *ast.CommentGroup) bool {
-	if doc == nil {
-		return false
-	}
-	for _, comment := range doc.List {
-		text := comment.Text
-		if i := strings.Index(text, " "); i >= 0 {
-			text = text[:i]
-		}
-		if text == "//gopherjs:keep-original" {
-			return true
-		}
-	}
-	return false
-}
-
 // parseAndAugment parses and returns all .go files of given pkg.
 // Standard Go library packages are augmented with files in compiler/natives folder.
 // If isTest is true and pkg.ImportPath has no _test suffix, package is built for running internal tests.
@@ -194,7 +177,7 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 				switch d := decl.(type) {
 				case *ast.FuncDecl:
 					k := astutil.FuncKey(d)
-					replacedDeclNames[k] = overrideInfo{keepOverridden: findKeepOverriddenComment(d.Doc)}
+					replacedDeclNames[k] = overrideInfo{keepOverridden: astutil.KeepOriginal(d)}
 					pruneOriginalFuncs[k] = astutil.PruneOriginal(d)
 				case *ast.GenDecl:
 					switch d.Tok {

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -93,6 +93,26 @@ func PruneOriginal(d *ast.FuncDecl) bool {
 	return false
 }
 
+// KeepOriginal returns true if gopherjs:keep-original directive is present
+// before a function decl.
+//
+// `//gopherjs:keep-original` is a GopherJS-specific directive, which can be
+// applied to functions in native overlays and will instruct the augmentation
+// logic to expose the original function such that it can be called. For a
+// function in the original called `foo`, it will be accessible by the name
+// `_gopherjs_overridden_foo`.
+func KeepOriginal(d *ast.FuncDecl) bool {
+	if d.Doc == nil {
+		return false
+	}
+	for _, c := range d.Doc.List {
+		if strings.HasPrefix(c.Text, "//gopherjs:keep-original") {
+			return true
+		}
+	}
+	return false
+}
+
 // FindLoopStmt tries to find the loop statement among the AST nodes in the
 // |stack| that corresponds to the break/continue statement represented by
 // branch.

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -100,7 +100,7 @@ func PruneOriginal(d *ast.FuncDecl) bool {
 // applied to functions in native overlays and will instruct the augmentation
 // logic to expose the original function such that it can be called. For a
 // function in the original called `foo`, it will be accessible by the name
-// `_gopherjs_overridden_foo`.
+// `_gopherjs_original_foo`.
 func KeepOriginal(d *ast.FuncDecl) bool {
 	if d.Doc == nil {
 		return false

--- a/compiler/natives/src/regexp/regexp_test.go
+++ b/compiler/natives/src/regexp/regexp_test.go
@@ -16,5 +16,5 @@ func TestOnePassCutoff(t *testing.T) {
 		}
 	}()
 
-	_gopherjs_overridden_TestOnePassCutoff(t)
+	_gopherjs_original_TestOnePassCutoff(t)
 }

--- a/compiler/natives/src/regexp/regexp_test.go
+++ b/compiler/natives/src/regexp/regexp_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+//gopherjs:keep_overridden
 func TestOnePassCutoff(t *testing.T) {
-	t.Skip() // "Maximum call stack size exceeded" on V8
+	defer func() {
+		if r := recover(); r != nil {
+			t.Log(r)
+			t.Skip("'Maximum call stack size exceeded' may happen on V8, skipping")
+		}
+	}()
+
+	_gopherjs_overridden_TestOnePassCutoff(t)
 }

--- a/compiler/natives/src/regexp/regexp_test.go
+++ b/compiler/natives/src/regexp/regexp_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-//gopherjs:keep_overridden
+//gopherjs:keep-original
 func TestOnePassCutoff(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Rebase of #798, and applied change suggested in https://github.com/gopherjs/gopherjs/pull/798#issuecomment-955238429, and a couple cleanups.