### PR TITLE
Add type parameter support for built-in functions.

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1565,10 +1565,15 @@ func (fc *funcContext) formatExprInternal(format string, a []interface{}, parens
 				out.WriteString(strconv.FormatInt(d, 10))
 				return
 			}
-			if is64Bit(fc.pkgCtx.TypeOf(e).Underlying().(*types.Basic)) {
+			if t, ok := fc.pkgCtx.TypeOf(e).Underlying().(*types.Basic); ok && is64Bit(t) {
 				out.WriteString("$flatten64(")
 				writeExpr("")
 				out.WriteString(")")
+				return
+			} else if t, ok := fc.pkgCtx.TypeOf(e).(*types.TypeParam); ok {
+				out.WriteString("$flatten64(")
+				writeExpr("")
+				fmt.Fprintf(out, ", %s)", fc.typeName(t))
 				return
 			}
 			writeExpr("")

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1072,6 +1072,8 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 			return fc.formatExpr("(%e ? %e.size : 0)", args[0], args[0])
 		case *types.Chan:
 			return fc.formatExpr("%e.$buffer.length", args[0])
+		case *types.Interface: // *types.TypeParam has interface as underlying type.
+			return fc.formatExpr("%s.$len(%e)", fc.typeName(fc.pkgCtx.TypeOf(args[0])), args[0])
 		// length of array is constant
 		default:
 			panic(fmt.Sprintf("Unhandled len type: %T\n", argType))

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1099,11 +1099,11 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 			argStr := fc.translateArgs(sig, args, ellipsis)
 			return fc.formatExpr("$appendSlice(%s, %s)", argStr[0], argStr[1])
 		}
-		sliceType := sig.Results().At(0).Type().Underlying().(*types.Slice)
-		return fc.formatExpr("$append(%e, %s)", args[0], strings.Join(fc.translateExprSlice(args[1:], sliceType.Elem()), ", "))
+		elType := sig.Params().At(1).Type().(*types.Slice).Elem()
+		return fc.formatExpr("$append(%e, %s)", args[0], strings.Join(fc.translateExprSlice(args[1:], elType), ", "))
 	case "delete":
 		args = fc.expandTupleArgs(args)
-		keyType := fc.pkgCtx.TypeOf(args[0]).Underlying().(*types.Map).Key()
+		keyType := sig.Params().At(1).Type()
 		return fc.formatExpr(
 			`$mapDelete(%1e, %2s.keyFor(%3s))`,
 			args[0],

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1084,9 +1084,13 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 			return fc.formatExpr("%e.$capacity", args[0])
 		case *types.Pointer:
 			return fc.formatExpr("(%e, %d)", args[0], argType.Elem().(*types.Array).Len())
-		// capacity of array is constant
+		case *types.Array:
+			// This should never happen™
+			panic(fmt.Errorf("array capacity should have been inlined as constant"))
+		case *types.Interface: // *types.TypeParam has interface as underlying type.
+			return fc.formatExpr("%s.$cap(%e)", fc.typeName(fc.pkgCtx.TypeOf(args[0])), args[0])
 		default:
-			panic(fmt.Sprintf("Unhandled cap type: %T\n", argType))
+			panic(fmt.Errorf("unhandled cap type: %T", argType))
 		}
 	case "panic":
 		return fc.formatExpr("$panic(%s)", fc.translateImplicitConversion(args[0], types.NewInterface(nil, nil)))

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1112,10 +1112,8 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 		)
 	case "copy":
 		args = fc.expandTupleArgs(args)
-		if basic, isBasic := fc.pkgCtx.TypeOf(args[1]).Underlying().(*types.Basic); isBasic && isString(basic) {
-			return fc.formatExpr("$copyString(%e, %e)", args[0], args[1])
-		}
-		return fc.formatExpr("$copySlice(%e, %e)", args[0], args[1])
+		dst, src := args[0], args[1]
+		return fc.formatExpr("%s.$copy(%e, %e)", fc.typeName(fc.pkgCtx.TypeOf(src)), dst, src)
 	case "print":
 		args = fc.expandTupleArgs(args)
 		return fc.formatExpr("$print(%s)", strings.Join(fc.translateExprSlice(args, nil), ", "))

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -94,6 +94,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
             typ.wrap = (v) => new typ(v);
             typ.keyFor = x => { return "$" + x; };
             typ.$len = (v) => v.length;
