### PR TITLE
Update FuncKey to handle generics

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -678,7 +678,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 		archive := s.buildCache.LoadArchive(pkg.ImportPath)
 		if archive != nil && !pkg.SrcModTime.After(archive.BuildTime) {
 			if err := archive.RegisterTypes(s.Types); err != nil {
-				panic(fmt.Errorf("Failed to load type information from %v: %w", archive, err))
+				panic(fmt.Errorf("failed to load type information from %v: %w", archive, err))
 			}
 			s.UpToDateArchives[pkg.ImportPath] = archive
 			// Existing archive is up to date, no need to build it from scratch.

--- a/compiler/astutil/astutil_test.go
+++ b/compiler/astutil/astutil_test.go
@@ -59,24 +59,41 @@ func TestFuncKey(t *testing.T) {
 		want string
 	}{
 		{
-			desc: "top-level function",
-			src:  `package testpackage; func foo() {}`,
-			want: "foo",
+			desc: `top-level function`,
+			src:  `func foo() {}`,
+			want: `foo`,
 		}, {
-			desc: "top-level exported function",
-			src:  `package testpackage; func Foo() {}`,
-			want: "Foo",
+			desc: `top-level exported function`,
+			src:  `func Foo() {}`,
+			want: `Foo`,
 		}, {
-			desc: "method",
-			src:  `package testpackage; func (_ myType) bar() {}`,
-			want: "myType.bar",
+			desc: `method on reference`,
+			src:  `func (_ myType) bar() {}`,
+			want: `myType.bar`,
+		}, {
+			desc: `method on pointer`,
+			src:  ` func (_ *myType) bar() {}`,
+			want: `myType.bar`,
+		}, {
+			desc: `method on generic reference`,
+			src:  ` func (_ myType[T]) bar() {}`,
+			want: `myType.bar`,
+		}, {
+			desc: `method on generic pointer`,
+			src:  ` func (_ *myType[T]) bar() {}`,
+			want: `myType.bar`,
+		}, {
+			desc: `method on struct with multiple generics`,
+			src:  ` func (_ *myType[T1, T2, T3, T4]) bar() {}`,
+			want: `myType.bar`,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			fdecl := srctesting.ParseFuncDecl(t, test.src)
+			src := `package testpackage; ` + test.src
+			fdecl := srctesting.ParseFuncDecl(t, src)
 			if got := FuncKey(fdecl); got != test.want {
-				t.Errorf("Got %q, want %q", got, test.want)
+				t.Errorf(`Got %q, want %q`, got, test.want)
 			}
 		})
 	}

--- a/compiler/natives/src/net/http/http.go
+++ b/compiler/natives/src/net/http/http.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/textproto"
 	"strconv"
 
@@ -68,7 +68,7 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 			StatusCode:    xhr.Get("status").Int(),
 			Header:        Header(header),
 			ContentLength: contentLength,
-			Body:          ioutil.NopCloser(bytes.NewReader(body)),
+			Body:          io.NopCloser(bytes.NewReader(body)),
 			Request:       req,
 		}
 	})
@@ -91,7 +91,7 @@ func (t *XHRTransport) RoundTrip(req *Request) (*Response, error) {
 	if req.Body == nil {
 		xhr.Call("send")
 	} else {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			req.Body.Close() // RoundTrip must always close the body, including on errors.
 			return nil, err


### PR DESCRIPTION
This ticket fixes the issue generics was causing in `parseAndAugment`. The problem was that `FuncKey` didn't handle `*ast.IndexListExpr` nor `*ast.IndexExpr` since those were introduced in function names for generics. This ticket has the following changes:

- Update FuncKey to handle generics.
- `compiler/natives/src/net/http/http.go` imports `io/util` which is no longer used in original runtime so causes the "extra import tests" in `build_test.go` to fail, so I also updated it to use `io`.
- Minor lint fix for creating an error.