### PR TITLE
Revert "reflect.DeepEquals: channels of the same underlying type can be equal."

### DIFF
--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1639,7 +1639,7 @@ func DeepEqual(a1, a2 interface{}) bool {
 	if i1 == i2 {
 		return true
 	}
-	if i1 == nil || i2 == nil {
+	if i1 == nil || i2 == nil || i1.Get("constructor") != i2.Get("constructor") {
 		return false
 	}
 	return deepValueEqualJs(ValueOf(a1), ValueOf(a2), nil)
@@ -1649,11 +1649,6 @@ func deepValueEqualJs(v1, v2 Value, visited [][2]unsafe.Pointer) bool {
 	if !v1.IsValid() || !v2.IsValid() {
 		return !v1.IsValid() && !v2.IsValid()
 	}
-
-	if v1.Kind() == Chan && v2.Kind() == Chan {
-		return v1.object() == v2.object()
-	}
-
 	if v1.Type() != v2.Type() {
 		return false
 	}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -959,31 +959,3 @@ func TestFileSetSize(t *testing.T) {
 		t.Errorf("Got: unsafe.Sizeof(token.FileSet{}) %v, Want: %v", n2, n1)
 	}
 }
-
-func TestChanEquality(t *testing.T) {
-	type ch chan string
-
-	ch1 := make(chan string)
-	ch2 := make(ch)
-	ch3 := ch(ch1)
-
-	t.Run("equal", func(t *testing.T) {
-		if ch1 != ch3 {
-			t.Errorf("Got: ch1 != ch3. Want: channels created by the same call to make are equal.")
-		}
-		if runtime.Compiler != "gopherjs" {
-			t.Skip("https://github.com/golang/go/issues/63886")
-		}
-		if !reflect.DeepEqual(ch1, ch3) {
-			t.Errorf("Got: reflect.DeepEqual(ch1, ch3) == false. Want: channels created by the same call to make are equal.")
-		}
-	})
-	t.Run("not equal", func(t *testing.T) {
-		if ch1 == ch2 {
-			t.Errorf("Got: ch1 == ch2. Want: channels created by different calls to make are not equal.")
-		}
-		if reflect.DeepEqual(ch1, ch2) {
-			t.Errorf("Got: reflect.DeepEqual(ch1, ch2) == true. Want: channels created by different calls to make are not equal.")
-		}
-	})
-}


### PR DESCRIPTION
In https://github.com/golang/go/issues/63886 it was pointed out that DeepEqual doc says: "Values of distinct types are never deeply equal", so the existing behavior is, in fact, correct even if somewhat surprising.

This reverts commit b66fa5779288949531caaf13f9d4e75e3e02e010.

#1013 