+            typ.$copy = (dst, src) => $copyString(dst, src);
             break;
 
         case $kindFloat32:
@@ -267,6 +268,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
             typ.$make = (size, capacity) => $makeSlice(typ, size, capacity);
             typ.$len = (v) => v.$length;
             typ.$cap = (v) => v.$capacity;
+            typ.$copy = (dst, src) => $copySlice(dst, src);
             break;
 
         case $kindStruct:

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -93,6 +93,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
             typ.wrapped = true;
             typ.wrap = (v) => new typ(v);
             typ.keyFor = x => { return "$" + x; };
+            typ.$len = (v) => v.length;
             break;
 
         case $kindFloat32:
@@ -163,6 +164,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.ptr.init(typ);
                 Object.defineProperty(typ.ptr.nil, "nilCheck", { get: $throwNilPointerError });
             };
+            typ.$len = (v) => typ.len;
             break;
 
         case $kindChan:
@@ -176,6 +178,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.recvOnly = recvOnly;
             };
             typ.$make = (bufsize) => new $Chan(typ.elem, bufsize ? bufsize : 0);
+            typ.$len = (v) => v.$buffer.length;
             break;
 
         case $kindFunc:
@@ -216,6 +219,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 if (size < 0 || size > 2147483647) { $throwRuntimeError("makemap: size out of range"); }
                 return new $global.Map();
             };
+            typ.$len = (v) => v ? v.size : 0;
             break;
 
         case $kindPtr:
@@ -236,6 +240,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 }
                 typ.nil = new typ($throwNilPointerError, $throwNilPointerError);
             };
+            typ.$len = (v) => typ.elem.$len(typ.wrapped ? v : v.$get());
             break;
 
         case $kindSlice:
@@ -257,6 +262,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.nil = new typ([]);
             };
             typ.$make = (size, capacity) => $makeSlice(typ, size, capacity);
+            typ.$len = (v) => v.$length;
             break;
 
         case $kindStruct:

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -165,6 +165,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 Object.defineProperty(typ.ptr.nil, "nilCheck", { get: $throwNilPointerError });
             };
             typ.$len = (v) => typ.len;
+            typ.$cap = (v) => typ.len;
             break;
 
         case $kindChan:
@@ -179,6 +180,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
             };
             typ.$make = (bufsize) => new $Chan(typ.elem, bufsize ? bufsize : 0);
             typ.$len = (v) => v.$buffer.length;
+            typ.$cap = (v) => v.$capacity;
             break;
 
         case $kindFunc:
@@ -241,6 +243,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.nil = new typ($throwNilPointerError, $throwNilPointerError);
             };
             typ.$len = (v) => typ.elem.$len(typ.wrapped ? v : v.$get());
+            typ.$cap = (v) => typ.elem.$cap(typ.wrapped ? v : v.$get());
             break;
 
         case $kindSlice:
@@ -263,6 +266,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
             };
             typ.$make = (size, capacity) => $makeSlice(typ, size, capacity);
             typ.$len = (v) => v.$length;
+            typ.$cap = (v) => v.$capacity;
             break;
 
         case $kindStruct:

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -175,6 +175,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.sendOnly = sendOnly;
                 typ.recvOnly = recvOnly;
             };
+            typ.$make = (bufsize) => new $Chan(typ.elem, bufsize ? bufsize : 0);
             break;
 
         case $kindFunc:
@@ -209,6 +210,11 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.key = key;
                 typ.elem = elem;
                 typ.comparable = false;
