### PR TITLE
[go1.19] Fix build issue and add override signature directive

### DIFF
--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 func RemoveParens(e ast.Expr) ast.Expr {
@@ -148,6 +149,24 @@ func Purge(d ast.Node) bool {
 	return hasDirective(d, `purge`)
 }
 
+// OverrideSignature returns true if gopherjs:override-signature directive is
+// present on a function.
+//
+// `//gopherjs:override-signature` is a GopherJS-specific directive, which can
+// be applied in native overlays and will instruct the augmentation logic to
+// replace the original function signature which has the same FuncKey with the
+// signature defined in the native overlays.
+// This directive can be used to remove generics from a function signature or
+// to replace a receiver of a function with another one. The given native
+// overlay function will be removed, so no method body is needed in the overlay.
+//
+// The new signature may not contain types which require a new import since
+// the imports will not be automatically added when needed, only removed.
+// Use a type alias in the overlay to deal manage imports.
+func OverrideSignature(d *ast.FuncDecl) bool {
+	return hasDirective(d, `override-signature`)
+}
+
 // directiveMatcher is a regex which matches a GopherJS directive
 // and finds the directive action.
 var directiveMatcher = regexp.MustCompile(`^\/(?:\/|\*)gopherjs:([\w-]+)`)
@@ -177,6 +196,19 @@ func hasDirective(node ast.Node, directiveAction string) bool {
 		}
 	})
 	return foundDirective
