### PR TITLE
go1.19: Fix reflect

### DIFF
--- a/compiler/natives/src/net/http/http.go
+++ b/compiler/natives/src/net/http/http.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/textproto"
 	"strconv"
 
@@ -68,7 +68,7 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 			StatusCode:    xhr.Get("status").Int(),
 			Header:        Header(header),
 			ContentLength: contentLength,
-			Body:          ioutil.NopCloser(bytes.NewReader(body)),
+			Body:          io.NopCloser(bytes.NewReader(body)),
 			Request:       req,
 		}
 	})
@@ -91,7 +91,7 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 	if req.Body == nil {
 		xhr.Call("send")
 	} else {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			req.Body.Close() // RoundTrip must always close the body, including on errors.
 			return nil, err

--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -182,7 +182,7 @@ func reflectType(typ *js.Object) *rtype {
 			for i := range reflectFields {
 				f := fields.Index(i)
 				reflectFields[i] = structField{
-					name:   newName(internalStr(f.Index.Get("name")), internalStr(f.Get("tag")), f.Get("exported").Bool(), f.Get("embedded").Bool()),
+					name:   newName(internalStr(f.Get("name")), internalStr(f.Get("tag")), f.Get("exported").Bool(), f.Get("embedded").Bool()),
 					typ:    reflectType(f.Get("typ")),
 					offset: uintptr(i),
 				}

--- a/go.mod
+++ b/go.mod
@@ -13,14 +13,13 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/visualfc/goembed v0.3.3
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.10.0
+	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
 	golang.org/x/tools v0.11.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -326,6 +326,7 @@ func TestInternalizeStruct(t *testing.T) {
 		t.Errorf("Mismatch (-want +got):\n%s", diff)
 	}
 }
+
 func TestInternalizeStructUnexportedFields(t *testing.T) {
 	type Person struct {
 		Name string

--- a/tests/lowlevel_test.go
+++ b/tests/lowlevel_test.go
@@ -1,7 +1,7 @@
 package tests_test
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -26,7 +26,7 @@ func TestTimeInternalizationExternalization(t *testing.T) {
 		t.Fatalf("%v:\n%s", err, got)
 	}
 
-	wantb, err := ioutil.ReadFile(filepath.Join("testdata", "time_inexternalization.out"))
+	wantb, err := os.ReadFile(filepath.Join("testdata", "time_inexternalization.out"))
 	want := string(wantb)
 	if err != nil {
 		t.Fatalf("error reading .out file: %v", err)

--- a/tests/syscall_test.go
+++ b/tests/syscall_test.go
@@ -4,7 +4,6 @@
 package tests
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -20,7 +19,7 @@ func TestGetpid(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create a temp file: %s", err)
 	}

--- a/tool.go
+++ b/tool.go
@@ -10,7 +10,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -35,8 +34,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 )
 
 var currentDirectory string
@@ -79,7 +78,7 @@ func main() {
 
 	compilerFlags := pflag.NewFlagSet("", 0)
 	compilerFlags.BoolVarP(&options.Minify, "minify", "m", false, "minify generated code")
-	compilerFlags.BoolVar(&options.Color, "color", terminal.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb", "colored output")
+	compilerFlags.BoolVar(&options.Color, "color", term.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb", "colored output")
 	compilerFlags.StringVar(&tags, "tags", "", "a list of build tags to consider satisfied during the build")
 	compilerFlags.BoolVar(&options.MapToLocalDisk, "localmap", false, "use local paths for sourcemap")
 	compilerFlags.BoolVarP(&options.NoCache, "no_cache", "a", false, "rebuild all packages from scratch")
@@ -280,9 +279,9 @@ func main() {
 			return fmt.Errorf("gopherjs run: no go files listed")
 		}
 
-		tempfile, err := ioutil.TempFile(currentDirectory, filepath.Base(args[0])+".")
+		tempfile, err := os.CreateTemp(currentDirectory, filepath.Base(args[0])+".")
 		if err != nil && strings.HasPrefix(currentDirectory, runtime.GOROOT()) {
-			tempfile, err = ioutil.TempFile("", filepath.Base(args[0])+".")
+			tempfile, err = os.CreateTemp("", filepath.Base(args[0])+".")
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Two changes to go1.19:

- Reflect fix: Since go1.19 is hitting CI issues from the missing generics, this copy/paste mistake wasn't caught until further testing against the generics branch.
- Merge master changes