+            };
+            typ.$make = (size) => {
+                if (size === undefined) { size = 0; }
+                if (size < 0 || size > 2147483647) { $throwRuntimeError("makemap: size out of range"); }
+                return new $global.Map();
             };
             break;
 
@@ -250,6 +256,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.nativeArray = $nativeArray(elem.kind);
                 typ.nil = new typ([]);
             };
+            typ.$make = (size, capacity) => $makeSlice(typ, size, capacity);
             break;
 
         case $kindStruct:

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -855,7 +855,7 @@ var $ptrType = elem => {
 };
 
 var $newDataPointer = (data, constructor) => {
-    if (constructor.elem.kind === $kindStruct) {
+    if (constructor.elem.kind === $kindStruct || constructor.elem.kind === $kindArray) {
         return data;
     }
     return new constructor(() => { return data; }, v => { data = v; });

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -704,6 +704,8 @@ func toJavaScriptType(t *types.Basic) string {
 		return "Int32"
 	case types.UnsafePointer:
 		return "UnsafePointer"
+	case types.UntypedString:
+		return "String"
 	default:
 		name := t.String()
 		return strings.ToUpper(name[:1]) + name[1:]

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -155,20 +155,18 @@ var knownFails = map[string]failReason{
 	// Failures related to the lack of generics support. Ideally, this section
 	// should be emptied once https://github.com/gopherjs/gopherjs/issues/1013 is
 	// fixed.
-	"typeparam/absdiff2.go":          {category: generics, desc: "missing support for unary minus operator"},
-	"typeparam/absdiff3.go":          {category: generics, desc: "missing support for unary minus operator"},
-	"typeparam/boundmethod.go":       {category: generics, desc: "missing support for method expressions with a type param"},
-	"typeparam/dictionaryCapture.go": {category: generics, desc: "make() doesn't support generic slice types"},
-	"typeparam/double.go":            {category: generics, desc: "make() doesn't support generic slice types"},
-	"typeparam/index2.go":            {category: generics, desc: "missing index operator support for generic types"},
-	"typeparam/issue47716.go":        {category: generics, desc: "unsafe.Sizeof() doesn't work with generic types"},
-	"typeparam/issue48453.go":        {category: generics, desc: "make() doesn't support generic slice types"},
-	"typeparam/issue49295.go":        {category: generics, desc: "len() doesn't support generic pointer to array types"},
-	"typeparam/issue51303.go":        {category: generics, desc: "missing support for range over type parameter"},
-	"typeparam/nested.go":            {category: generics, desc: "missing comparison operator support for generic types"},
-	"typeparam/typeswitch2.go":       {category: generics, desc: "complex types have different print() format"},
-	"typeparam/typeswitch3.go":       {category: generics, desc: "missing support for type switching on generic types"},
-	"typeparam/typeswitch5.go":       {category: generics, desc: "different print() format for floating point types"},
+	"typeparam/absdiff2.go":    {category: generics, desc: "missing support for unary minus operator"},
+	"typeparam/absdiff3.go":    {category: generics, desc: "missing support for unary minus operator"},
+	"typeparam/boundmethod.go": {category: generics, desc: "missing support for method expressions with a type param"},
+	"typeparam/double.go":      {category: generics, desc: "missing support for range over type parameter"},
+	"typeparam/index2.go":      {category: generics, desc: "missing index operator support for generic types"},
+	"typeparam/issue47716.go":  {category: generics, desc: "unsafe.Sizeof() doesn't work with generic types"},
+	"typeparam/issue48453.go":  {category: generics, desc: "missing support for range over type parameter"},
+	"typeparam/issue51303.go":  {category: generics, desc: "missing support for range over type parameter"},
+	"typeparam/nested.go":      {category: generics, desc: "missing comparison operator support for generic types"},
+	"typeparam/typeswitch2.go": {category: generics, desc: "complex types have different print() format"},
+	"typeparam/typeswitch3.go": {category: generics, desc: "missing support for type switching on generic types"},
+	"typeparam/typeswitch5.go": {category: generics, desc: "different print() format for floating point types"},
 }
 
 type failCategory uint8

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -124,3 +124,42 @@ func TestLen(t *testing.T) {
 		})
 	}
 }
