### PR TITLE
Fix minified variable name collision in a type generic factory function.

### DIFF
--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -572,7 +572,14 @@ func (fc *funcContext) typeName(ty types.Type) string {
 		}
 		return fmt.Sprintf("(%s(%s))", fc.objectName(t.Obj()), strings.Join(args, ","))
 	case *types.TypeParam:
-		return fc.objectName(fc.pkgCtx.canonicalTypeParams.Lookup(t).Obj())
+		o := t.Obj()
+		if fc.funcObject == nil {
+			// If the current context is not associated with a function or method,
+			// we processing type declaration, so we canonicalize method's type
+			// parameter names to their receiver counterparts.
+			o = fc.pkgCtx.canonicalTypeParams.Lookup(t).Obj()
+		}
+		return fc.objectName(o)
 	case *types.Interface:
 		if t.Empty() {
 			return "$emptyInterface"

--- a/tests/typeparams/low_level_test.go
+++ b/tests/typeparams/low_level_test.go
@@ -1,0 +1,49 @@
+package typeparams
+
+import "testing"
+
+// This file contains test cases for low-level details of typeparam
+// implementation like variable name assignment.
+
+type TypeParamNameMismatch[T any] struct{}
+
+func (TypeParamNameMismatch[T1]) M(_ T1) {}
+
+func TestTypeParamNameMismatch(t *testing.T) {
+	// This test case exercises the case when the same typeparam is named
+	// differently between the struct definition and one of its methods. GopherJS
+	// must allocate the same JS variable name to both instances of the type param
+	// in order to make it possible for the reflection method data to be evaluated
+	// within the type's generic factory function.
+
+	a := TypeParamNameMismatch[int]{}
+	a.M(0) // Make sure the method is not eliminated as dead code.
+}
+
+type (
+	TypeParamVariableCollision1[T any] struct{}
+	TypeParamVariableCollision2[T any] struct{}
+	TypeParamVariableCollision3[T any] struct{}
+)
+
+func (TypeParamVariableCollision1[T]) M() {}
+func (TypeParamVariableCollision2[T]) M() {}
+func (TypeParamVariableCollision3[T]) M() {}
+
+func TestTypeParamVariableCollision(t *testing.T) {
+	// This test case exercises a situation when in minified mode the variable
+	// name that gets assigned to the type parameter in the method's generic
+	// factory function collides with a different variable in the type's generic
+	// factory function. The bug occurred because the JS variable name allocated
+	// to the *types.TypeName object behind a type param within the method's
+	// factory function was not marked as used within type's factory function.
+
+	// Note: to trigger the bug, a package should contain multiple generic types,
+	// so that sequentially allocated minified variable names get far enough to
+	// cause the collision.
+
+	// Make sure types and methods are not eliminated as dead code.
+	TypeParamVariableCollision1[int]{}.M()
+	TypeParamVariableCollision2[int]{}.M()
+	TypeParamVariableCollision3[int]{}.M()
+}


### PR DESCRIPTION
Prior to this change we always canonicalized method's type parameter names to their receiver counterparts. This was mainly necessary to avoid errors when we needed to reference method's type parameters inside a type generic factory function, e.g. when initializing method's reflection metadata.

Such implementation, however, was causing a bug when minification is enabled:

 1. Methods are compiled first, variable names are allocated to their type parameters and the association is stored in the package context.
 2. The allocated variable name is marked as in use within the mathod's functionContext, up to the enclosing generic factory function context, but not at the package level.
 3. Type definitions are compiled second. Because the type's typeparams are already associated with variable names, these variable names are used. The process of allocating a new variable is omitted and the previously allocated name is not marked as allocated within the type's generic factory function.
 4. A new variable inside the type's generic factory function is allocated, and its name may collide with the type param's variable leading to errors.

With this change, canonicalization is only done if we are outside of the method's functionContext. That way no variable name is associated with type's typeparam objects while compiling the method, and the JS variable is correctly allocated and marked as in use.

Updates #1013 