### PR TITLE
Fix a few outstanding bugs in generics handling

### DIFF
--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -27,10 +27,16 @@ func SetType(info *types.Info, t types.Type, e ast.Expr) ast.Expr {
 
 // NewVarIdent creates a new variable object with the given name and type.
 func NewVarIdent(name string, t types.Type, info *types.Info, pkg *types.Package) *ast.Ident {
-	ident := ast.NewIdent(name)
-	info.Types[ident] = types.TypeAndValue{Type: t}
-	obj := types.NewVar(0, pkg, name, t)
+	obj := types.NewVar(token.NoPos, pkg, name, t)
+	return NewIdentFor(info, obj)
+}
+
+// NewIdentFor creates a new identifier referencing the given object.
+func NewIdentFor(info *types.Info, obj types.Object) *ast.Ident {
+	ident := ast.NewIdent(obj.Name())
+	ident.NamePos = obj.Pos()
 	info.Uses[ident] = obj
+	SetType(info, obj.Type(), ident)
 	return ident
 }
 

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// RemoveParens removed parens around an expression, if any.
 func RemoveParens(e ast.Expr) ast.Expr {
 	for {
 		p, isParen := e.(*ast.ParenExpr)
@@ -18,12 +19,14 @@ func RemoveParens(e ast.Expr) ast.Expr {
 	}
 }
 
+// SetType of the expression e to type t.
 func SetType(info *types.Info, t types.Type, e ast.Expr) ast.Expr {
 	info.Types[e] = types.TypeAndValue{Type: t}
 	return e
 }
 
-func NewIdent(name string, t types.Type, info *types.Info, pkg *types.Package) *ast.Ident {
+// NewVarIdent creates a new variable object with the given name and type.
+func NewVarIdent(name string, t types.Type, info *types.Info, pkg *types.Package) *ast.Ident {
 	ident := ast.NewIdent(name)
 	info.Types[ident] = types.TypeAndValue{Type: t}
 	obj := types.NewVar(0, pkg, name, t)
@@ -31,6 +34,7 @@ func NewIdent(name string, t types.Type, info *types.Info, pkg *types.Package) *
 	return ident
 }
 
+// IsTypeExpr returns true if expr denotes a type.
 func IsTypeExpr(expr ast.Expr, info *types.Info) bool {
 	switch e := expr.(type) {
 	case *ast.ArrayType, *ast.ChanType, *ast.FuncType, *ast.InterfaceType, *ast.MapType, *ast.StructType:
@@ -57,6 +61,7 @@ func IsTypeExpr(expr ast.Expr, info *types.Info) bool {
 	}
 }
 
+// ImportsUnsafe returns true of the source imports package "unsafe".
 func ImportsUnsafe(file *ast.File) bool {
 	for _, imp := range file.Imports {
 		if imp.Path.Value == `"unsafe"` {

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -172,3 +172,30 @@ func EndsWithReturn(stmts []ast.Stmt) bool {
 		return false
 	}
 }
+
+// TypeCast wraps expression e into an AST of type conversion to a type denoted
+// by typeExpr. The new AST node is associated with the appropriate type.
+func TypeCast(info *types.Info, e ast.Expr, typeExpr ast.Expr) *ast.CallExpr {
+	cast := &ast.CallExpr{
+		Fun:    typeExpr,
+		Lparen: e.Pos(),
+		Args:   []ast.Expr{e},
+		Rparen: e.End(),
+	}
+	SetType(info, info.TypeOf(typeExpr), cast)
+	return cast
+}
+
+// TakeAddress wraps expression e into an AST of address-taking operator &e. The
+// new AST node is associated with pointer to the type of e.
+func TakeAddress(info *types.Info, e ast.Expr) *ast.UnaryExpr {
+	exprType := info.TypeOf(e)
+	ptrType := types.NewPointer(exprType)
+	addrOf := &ast.UnaryExpr{
+		OpPos: e.Pos(),
+		Op:    token.AND,
+		X:     e,
+	}
+	SetType(info, ptrType, addrOf)
+	return addrOf
+}

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -100,12 +100,24 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 
 	switch e := expr.(type) {
 	case *ast.CompositeLit:
+		if exprType, ok := exprType.(*types.TypeParam); ok {
+			// Composite literals can be used with a type parameter if it has a core
+			// type. However, because at compile time we don't know the concrete type
+			// the type parameter will take, we initialize the literal with the core
+			// type and cast it to the a type denoted by the type param at runtime.
+			litValue := fc.setType(&ast.CompositeLit{
+				Elts: e.Elts,
+			}, typesutil.CoreType(exprType))
+			cast := fc.typeCastExpr(litValue, fc.newIdentFor(exprType.Obj()))
+			return fc.translateExpr(cast)
+		}
+
 		if ptrType, isPointer := exprType.Underlying().(*types.Pointer); isPointer {
 			// Go automatically treats `[]*T{{}}` as `[]*T{&T{}}`, in which case the
 			// inner composite literal `{}` would has a pointer type. To make sure the
 			// type conversion is handled correctly, we generate the explicit AST for
 			// this.
-			var rewritten ast.Expr = fc.takeAddress(fc.setType(&ast.CompositeLit{
+			var rewritten ast.Expr = fc.takeAddressExpr(fc.setType(&ast.CompositeLit{
 				Elts: e.Elts,
 			}, ptrType.Elem()))
 
@@ -115,7 +127,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 				//   _ = []PS{{}}
 				// In that case the value corresponding to the inner literal `{}` is
 				// initialized as `&S{}` and then converted to `PS`: `[]PS{PS(&S{})}`.
-				rewritten = fc.typeCast(rewritten, fc.newIdentFor(exprType.Obj()))
+				rewritten = fc.typeCastExpr(rewritten, fc.newIdentFor(exprType.Obj()))
 			}
 			return fc.translateExpr(rewritten)
 		}
@@ -956,7 +968,7 @@ func (fc *funcContext) makeReceiver(e *ast.SelectorExpr) *expression {
 	_, pointerExpected := methodsRecvType.(*types.Pointer)
 	if !isPointer && pointerExpected {
 		recvType = types.NewPointer(recvType)
-		x = fc.takeAddress(x)
+		x = fc.takeAddressExpr(x)
 	}
 	if isPointer && !pointerExpected {
 		x = fc.setType(x, methodsRecvType)

--- a/compiler/filter/assign.go
+++ b/compiler/filter/assign.go
@@ -71,7 +71,7 @@ func Assign(stmt ast.Stmt, info *types.Info, pkg *types.Package) ast.Stmt {
 				return e
 
 			default:
-				tmpVar := astutil.NewIdent(name, info.TypeOf(e), info, pkg)
+				tmpVar := astutil.NewVarIdent(name, info.TypeOf(e), info, pkg)
 				list = append(list, &ast.AssignStmt{
 					Lhs: []ast.Expr{tmpVar},
 					Tok: token.DEFINE,

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -661,6 +661,10 @@ var $newDataPointer = function (data, constructor) {
 };
 
 var $indexPtr = function (array, index, constructor) {
+    if (constructor.kind == $kindPtr && constructor.elem.kind == $kindStruct) {
+        // Pointer to a struct is represented by the underlying object itself, no wrappers needed.
+        return array[index]
+    }
     if (array.buffer) {
         // Pointers to the same underlying ArrayBuffer share cache.
         var cache = array.buffer.$ptr = array.buffer.$ptr || {};

--- a/compiler/typesutil/coretype.go
+++ b/compiler/typesutil/coretype.go
@@ -1,0 +1,20 @@
+package typesutil
+
+import (
+	"go/types"
+	_ "unsafe" // for go:linkname
+)
+
+// Currently go/types doesn't offer a public API to determine type's core type.
+// Instead of importing a third-party reimplementation, I opted to hook into
+// the unexported implementation go/types already has.
+//
+// If https://github.com/golang/go/issues/60994 gets accepted, we will be able
+// to switch to the official API.
+
+// CoreType of the given type, or nil of it has no core type.
+// https://go.dev/ref/spec#Core_types
+func CoreType(t types.Type) types.Type { return coreTypeImpl(t) }
+
+//go:linkname coreTypeImpl go/types.coreType
+func coreTypeImpl(t types.Type) types.Type

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -451,11 +451,11 @@ func (fc *funcContext) setType(e ast.Expr, t types.Type) ast.Expr {
 	return astutil.SetType(fc.pkgCtx.Info.Info, t, e)
 }
 
-func (fc *funcContext) typeCast(e ast.Expr, typeExpr ast.Expr) *ast.CallExpr {
+func (fc *funcContext) typeCastExpr(e ast.Expr, typeExpr ast.Expr) *ast.CallExpr {
 	return astutil.TypeCast(fc.pkgCtx.Info.Info, e, typeExpr)
 }
 
-func (fc *funcContext) takeAddress(e ast.Expr) *ast.UnaryExpr {
+func (fc *funcContext) takeAddressExpr(e ast.Expr) *ast.UnaryExpr {
 	return astutil.TakeAddress(fc.pkgCtx.Info.Info, e)
 }
 

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
+	"github.com/gopherjs/gopherjs/compiler/astutil"
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
 )
 
@@ -406,18 +407,14 @@ func (fc *funcContext) newVariable(name string, level varLevel) string {
 // newIdent declares a new Go variable with the given name and type and returns
 // an *ast.Ident referring to that object.
 func (fc *funcContext) newIdent(name string, t types.Type) *ast.Ident {
-	obj := types.NewVar(0, fc.pkgCtx.Pkg, name, t)
+	obj := types.NewVar(token.NoPos, fc.pkgCtx.Pkg, name, t)
 	fc.pkgCtx.objectNames[obj] = name
 	return fc.newIdentFor(obj)
 }
 
 // newIdentFor creates a new *ast.Ident referring to the given Go object.
 func (fc *funcContext) newIdentFor(obj types.Object) *ast.Ident {
-	ident := ast.NewIdent(obj.Name())
-	ident.NamePos = obj.Pos()
-	fc.pkgCtx.Uses[ident] = obj
-	fc.setType(ident, obj.Type())
-	return ident
+	return astutil.NewIdentFor(fc.pkgCtx.Info.Info, obj)
 }
 
 // newLitFuncName generates a new synthetic name for a function literal.
@@ -451,8 +448,7 @@ func (fc *funcContext) typeParamVars(params *types.TypeParamList) []string {
 }
 
 func (fc *funcContext) setType(e ast.Expr, t types.Type) ast.Expr {
-	fc.pkgCtx.Types[e] = types.TypeAndValue{Type: t}
-	return e
+	return astutil.SetType(fc.pkgCtx.Info.Info, t, e)
 }
 
 func (fc *funcContext) pkgVar(pkg *types.Package) string {

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -451,6 +451,14 @@ func (fc *funcContext) setType(e ast.Expr, t types.Type) ast.Expr {
 	return astutil.SetType(fc.pkgCtx.Info.Info, t, e)
 }
 
+func (fc *funcContext) typeCast(e ast.Expr, typeExpr ast.Expr) *ast.CallExpr {
+	return astutil.TypeCast(fc.pkgCtx.Info.Info, e, typeExpr)
+}
+
+func (fc *funcContext) takeAddress(e ast.Expr) *ast.UnaryExpr {
+	return astutil.TakeAddress(fc.pkgCtx.Info.Info, e)
+}
+
 func (fc *funcContext) pkgVar(pkg *types.Package) string {
 	if pkg == fc.pkgCtx.Pkg {
 		return "$pkg"

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -183,7 +183,6 @@ var knownFails = map[string]failReason{
 	"typeparam/ordered.go":           {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/orderedmap.go":        {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/sets.go":              {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/settable.go":          {category: generics, desc: "undiagnosed: len() returns an invalid value on a generic function result"},
 	"typeparam/slices.go":            {category: generics, desc: "missing operator support for generic types"},
 	"typeparam/subdict.go":           {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/typeswitch2.go":       {category: generics, desc: "complex types have different print() format"},

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -149,6 +149,7 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue48898.go": {category: other, desc: "https://github.com/gopherjs/gopherjs/issues/1128"},
 	"fixedbugs/issue48536.go": {category: usesUnsupportedPackage, desc: "https://github.com/gopherjs/gopherjs/issues/1130"},
 	"fixedbugs/issue53600.go": {category: lowLevelRuntimeDifference, desc: "GopherJS println format is different from Go's"},
+	"typeparam/issue51733.go": {category: usesUnsupportedPackage, desc: "unsafe: uintptr to struct pointer conversion is unsupported"},
 
 	// Failures related to the lack of generics support. Ideally, this section
 	// should be emptied once https://github.com/gopherjs/gopherjs/issues/1013 is
@@ -175,7 +176,6 @@ var knownFails = map[string]failReason{
 	"typeparam/issue51303.go":        {category: generics, desc: "missing support for conversion into a parameterized type"},
 	"typeparam/issue51522a.go":       {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/issue51522b.go":       {category: generics, desc: "missing support for the comparable type constraint"},
-	"typeparam/issue51733.go":        {category: generics, desc: "undiagnosed: unsafe.Pointer to struct pointer conversion"},
 	"typeparam/list.go":              {category: generics, desc: "missing operator support for generic types"},
 	"typeparam/maps.go":              {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/metrics.go":           {category: generics, desc: "missing support for the comparable type constraint"},

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -172,7 +172,6 @@ var knownFails = map[string]failReason{
 	"typeparam/issue48453.go":        {category: generics, desc: "make() doesn't support generic slice types"},
 	"typeparam/issue49295.go":        {category: generics, desc: "len() doesn't support generic pointer to array types"},
 	"typeparam/issue50193.go":        {category: generics, desc: "invalid print format for complex numbers"},
-	"typeparam/issue50833.go":        {category: generics, desc: "undiagnosed: compiler panic triggered by a composite literal"},
 	"typeparam/issue51303.go":        {category: generics, desc: "missing support for conversion into a parameterized type"},
 	"typeparam/issue51522a.go":       {category: generics, desc: "missing support for the comparable type constraint"},
 	"typeparam/issue51522b.go":       {category: generics, desc: "missing support for the comparable type constraint"},


### PR DESCRIPTION
 - Fix a compiler panic caused by composite literals like `T{f: 1}` where `T` is a type param.
 - Fix address taking of an array/slice element where the array is element type is a type param and the concrete type is a struct.
 - Reclassify one of the test failures as unrelated to generics, since it uses unsafe if ways we don't support.

While at it, make a few small refactorings of the AST utility methods.

See commit messages for the detailed information. At this point all remaining typeparam test failures seem to be related to unimplemented features rather than bugs.

Updates #1013 