### PR TITLE
nosync: fix build for golang.org/x/tools/internal/tokeninternal

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -99,7 +99,8 @@ jobs:
           set -e
           export GO111MODULE=off
           export GOPATH=/tmp/gopath
-          mkdir -p $GOPATH/src
+          mkdir -p $GOPATH/src/github.com/gopherjs/gopherjs
+          cp -r -p . $GOPATH/src/github.com/gopherjs/gopherjs/
           go get -v github.com/gopherjs/todomvc
           gopherjs build -v -o /tmp/todomvc_gopath.js github.com/gopherjs/todomvc
           gopherjs test -v github.com/gopherjs/todomvc/...

--- a/nosync/mutex.go
+++ b/nosync/mutex.go
@@ -3,7 +3,9 @@ package nosync
 // Mutex is a dummy which is non-blocking.
 type Mutex struct {
 	locked bool
-	_      [3]bool
+	_      bool
+	_      bool
+	_      bool
 	_      uint32
 }
 
@@ -27,7 +29,9 @@ func (m *Mutex) Unlock() {
 type RWMutex struct {
 	_               Mutex
 	writeLocked     bool
-	_               [3]bool
+	_               bool
+	_               bool
+	_               bool
 	readLockCounter int32
 	_               int32
 	_               int32

--- a/nosync/mutex.go
+++ b/nosync/mutex.go
@@ -3,6 +3,8 @@ package nosync
 // Mutex is a dummy which is non-blocking.
 type Mutex struct {
 	locked bool
+	_      [3]bool
+	_      uint32
 }
 
 // Lock locks m. It is a run-time error if m is already locked.
@@ -23,8 +25,12 @@ func (m *Mutex) Unlock() {
 
 // RWMutex is a dummy which is non-blocking.
 type RWMutex struct {
+	_               Mutex
 	writeLocked     bool
-	readLockCounter int
+	_               [3]bool
+	readLockCounter int32
+	_               int32
+	_               int32
 }
 
 // Lock locks m for writing. It is a run-time error if rw is already locked for reading or writing.

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -1,12 +1,15 @@
 package tests
 
 import (
+	"go/token"
 	"math"
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/gopherjs/gopherjs/tests/otherpkg"
 )
@@ -939,5 +942,20 @@ func TestCompositeLiterals(t *testing.T) {
 	s2 := []SP{{}}
 	if got := reflect.TypeOf(s2[0]); got.String() != "tests.SP" {
 		t.Errorf("Got: reflect.TypeOf(s2[0]) = %v. Want: tests.SP", got)
+	}
+}
+
+func TestFileSetSize(t *testing.T) {
+	type tokenFileSet struct {
+		// This type remained essentially consistent from go1.16 to go1.21.
+		mutex sync.RWMutex
+		base  int
+		files []*token.File
+		_     *token.File // changed to atomic.Pointer[token.File] in go1.19
+	}
+	n1 := unsafe.Sizeof(tokenFileSet{})
+	n2 := unsafe.Sizeof(token.FileSet{})
+	if n1 != n2 {
+		t.Errorf("Got: unsafe.Sizeof(token.FileSet{}) %v, Want: %v", n2, n1)
 	}
 }


### PR DESCRIPTION
fix build for golang.org/x/tools/internal/tokeninternal

```
// require golang.org/x/tools v0.12.1-0.20230901210945-21090a2aa8d3

package main

import (
	_ "golang.org/x/tools/go/gcexportdata"
)
func main() {
}
```
dump error
```
../../../go/pkg/mod/golang.org/x/tools@v0.12.1-0.20230901210945-21090a2aa8d3/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta
 * delta (constant -64 of type int64)
```

fixed:
Full in size nosync.RWMutex => sync.RWMutex