+}
+
+// HasDirectivePrefix determines if any line in the given file
+// has the given directive prefix in it.
+func HasDirectivePrefix(file *ast.File, prefix string) bool {
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if strings.HasPrefix(c.Text, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // FindLoopStmt tries to find the loop statement among the AST nodes in the

--- a/doc/pargma.md
+++ b/doc/pargma.md
@@ -7,6 +7,12 @@ issues, so it is recommended to avoid using them if possible.
 
 GopherJS compiler supports the following directives:
 
+- [go:linkname](#golinkname)
+- [go:embed](#goembed)
+- [gopherjs:keep-original](#gopherjskeep-original)
+- [gopherjs:purge](#gopherjspurge)
+- [gopherjs:override-signature](#gopherjsoverride-signature)
+
 ## `go:linkname`
 
 This is a limited version of the `go:linkname` directive the upstream Go
@@ -25,16 +31,166 @@ Signatures of `remotename` and `localname` must be identical. Since this
 directive can subvert package incapsulation, the source file that uses the
 directive must also import `unsafe`.
 
-The following directive format is supported:
-//go:linkname <localname> <importpath>.<name>
-//go:linkname <localname> <importpath>.<type>.<name>
-//go:linkname <localname> <importpath>.<(*type)>.<name>
+The following directive formats are supported:
+
+- `//go:linkname <localname> <importpath>.<name>`
+- `//go:linkname <localname> <importpath>.<type>.<name>`
+- `//go:linkname <localname> <importpath>.<(*type)>.<name>`
 
 Compared to the upstream Go, the following limitations exist in GopherJS:
 
-  - The directive only works on package-level functions or methods (variables
-    are not supported).
-  - The directive can only be used to "import" implementation from another
-    package, and not to "provide" local implementation to another package.
+- The directive only works on package-level functions or methods (variables
+  are not supported).
+- The directive can only be used to "import" implementation from another
+  package, and not to "provide" local implementation to another package.
 
-See https://github.com/gopherjs/gopherjs/issues/1000 for details.
+See [gopherjs/issues/1000](https://github.com/gopherjs/gopherjs/issues/1000)
+for details.
+
+## `go:embed`
+
+This is a very similar version of the `go:embed` directive the upstream Go
+compiler implements.
+GopherJS leverages [goembed](https://github.com/visualfc/goembed)
+to parse this directive and provide support reading embedded content. Usage:
+
+```go
+import _ "embed" // for go:embed
+
+//go:embed externalText
+var embeddedText string
+
+//go:embed externalContent
+var embeddedContent []byte
+
+//go:embed file1
+//go:embed file2
+// ...
+//go:embed image/* blobs/*
+var embeddedFiles embed.FS
+```
+
+This directive affects the variable specification (e.g. `embeddedText`)
+that the comment containing the directive is associated with.
+There may be one embed directives associated with `string` or `[]byte`
+variables. There may be one or more embed directives associated with
+`embed.FS` variables and each directive may contain one or more
+file matching patterns. The effect is that the variable will be assigned to
+the content (e.g. `externalText`) given in the directive. In the case
+of `embed.FS`, several embedded files will be accessible.
+
+See [pkg.go.dev/embed](https://pkg.go.dev/embed#hdr-Directives)
+for more information.
+
+## `gopherjs:keep-original`
+
+This directive is custom to GopherJS. This directive can be added to a
+function declaration in the native file overrides as part of the build step.
+
+This will keep the original function by the same name as the function
+in the overrides, however it will prepend `_gopherjs_original_` to the original
+function's name. This allows the original function to be called by functions
+in the overrides and the overridden function to be called instead of the
+original. This is useful when wanting to augment the original behavior without
+having to rewrite the entire original function. Usage:
+
+```go
+//gopherjs:keep-original
+func foo(a, b int) int {
+  return _gopherjs_original_foo(a+1, b+1) - 1
+}
+```
+
+## `gopherjs:purge`
+
+This directive is custom to GopherJS. This directive can be added
+to most declarations and specification in the native file overrides as
+part of the build step.
+This can be added to structures, interfaces, methods, functions,
+variables, or constants, but are not supported for imports, structure fields,
+nor interface function signatures.
+
+This will remove the original structure, interface, etc from both the override
+files and the original files.
+If this is added to a structure, then all functions in the original files
+that use that structure as a receiver will also be removed.
+This is useful for removing all the code that is invalid in GopherJS,
+such as code using unsupported features (e.g. generic interfaces before
+generics were fully supported). In many cases the overrides to replace
+the original code may not have use of all the original functions and
+variables or the original code is not intended to be replaced yet.
+Usage:
+
+```go
+//gopherjs:purge
+var data string
+
+//gopherjs:purge
+// This will also purge any function starting with `dataType` as the receiver.
+type dataType struct {}
+
+//gopherjs:purge
+type interfaceType interface{}
+
+//gopherjs:purge
+func doThing[T ~string](value T)
+```
+
+## `gopherjs:override-signature`
+
+This directive is custom to GopherJS. This directive can be added to a
+function declaration in the native file overrides as part of the build step.
+
+This will remove the function from the overrides but record the signature
+used in the overrides, then update the original function with that signature
+provided in the overrides.
+The affect is to change the receiver, type parameters,
+parameters, or return types of the original function. The original function
+and override function must have the same function key name so that they can
+be associated, meaning the identifier of the receiver, if there is one, must
+match and the identifier of the function must match.
+
+This allows the signature to be modified without modifying the body of a
+function thus allowing the types to be adjusted to work in GopherJS.
+The signature may need to be replaced because it uses a parameter type
+that is invalid in GopherJS or the signature uses unsupported features
+(e.g. generic interfaces before generics were fully supported).
+Usage:
+
+```go
+// -- in original file --
+func Foo[T comparable](a, b T) (T, bool) {
+  if a == b {
+    return a, true
+  }
+  return b, false
+}
+
+// -- in override file --
+//gopherjs:override-signature
+func Foo(a, b any) (any, bool)
+
+// -- result in augmented original --
+func Foo(a, b any) (any, bool) {
+  if a == b {
+    return a, true
+  }
+  return b, false
+}
+```
+
+```go
+// -- in original file --
+func (f *Foo[A, B, C]) Bar(a int, b *A) (*A, error) {
+  //...
+}
+
+// -- in override file --
+//gopherjs:override-signature
+func (f *Foo) Bar(a int, b jsTypeA) (jsTypeA, error)
+
+// -- result in augmented original --
+func (f *Foo) Bar(a int, b jsTypeA) (jsTypeA, error) {
+  //...
+}
+```


### PR DESCRIPTION
- The build updates changes I did will still remove imports which are needed by directive only (i.e. `unsafe` for `go:linkname` and `embed` for `go:embed`). These directives are also read from the top-level comments by the compiler so we may not simply clear out the top-level comments.

- The import remover also had to deal with files like [src/math/rand/race_test.go](https://cs.opensource.google/go/go/+/refs/tags/go1.19.13:src/math/rand/race_test.go) which has a dot import (`	import . "math/rand"`). Typically we leave dot imports alone because it is hard to determine if they are used or not, however in this case, the test is removed making the import unused. So now, if the file is empty of anything but imports or the `go:linkname` directive (we don't have to worry about the `embed` since that needs a target variable), clear out everything including dot and blank (`_`) imports.

- Add `//gopherjs:override-signature` directive which allows us to replace a function signature with another while not modifying the body of the function. The two functions will still have to match `FuncKey` which is based off the receiver and function name.