### PR TITLE
Bump xcode version used in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -198,7 +198,7 @@ jobs:
     
   darwin_smoke:
     macos:
-      xcode: 13.3.0  # Mac OS 12.2.1
+      xcode: 13.4.1 # Mac OS 12.6.1, see https://circleci.com/docs/using-macos/
     steps:
       - checkout
       - setup_environment


### PR DESCRIPTION
Some recent PRs have failed, apparently due to CircleCI dropping support for the old version of xcode we were using.  This bumps up to the oldest version currently supported. Maybe we want something much newer, but as a non-Mac user, I'm not really sure what that might entail, so making the most conservitive change possible.