+
+func _cap[T []int | *[3]int | [3]int | chan int](x T) int {
+	return cap(x)
+}
+
+func TestCap(t *testing.T) {
+	ch := make(chan int, 2)
+	ch <- 1
+
+	tests := []struct {
+		desc string
+		got  int
+		want int
+	}{{
+		desc: "[]int",
+		got:  _cap([]int{1, 2, 3}),
+		want: 3,
+	}, {
+		desc: "*[3]int",
+		got:  _cap(&[3]int{1}),
+		want: 3,
+	}, {
+		desc: "[3]int",
+		got:  _cap([3]int{1}),
+		want: 3,
+	}, {
+		desc: "chan int",
+		got:  _cap(ch),
+		want: 2,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if test.got != test.want {
+				t.Errorf("Got: len() = %d. Want: %d.", test.got, test.want)
+			}
+		})
+	}
+}

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -198,3 +198,30 @@ func TestNew(t *testing.T) {
 		})
 	}
 }
+
+func _append[E any, S []E](s S, e E) S {
+	return append(s, e)
+}
+
+func TestAppend(t *testing.T) {
+	got := _append([]int{1, 2}, 3)
+	want := []int{1, 2, 3}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Got: append(...) = %#v. Want: %#v", got, want)
+	}
+}
+
+func _delete[K comparable, M map[K]string | map[K]int](m M, k K) {
+	delete(m, k)
+}
+
+func TestDelete(t *testing.T) {
+	got := map[int]string{1: "a", 2: "b"}
+	delete(got, 1)
+	want := map[int]string{2: "b"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Got: delete(...) = %#v. Want: %#v", got, want)
+	}
+}

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -1,0 +1,83 @@
+package typeparams_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMake(t *testing.T) {
+	t.Run("slice", func(t *testing.T) {
+		tests := []struct {
+			slice   []int
+			wantStr string
+			wantLen int
+			wantCap int
+		}{{
+			slice:   make([]int, 1),
+			wantStr: "[]int{0}",
+			wantLen: 1,
+			wantCap: 1,
+		}, {
+			slice:   make([]int, 1, 2),
+			wantStr: "[]int{0}",
+			wantLen: 1,
+			wantCap: 2,
+		}}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				if got := fmt.Sprintf("%#v", test.slice); got != test.wantStr {
+					t.Errorf("Got: fmt.Sprint(%v) = %q. Want: %q.", test.slice, got, test.wantStr)
+				}
+				if got := len(test.slice); got != test.wantLen {
+					t.Errorf("Got: len(%v) = %d. Want: %d.", test.slice, got, test.wantLen)
+				}
+				if got := cap(test.slice); got != test.wantCap {
+					t.Errorf("Got: cap(%v) = %d. Want: %d.", test.slice, got, test.wantCap)
+				}
+			})
+		}
+	})
+
+	t.Run("map", func(t *testing.T) {
+		tests := []map[int]int{
+			make(map[int]int),
+			make(map[int]int, 1),
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				want := "map[int]int{}"
+				got := fmt.Sprintf("%#v", test)
+				if want != got {
+					t.Errorf("Got: fmt.Sprint(%v) = %q. Want: %q.", test, got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("chan", func(t *testing.T) {
+		tests := []struct {
+			ch      chan int
+			wantCap int
+		}{{
+			ch:      make(chan int),
+			wantCap: 0,
+		}, {
+			ch:      make(chan int, 1),
+			wantCap: 1,
+		}}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				wantStr := "chan int"
+				if got := fmt.Sprintf("%T", test.ch); got != wantStr {
+					t.Errorf("Got: fmt.Sprint(%v) = %q. Want: %q.", test.ch, got, wantStr)
+				}
+				if got := cap(test.ch); got != test.wantCap {
+					t.Errorf("Got: cap(%v) = %d. Want: %d.", test.ch, got, test.wantCap)
+				}
+			})
+		}
+	})
+}

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -81,3 +81,46 @@ func TestMake(t *testing.T) {
 		}
 	})
 }
