### PR TITLE
Avoid build failures with Go 1.21.0 installed in the environment.

### DIFF
--- a/build/context.go
+++ b/build/context.go
@@ -179,7 +179,7 @@ func (sc simpleCtx) gotool(subcommand string, args ...string) (string, error) {
 		panic(fmt.Errorf("can't use go tool with a virtual build context"))
 	}
 	args = append([]string{subcommand}, args...)
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(filepath.Join(sc.bctx.GOROOT, "bin", "go"), args...)
 
 	if sc.bctx.Dir != "" {
 		cmd.Dir = sc.bctx.Dir


### PR DESCRIPTION
```console
$ GOPHERJS_GOROOT="$(go1.18.10 env GOROOT)" gopherjs build
failed to expand patterns []: failed to list packages in the primary context: failed to list packages on FS: go tool error: /home/makki/Development/go/bin/go list -e -compiler=gc -tags=netgo,purego,math_big_pure_go,gopherjs -installsuffix= -f={{.ImportPath}} --: exit status 1
go: updates to go.mod needed; to update it:
        go mod tidy
```

This error occurred when the built module targets a version earlier than go 1.21.0 in go.mod, while the imported package targets go 1.21.0.
In such cases, go 1.21.0 requires us to run `go mod tidy`, which was not required in previous versions of go.

Please see the example for detail: [github.com/makiuchi-d/gopherjs-fail-example](/makiuchi-d/gopherjs-fail-example)


In the GopherJS build process, gopherjs calls `go`, and go 1.21.0 is used when it's installed under the `$PATH`.
To avoid this error, we should use `$GOPHERJS_GOROOT/bin/go` instead of the `go` under the `$PATH`.
