### PR TITLE
Add purge directive

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -406,14 +406,14 @@ func pruneImports(file *ast.File) {
 	}
 
 	// Remove "unused import" for any import which is used.
-	ast.Walk(astutil.NewCallbackVisitor(func(n ast.Node) bool {
+	ast.Inspect(file, func(n ast.Node) bool {
 		if sel, ok := n.(*ast.SelectorExpr); ok {
 			if id, ok := sel.X.(*ast.Ident); ok && id.Obj == nil {
 				delete(unused, id.Name)
 			}
 		}
 		return len(unused) > 0
-	}), file)
+	})
 	if len(unused) == 0 {
 		return
 	}

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -1,10 +1,8 @@
 package build
 
 import (
-	"bytes"
 	"fmt"
 	gobuild "go/build"
-	"go/printer"
 	"go/token"
 	"strconv"
 	"testing"
@@ -390,16 +388,11 @@ func TestOverlayAugmentation(t *testing.T) {
 			augmentOverlayFile(fileSrc, overrides)
 			pruneImports(fileSrc)
 
-			buf := &bytes.Buffer{}
-			_ = printer.Fprint(buf, fsetSrc, fileSrc)
-			got := buf.String()
+			got := srctesting.Format(t, fsetSrc, fileSrc)
 
 			fsetWant := token.NewFileSet()
 			fileWant := srctesting.Parse(t, fsetWant, pkgName+test.want)
-
-			buf.Reset()
-			_ = printer.Fprint(buf, fsetWant, fileWant)
-			want := buf.String()
+			want := srctesting.Format(t, fsetWant, fileWant)
 
 			if got != want {
 				t.Errorf("augmentOverlayFile and pruneImports got unexpected code:\n"+
@@ -536,7 +529,7 @@ func TestOriginalAugmentation(t *testing.T) {
 
 				func NewFoo(bar int) *Foo { return &Foo{bar: bar} }`,
 			// NewFoo is not removed automatically since
-			// only functions with Foo as a receiver is removed.
+			// only functions with Foo as a receiver are removed.
 			want: `func NewFoo(bar int) *Foo { return &Foo{bar: bar} }`,
 		}, {
 			desc: `remove generics`,
@@ -591,16 +584,11 @@ func TestOriginalAugmentation(t *testing.T) {
 			augmentOriginalFile(fileSrc, test.info)
 			pruneImports(fileSrc)
 
-			buf := &bytes.Buffer{}
-			_ = printer.Fprint(buf, fsetSrc, fileSrc)
-			got := buf.String()
+			got := srctesting.Format(t, fsetSrc, fileSrc)
 
 			fsetWant := token.NewFileSet()
 			fileWant := srctesting.Parse(t, fsetWant, pkgName+test.want)
-
-			buf.Reset()
-			_ = printer.Fprint(buf, fsetWant, fileWant)
-			want := buf.String()
+			want := srctesting.Format(t, fsetWant, fileWant)
 
 			if got != want {
 				t.Errorf("augmentOriginalImports, augmentOriginalFile, and pruneImports got unexpected code:\n"+

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -133,15 +133,18 @@ func (m stringSet) String() string {
 
 func TestOverlayAugmentation(t *testing.T) {
 	tests := []struct {
-		desc    string
-		src     string
-		expInfo map[string]overrideInfo
+		desc         string
+		src          string
+		noCodeChange bool
+		want         string
+		expInfo      map[string]overrideInfo
 	}{
 		{
 			desc: `remove function`,
 			src: `func Foo(a, b int) int {
-						return a + b
-					}`,
+					return a + b
+				}`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`Foo`: {},
 			},
@@ -151,17 +154,9 @@ func TestOverlayAugmentation(t *testing.T) {
 				func Foo(a, b int) int {
 					return a + b
 				}`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`Foo`: {keepOriginal: true},
-			},
-		}, {
-			desc: `prune function body`,
-			src: `//gopherjs:prune-original
-				func Foo(a, b int) int {
-					return a + b
-				}`,
-			expInfo: map[string]overrideInfo{
-				`Foo`: {pruneMethodBody: true},
 			},
 		}, {
 			desc: `remove constants and values`,
@@ -173,6 +168,7 @@ func TestOverlayAugmentation(t *testing.T) {
 				)
 
 				var now = time.Now`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`foo`: {},
 				`bar`: {},
@@ -180,14 +176,13 @@ func TestOverlayAugmentation(t *testing.T) {
 			},
 		}, {
 			desc: `remove types`,
-			src: `import "time"
-
-				type (
+			src: `type (
 					foo struct {}
 					bar int
 				)
 
 				type bob interface {}`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`foo`: {},
 				`bar`: {},
@@ -195,14 +190,13 @@ func TestOverlayAugmentation(t *testing.T) {
 			},
 		}, {
 			desc: `remove methods`,
-			src: `import "cmp"
-
-				type Foo struct {
+			src: `type Foo struct {
 					bar int
 				}
-				
+
 				func (x *Foo) GetBar() int    { return x.bar }
 				func (x *Foo) SetBar(bar int) { x.bar = bar }`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`Foo`:        {},
 				`Foo.GetBar`: {},
@@ -218,8 +212,164 @@ func TestOverlayAugmentation(t *testing.T) {
 
 				// this is a stub for "func Equal[S ~[]E, E any](s1, s2 S) bool {}"
 				func Equal[S ~[]E, E any](s1, s2 S) bool {}`,
+			noCodeChange: true,
 			expInfo: map[string]overrideInfo{
 				`Pointer`: {},
+				`Sort`:    {},
+				`Equal`:   {},
+			},
+		}, {
+			desc:    `prune an unused import`,
+			src:     `import foo "some/other/bar"`,
+			want:    ``,
+			expInfo: map[string]overrideInfo{},
+		}, {
+			desc: `purge function`,
+			src: `//gopherjs:purge
+				func Foo(a, b int) int {
+					return a + b
+				}`,
+			want: ``,
+			expInfo: map[string]overrideInfo{
+				`Foo`: {},
+			},
+		}, {
+			desc: `purge struct removes an import`,
+			src: `import "bytes"
+				import "math"
+
+				//gopherjs:purge
+				type Foo struct {
+					bar *bytes.Buffer
+				}
+
+				const Tau = math.Pi * 2.0`,
+			want: `import "math"
+
+				const Tau = math.Pi * 2.0`,
+			expInfo: map[string]overrideInfo{
+				`Foo`: {purgeMethods: true},
+				`Tau`: {},
+			},
+		}, {
+			desc: `purge whole type decl`,
+			src: `//gopherjs:purge
+				type (
+					Foo struct {}
+					bar interface{}
+					bob int
+				)`,
+			want: ``,
+			expInfo: map[string]overrideInfo{
+				`Foo`: {purgeMethods: true},
+				`bar`: {purgeMethods: true},
+				`bob`: {purgeMethods: true},
+			},
+		}, {
+			desc: `purge part of type decl`,
+			src: `type (
+					Foo struct {}
+
+					//gopherjs:purge
+					bar interface{}
+
+					//gopherjs:purge
+					bob int
+				)`,
+			want: `type (
+					Foo struct {}
+				)`,
+			expInfo: map[string]overrideInfo{
+				`Foo`: {},
+				`bar`: {purgeMethods: true},
+				`bob`: {purgeMethods: true},
+			},
+		}, {
+			desc: `purge all of a type decl`,
+			src: `type (
+					//gopherjs:purge
+					Foo struct {}
+				)`,
+			want: ``,
+			expInfo: map[string]overrideInfo{
+				`Foo`: {purgeMethods: true},
+			},
+		}, {
+			desc: `remove and purge values`,
+			src: `import "time"
+
+				const (
+					foo = 42
+					//gopherjs:purge
+					bar = "gopherjs"
+				)
+
+				//gopherjs:purge
+				var now = time.Now`,
+			want: `const (
+					foo = 42
+				)`,
+			expInfo: map[string]overrideInfo{
+				`foo`: {},
+				`bar`: {},
+				`now`: {},
+			},
+		}, {
+			desc: `purge all value names`,
+			src: `//gopherjs:purge
+				var foo, bar int
+
+				//gopherjs:purge
+				const bob, sal = 12, 42`,
+			want: ``,
+			expInfo: map[string]overrideInfo{
+				`foo`: {},
+				`bar`: {},
+				`bob`: {},
+				`sal`: {},
+			},
+		}, {
+			desc: `imports not confused by local variables`,
+			src: `import (
+					"cmp"
+					"time"
+				)
+
+				//gopherjs:purge
+				func Sort[S ~[]E, E cmp.Ordered](x S) {}
+
+				func SecondsSince(start time.Time) int {
+					cmp := time.Now().Sub(start)
+					return int(cmp.Second())
+				}`,
+			want: `import (
+					"time"
+				)
+
+				func SecondsSince(start time.Time) int {
+					cmp := time.Now().Sub(start)
+					return int(cmp.Second())
+				}`,
+			expInfo: map[string]overrideInfo{
+				`Sort`:         {},
+				`SecondsSince`: {},
+			},
+		}, {
+			desc: `purge generics`,
+			src: `import "cmp"
+
+				//gopherjs:purge
+				type Pointer[T any] struct {}
+
+				//gopherjs:purge
+				func Sort[S ~[]E, E cmp.Ordered](x S) {}
+
+				// stub for "func Equal[S ~[]E, E any](s1, s2 S) bool"
+				func Equal() {}`,
+			want: `// stub for "func Equal[S ~[]E, E any](s1, s2 S) bool"
+				func Equal() {}`,
+			expInfo: map[string]overrideInfo{
+				`Pointer`: {purgeMethods: true},
 				`Sort`:    {},
 				`Equal`:   {},
 			},
@@ -228,12 +378,33 @@ func TestOverlayAugmentation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			pkgName := "package testpackage\n\n"
+			const pkgName = "package testpackage\n\n"
+			if test.noCodeChange {
+				test.want = test.src
+			}
+
 			fsetSrc := token.NewFileSet()
 			fileSrc := srctesting.Parse(t, fsetSrc, pkgName+test.src)
 
 			overrides := map[string]overrideInfo{}
 			augmentOverlayFile(fileSrc, overrides)
+			pruneImports(fileSrc)
+
+			buf := &bytes.Buffer{}
+			_ = printer.Fprint(buf, fsetSrc, fileSrc)
+			got := buf.String()
+
+			fsetWant := token.NewFileSet()
+			fileWant := srctesting.Parse(t, fsetWant, pkgName+test.want)
+
+			buf.Reset()
+			_ = printer.Fprint(buf, fsetWant, fileWant)
+			want := buf.String()
+
+			if got != want {
+				t.Errorf("augmentOverlayFile and pruneImports got unexpected code:\n"+
+					"returned:\n\t%q\nwant:\n\t%q", got, want)
+			}
 
 			for key, expInfo := range test.expInfo {
 				if gotInfo, ok := overrides[key]; !ok {
@@ -293,9 +464,7 @@ func TestOriginalAugmentation(t *testing.T) {
 			src: `func Foo(a, b int) int {
 					return a + b
 				}`,
-			want: `func _(a, b int) int {
-					return a + b
-				}`,
+			want: ``,
 		}, {
 			desc: `keep original function`,
 			info: map[string]overrideInfo{
@@ -322,13 +491,7 @@ func TestOriginalAugmentation(t *testing.T) {
 
 				var now = time.Now
 				const bar1, bar2 = 21, 42`,
-			want: `import "time"
-
-				type _ struct {
-				}
-
-				var _ = time.Now
-				const _, bar2 = 21, 42`,
+			want: `const bar2 = 42`,
 		}, {
 			desc: `remove in multi-value context`,
 			info: map[string]overrideInfo{
@@ -341,27 +504,40 @@ func TestOriginalAugmentation(t *testing.T) {
 					return 24, 12
 				}()`,
 		}, {
+			desc: `full remove in multi-value context`,
+			info: map[string]overrideInfo{
+				`bar`: {},
+			},
+			src: `const _, bar = func() (int, int) {
+					return 24, 12
+				}()`,
+			want: ``,
+		}, {
 			desc: `remove methods`,
 			info: map[string]overrideInfo{
-				`Foo`:        {},
 				`Foo.GetBar`: {},
 				`Foo.SetBar`: {},
 			},
-			src: `import "cmp"
-
-				type Foo struct {
+			src: `
+				func (x Foo) GetBar() int     { return x.bar }
+				func (x *Foo) SetBar(bar int) { x.bar = bar }`,
+			want: ``,
+		}, {
+			desc: `purge struct and methods`,
+			info: map[string]overrideInfo{
+				`Foo`: {purgeMethods: true},
+			},
+			src: `type Foo struct{
 					bar int
 				}
-				
-				func (x *Foo) GetBar() int    { return x.bar }
-				func (x *Foo) SetBar(bar int) { x.bar = bar }`,
-			want: `import "cmp"
 
-				type _ struct {
-				}
-				
-				func (x *Foo) _() int    { return x.bar }
-				func (x *Foo) _(bar int) { x.bar = bar }`,
+				func (f Foo) GetBar() int     { return f.bar }
+				func (f *Foo) SetBar(bar int) { f.bar = bar }
+
+				func NewFoo(bar int) *Foo { return &Foo{bar: bar} }`,
+			// NewFoo is not removed automatically since
+			// only functions with Foo as a receiver is removed.
+			want: `func NewFoo(bar int) *Foo { return &Foo{bar: bar} }`,
 		}, {
 			desc: `remove generics`,
 			info: map[string]overrideInfo{
@@ -377,15 +553,30 @@ func TestOriginalAugmentation(t *testing.T) {
 
 				// overlay had stub "func Equal() {}"
 				func Equal[S ~[]E, E any](s1, s2 S) bool {}`,
-			want: `import "cmp"
+			want: ``,
+		}, {
+			desc: `purge generics`,
+			info: map[string]overrideInfo{
+				`Pointer`: {purgeMethods: true},
+				`Sort`:    {},
+				`Equal`:   {},
+			},
+			src: `import "cmp"
 
-				type _ struct {
-				}
+				type Pointer[T any] struct {}
+				func (x *Pointer[T]) Load() *T {}
+				func (x *Pointer[T]) Store(val *T) {}
 
-				func _[S ~[]E, E cmp.Ordered](x S) {}
+				func Sort[S ~[]E, E cmp.Ordered](x S) {}
 
 				// overlay had stub "func Equal() {}"
-				func _[S ~[]E, E any](s1, s2 S) bool {}`,
+				func Equal[S ~[]E, E any](s1, s2 S) bool {}`,
+			want: ``,
+		}, {
+			desc: `prune an unused import`,
+			info: map[string]overrideInfo{},
+			src:  `import foo "some/other/bar"`,
+			want: ``,
 		},
 	}
 
@@ -398,6 +589,7 @@ func TestOriginalAugmentation(t *testing.T) {
 
 			augmentOriginalImports(importPath, fileSrc)
 			augmentOriginalFile(fileSrc, test.info)
+			pruneImports(fileSrc)
 
 			buf := &bytes.Buffer{}
 			_ = printer.Fprint(buf, fsetSrc, fileSrc)

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -251,19 +251,3 @@ func Squeeze[E ast.Node, S ~[]E](s S) S {
 	}
 	return s[:dest]
 }
-
-type CallbackVisitor struct {
-	predicate func(node ast.Node) bool
-}
-
-func NewCallbackVisitor(predicate func(node ast.Node) bool) *CallbackVisitor {
-	return &CallbackVisitor{predicate: predicate}
-}
-
-func (v *CallbackVisitor) Visit(node ast.Node) ast.Visitor {
-	if v.predicate != nil && v.predicate(node) {
-		return v
-	}
-	v.predicate = nil
-	return nil
-}

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -5,7 +5,10 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"path"
+	"reflect"
 	"regexp"
+	"strconv"
 )
 
 func RemoveParens(e ast.Expr) ast.Expr {
@@ -59,6 +62,29 @@ func ImportsUnsafe(file *ast.File) bool {
 	return false
 }
 
+// ImportName tries to determine the package name for an import.
+//
+// If the package name isn't specified then this will make a best
+// make a best guess using the import path.
+// If the import name is dot (`.`), blank (`_`), or there
+// was an issue determining the package name then empty is returned.
+func ImportName(spec *ast.ImportSpec) string {
+	var name string
+	if spec.Name != nil {
+		name = spec.Name.Name
+	} else {
+		importPath, _ := strconv.Unquote(spec.Path.Value)
+		name = path.Base(importPath)
+	}
+
+	switch name {
+	case `_`, `.`, `/`:
+		return ``
+	default:
+		return name
+	}
+}
+
 // FuncKey returns a string, which uniquely identifies a top-level function or
 // method in a package.
 func FuncKey(d *ast.FuncDecl) string {
@@ -95,19 +121,6 @@ func FuncReceiverKey(d *ast.FuncDecl) string {
 	}
 }
 
-// PruneOriginal returns true if gopherjs:prune-original directive is present
-// before a function decl.
-//
-// `//gopherjs:prune-original` is a GopherJS-specific directive, which can be
-// applied to functions in native overlays and will instruct the augmentation
-// logic to delete the body of a standard library function that was replaced.
-// This directive can be used to remove code that would be invalid in GopherJS,
-// such as code expecting ints to be 64-bit. It should be used with caution
-// since it may create unused imports in the original source file.
-func PruneOriginal(d *ast.FuncDecl) bool {
-	return hasDirective(d, `prune-original`)
-}
-
 // KeepOriginal returns true if gopherjs:keep-original directive is present
 // before a function decl.
 //
@@ -118,6 +131,21 @@ func PruneOriginal(d *ast.FuncDecl) bool {
 // `_gopherjs_original_foo`.
 func KeepOriginal(d *ast.FuncDecl) bool {
 	return hasDirective(d, `keep-original`)
+}
+
+// Purge returns true if gopherjs:purge directive is present
+// on a struct, interface, type, variable, constant, or function.
+//
+// `//gopherjs:purge` is a GopherJS-specific directive, which can be
+// applied in native overlays and will instruct the augmentation logic to
+// delete part of the standard library without a replacement. This directive
+// can be used to remove code that would be invalid in GopherJS, such as code
+// using unsupported features (e.g. generic interfaces before generics were
+// fully supported). It should be used with caution since it may remove needed
+// dependencies. If a type is purged, all methods using that type as
+// a receiver will also be purged.
+func Purge(d any) bool {
+	return hasDirective(d, `purge`)
 }
 
 // anyDocLine calls the given predicate on all associated documentation
@@ -227,4 +255,38 @@ func EndsWithReturn(stmts []ast.Stmt) bool {
 	default:
 		return false
 	}
+}
+
+// Squeeze removes all nil nodes from the slice.
+//
+// The given slice will be modified. This is designed for squeezing
+// declaration, specification, imports, and identifier lists.
+func Squeeze[E ast.Node, S ~[]E](s S) S {
+	var zero E
+	count, dest := len(s), 0
+	for src := 0; src < count; src++ {
+		if !reflect.DeepEqual(s[src], zero) {
+			// Swap the values, this will put the nil values to the end
+			// of the slice so that the tail isn't holding onto pointers.
+			s[dest], s[src] = s[src], s[dest]
+			dest++
+		}
+	}
+	return s[:dest]
+}
+
+type CallbackVisitor struct {
+	predicate func(node ast.Node) bool
+}
+
+func NewCallbackVisitor(predicate func(node ast.Node) bool) *CallbackVisitor {
+	return &CallbackVisitor{predicate: predicate}
+}
+
+func (v *CallbackVisitor) Visit(node ast.Node) ast.Visitor {
+	if v.predicate != nil && v.predicate(node) {
+		return v
+	}
+	v.predicate = nil
+	return nil
 }


### PR DESCRIPTION
### Summary

After a conversation with Nevkontakte ([here](https://gophers.slack.com/archives/C039C0R2T/p1701798056129639)), the current goal is to make go1.19 support without generics possible by dropping generic code. To accomplish this, I'm adding a new directive, `gopherjs:purge`, which will remove parts of the original code without replacing them with something in the overlay/override code. The native code will have the directive for some declaration or specification identifier and both the overlay and original will have that decl/spec removed from it.

This will allow us, in a follow up ticket, to add things into the natives that we want to remove, e.g. `type Pointer[T any] struct {}` in atomic. This will also help with imports for variable type constraints, e.g. `type Foo[T cmp.Ordered](value T)`.

### Dependancies

- https://github.com/gopherjs/gopherjs/pull/1255
- https://github.com/gopherjs/gopherjs/pull/1256
- https://github.com/gopherjs/gopherjs/pull/1257