+
+func _len[T []int | *[3]int | map[int]int | chan int | string](x T) int {
+	return len(x)
+}
+
+func TestLen(t *testing.T) {
+	ch := make(chan int, 2)
+	ch <- 1
+
+	tests := []struct {
+		desc string
+		got  int
+		want int
+	}{{
+		desc: "string",
+		got:  _len("abcd"),
+		want: 4,
+	}, {
+		desc: "[]int",
+		got:  _len([]int{1, 2, 3}),
+		want: 3,
+	}, {
+		desc: "[3]int",
+		got:  _len(&[3]int{1}),
+		want: 3,
+	}, {
+		desc: "map[int]int",
+		got:  _len(map[int]int{1: 1, 2: 2}),
+		want: 2,
+	}, {
+		desc: "chan int",
+		got:  _len(ch),
+		want: 1,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if test.got != test.want {
+				t.Errorf("Got: len() = %d. Want: %d.", test.got, test.want)
+			}
+		})
+	}
+}

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -225,3 +225,34 @@ func TestDelete(t *testing.T) {
 		t.Errorf("Got: delete(...) = %#v. Want: %#v", got, want)
 	}
 }
+
+func _copy[D []byte, S []byte | string](dst D, src S) int {
+	return copy(dst, src)
+}
+
+func TestCopy(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		src := "abc"
+		got := make([]byte, 3)
+		n := _copy(got, src)
+		want := []byte{'a', 'b', 'c'}
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("Got: copy result: %v. Want: %v", got, want)
+		}
+		if n != 3 {
+			t.Errorf("Got: copied %d elements. Want: 3", n)
+		}
+	})
+	t.Run("slice", func(t *testing.T) {
+		src := []byte{'a', 'b', 'c', 'd'}
+		got := make([]byte, 3)
+		n := _copy(got, src)
+		want := []byte{'a', 'b', 'c'}
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("Got: copy result: %v. Want: %v", got, want)
+		}
+		if n != 3 {
+			t.Errorf("Got: copied %d elements. Want: 3", n)
+		}
+	})
+}

--- a/tests/typeparams/builtins_test.go
+++ b/tests/typeparams/builtins_test.go
@@ -2,6 +2,7 @@ package typeparams_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -159,6 +160,40 @@ func TestCap(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			if test.got != test.want {
 				t.Errorf("Got: len() = %d. Want: %d.", test.got, test.want)
+			}
+		})
+	}
+}
+
+func _new[T any]() *T {
+	return new(T)
+}
+
+func TestNew(t *testing.T) {
+	type S struct{ i int }
+
+	tests := []struct {
+		desc string
+		got  any
+		want any
+	}{{
+		desc: "struct S",
+		got:  *_new[S](),
+		want: S{},
+	}, {
+		desc: "[3]int",
+		got:  *_new[[3]int](),
+		want: [3]int{},
+	}, {
+		desc: "int",
+		got:  *_new[int](),
+		want: int(0),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if !reflect.DeepEqual(test.got, test.want) {
+				t.Errorf("Got: new(%T) = %#v. Want: %#v.", test.want, test.got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
For many built-ins the behavior differs depending on their argument types. In such cases, each relevant type constructor has a method implementing the built-in for that specific type, e.g. for a slice `t` of type `T`, expression `len(t)` will translate into something like `T.$len(t)`. In some cases, where it doesn't seem performance-critical, I changed the whole implementation of the built-in to use this mechanism, even if no type parameters are involved to reduce the amount of duplicated logic.

Some functions like `append()` or `delete()` put sufficiently strict constraints on the type parameter to not require runtime dispatch. In those cases I only had to tweak the code a bit to correctly identify types.

Updates #1013.