### PR TITLE
support internalising structs

### DIFF
--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -384,6 +384,19 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
             if (o !== noJsObject) {
                 return o;
             }
+            var n = new t.ptr();
+            for (var i = 0; i < t.fields.length; i++) {
+              var f = t.fields[i];
+      
+              if (!f.exported) {
+                continue;
+              }
+              var jsProp = v[f.name];
+      
+              n[f.prop] = $internalize(jsProp, f.typ, recv, seen, makeWrapper);
+            }
+      
+            return n;
     }
     $throwRuntimeError("cannot internalize " + t.string);
 };


### PR DESCRIPTION
This PR adds code that maps JavaScript object fields to Go struct fields.
Updated the $kindStruct case with a loop to dynamically map JavaScript object fields to corresponding Go struct fields.

Stuff I've tested,

- [x] simple object to struct conversion
- [x] an object that is nested within an object
- [x] exported/none exported fields

possibly fixes #975 