### PR TITLE
fix build for golang.org/x/tools/internal/tokeninternal

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -226,16 +226,13 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 			continue
 		}
 
-		switch pkg.ImportPath {
-		case "crypto/rand", "encoding/gob", "encoding/json", "expvar", "go/token", "log", "math/big", "math/rand", "regexp", "time":
-			for _, spec := range file.Imports {
-				path, _ := strconv.Unquote(spec.Path.Value)
-				if path == "sync" {
-					if spec.Name == nil {
-						spec.Name = ast.NewIdent("sync")
-					}
-					spec.Path.Value = `"github.com/gopherjs/gopherjs/nosync"`
+		for _, spec := range file.Imports {
+			path, _ := strconv.Unquote(spec.Path.Value)
+			if path == "sync" {
+				if spec.Name == nil {
+					spec.Name = ast.NewIdent("sync")
 				}
+				spec.Path.Value = `"github.com/gopherjs/gopherjs/nosync"`
 			}
 		}
 

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -1,12 +1,15 @@
 package tests
 
 import (
+	"go/token"
 	"math"
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/gopherjs/gopherjs/tests/otherpkg"
 )
@@ -939,5 +942,20 @@ func TestCompositeLiterals(t *testing.T) {
 	s2 := []SP{{}}
 	if got := reflect.TypeOf(s2[0]); got.String() != "tests.SP" {
 		t.Errorf("Got: reflect.TypeOf(s2[0]) = %v. Want: tests.SP", got)
+	}
+}
+
+func TestFileSetSize(t *testing.T) {
+	type tokenFileSet struct {
+		// This type remained essentially consistent from go1.16 to go1.21.
+		mutex sync.RWMutex
+		base  int
+		files []*token.File
+		_     *token.File // changed to atomic.Pointer[token.File] in go1.19
+	}
+	n1 := unsafe.Sizeof(tokenFileSet{})
+	n2 := unsafe.Sizeof(token.FileSet{})
+	if n1 != n2 {
+		t.Errorf("Got: unsafe.Sizeof(token.FileSet{}) %v, Want: %v", n2, n1)
 	}
 }


### PR DESCRIPTION
fix build for golang.org/x/tools/internal/tokeninternal
```
// require golang.org/x/tools v0.12.1-0.20230901210945-21090a2aa8d3

package main

import (
	_ "golang.org/x/tools/go/gcexportdata"
)
func main() {
}
```
gopherjs build dump error
```
../../../go/pkg/mod/golang.org/x/tools@v0.12.1-0.20230901210945-21090a2aa8d3/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta
 * delta (constant -64 of type int64)
```