### PR TITLE
[go1.19] Update compiler

### DIFF
--- a/compiler/analysis/info.go
+++ b/compiler/analysis/info.go
@@ -93,7 +93,10 @@ func (info *Info) newFuncInfo(n ast.Node) *FuncInfo {
 }
 
 func (info *Info) IsBlocking(fun *types.Func) bool {
-	return len(info.FuncDeclInfos[fun].Blocking) > 0
+	if funInfo := info.FuncDeclInfos[fun]; funInfo != nil {
+		return len(funInfo.Blocking) > 0
+	}
+	panic(fmt.Errorf(`info did not have function declaration for %s`, fun.FullName()))
 }
 
 func AnalyzePkg(files []*ast.File, fileSet *token.FileSet, typesInfo *types.Info, typesPkg *types.Package, isBlocking func(*types.Func) bool) *Info {

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -32,7 +32,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			panic(err) // Continue orderly bailout.
 		}
 
-		// Oh noes, we've tried to compile something so bad that compiler paniced
+		// Oh noes, we've tried to compile something so bad that compiler panicked
 		// and ran away. Let's gather some debugging clues.
 		bail := bailout(err)
 		pos := stmt.Pos()
@@ -471,7 +471,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 	case *ast.SendStmt:
 		chanType := fc.pkgCtx.TypeOf(s.Chan).Underlying().(*types.Chan)
 		call := &ast.CallExpr{
-			Fun:  fc.newIdent("$send", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", chanType), types.NewVar(0, nil, "", chanType.Elem())), nil, false)),
+			Fun:  fc.newIdent("$send", types.NewSignatureType(nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", chanType), types.NewVar(0, nil, "", chanType.Elem())), nil, false)),
 			Args: []ast.Expr{s.Chan, fc.newIdent(fc.translateImplicitConversionWithCloning(s.Value, chanType.Elem()).String(), chanType.Elem())},
 		}
 		fc.Blocking[call] = true
@@ -522,8 +522,8 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 		}
 
 		selectCall := fc.setType(&ast.CallExpr{
-			Fun:  fc.newIdent("$select", types.NewSignature(nil, types.NewTuple(types.NewVar(0, nil, "", types.NewInterface(nil, nil))), types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)),
-			Args: []ast.Expr{fc.newIdent(fmt.Sprintf("[%s]", strings.Join(channels, ", ")), types.NewInterface(nil, nil))},
+			Fun:  fc.newIdent("$select", types.NewSignatureType(nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.NewInterfaceType(nil, nil))), types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)),
+			Args: []ast.Expr{fc.newIdent(fmt.Sprintf("[%s]", strings.Join(channels, ", ")), types.NewInterfaceType(nil, nil))},
 		}, types.Typ[types.Int])
 		if !hasDefault {
 			fc.Blocking[selectCall] = true

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -518,13 +518,13 @@ func isBlank(expr ast.Expr) bool {
 //
 // For example, consider a Go type:
 //
-//			 type SecretInt int
-//	    func (_ SecretInt) String() string { return "<secret>" }
+//	type SecretInt int
+//	func (_ SecretInt) String() string { return "<secret>" }
 //
-//	    func main() {
-//	      var i SecretInt = 1
-//	      println(i.String())
-//	    }
+//	func main() {
+//	  var i SecretInt = 1
+//	  println(i.String())
+//	}
 //
 // For this example the compiler will generate code similar to the snippet below:
 //
@@ -765,7 +765,7 @@ func (st signatureTypes) Param(i int, ellipsis bool) types.Type {
 	}
 	if !st.Sig.Variadic() {
 		// This should never happen if the code was type-checked successfully.
-		panic(fmt.Errorf("Tried to access parameter %d of a non-variadic signature %s", i, st.Sig))
+		panic(fmt.Errorf("tried to access parameter %d of a non-variadic signature %s", i, st.Sig))
 	}
 	if ellipsis {
 		return st.VariadicType()


### PR DESCRIPTION
Some generalized updates to the compiler as we head towards go1.19. `NewSignature` and `NewInterface` are deprecates for `NewSignatureType` and `NewInterfaceType`; update those deprecated methods. Add some more checks for generics and type parameters. Fixing some lint too.