### PR TITLE
natives: duplicate aliasing.go in x/crypto revisted

### DIFF
--- a/compiler/natives/src/golang.org/x/crypto/internal/alias/alias.go
+++ b/compiler/natives/src/golang.org/x/crypto/internal/alias/alias.go
@@ -1,7 +1,7 @@
 //go:build js
 // +build js
 
-package subtle
+package alias
 
 // This file duplicated is these two locations:
 // - src/crypto/internal/subtle/aliasing.go

--- a/compiler/natives/src/golang.org/x/crypto/internal/subtle/aliasing.go
+++ b/compiler/natives/src/golang.org/x/crypto/internal/subtle/aliasing.go
@@ -4,8 +4,9 @@
 package subtle
 
 // This file duplicated is these two locations:
-// - src/crypto/internal/subtle/
-// - src/golang.org/x/crypto/internal/subtle/
+// - src/crypto/internal/subtle/aliasing.go
+// - src/golang.org/x/crypto/internal/subtle/aliasing.go
+// - src/golang.org/x/crypto/internal/alias/alias.go
 
 import "github.com/gopherjs/gopherjs/js"
 


### PR DESCRIPTION
Same as fcd349a8b55efd1bb45c715624591e75dd237138.

x/crypto internally moved the AnyOverlap from
x/crypto/internal/subtle/ to /x/crypto/internal/alias/.