### PR TITLE
Decrement $stackDepthOffset in deferred wrapper func

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -841,7 +841,7 @@ func (fc *funcContext) translateCall(e *ast.CallExpr, sig *types.Signature, fun 
 // where we need to compute function and its arguments at the the keyword site,
 // but the call itself will happen elsewhere (hence "delegated").
 //
-// Built-in functions and cetrain `js.Object` methods don't translate into JS
+// Built-in functions and certain `js.Object` methods don't translate into JS
 // function calls, and need to be wrapped before they can be delegated, which
 // this function handles and returns JS expressions that are safe to delegate
 // and behave like a regular JS function and a list of its argument values.


### PR DESCRIPTION
This is my attempt to implement the solution described [here](https://github.com/gopherjs/gopherjs/issues/1127#issuecomment-1186582490).  If I'm honest, it's a bit of a stab in the dark, as I don't have a full grasp of how this `$stackDepthOffset` variable is inc/decremented throughout the code.