### PR TITLE
[go1.19] Known fails and build issues fix

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -475,6 +475,8 @@ func pruneImports(file *ast.File) {
 		path, _ := strconv.Unquote(in.Path.Value)
 		directivePrefix, hasPath := directiveImports[path]
 		if hasPath && astutil.HasDirectivePrefix(file, directivePrefix) {
+			// since the import is otherwise unused set the name to blank.
+			in.Name = ast.NewIdent(`_`)
 			delete(unused, name)
 			if len(unused) == 0 {
 				return

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -396,7 +396,14 @@ func TestOverlayAugmentation(t *testing.T) {
 
 				//go:linkname runtimeNano runtime.nanotime
 				func runtimeNano() int64`,
-			noCodeChange: true,
+			want: `import _ "unsafe"
+				import "embed"
+
+				//go:embed hello.txt
+				var eFile embed.FS
+				
+				//go:linkname runtimeNano runtime.nanotime
+				func runtimeNano() int64`,
 			expInfo: map[string]overrideInfo{
 				`eFile`:       {},
 				`runtimeNano`: {},

--- a/circle.yml
+++ b/circle.yml
@@ -55,6 +55,10 @@ parameters:
   go_version:
     type: string
     default: "1.19.13"
+  chocolatey_go_version:
+    type: string
+    # Chocolatey doesn't have 1.19.13, closest is 1.19.9
+    default: "1.19.9"
   nvm_version:
     type: string
     default: "0.38.0"
@@ -171,7 +175,7 @@ jobs:
       - run:
           name: Install Go
           command: |
-            choco install golang --version="<< pipeline.parameters.go_version >>" -my
+            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my
             go version
             (Get-Command go).Path
             [Environment]::SetEnvironmentVariable(

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -151,10 +151,16 @@ var knownFails = map[string]failReason{
 	// These are new tests in Go 1.18
 	"fixedbugs/issue46938.go": {category: notApplicable, desc: "tests -d=checkptr compiler mode, which GopherJS doesn't support"},
 	"fixedbugs/issue47928.go": {category: notApplicable, desc: "//go:nointerface is a part of GOEXPERIMENT=fieldtrack and is not supported by GopherJS"},
-	"fixedbugs/issue49665.go": {category: other, desc: "attempts to pass -gcflags=-G=3 to enable generics, GopherJS doesn't expect the flag; re-enable in Go 1.19 where the flag is removed"},
 	"fixedbugs/issue48898.go": {category: other, desc: "https://github.com/gopherjs/gopherjs/issues/1128"},
 	"fixedbugs/issue48536.go": {category: usesUnsupportedPackage, desc: "https://github.com/gopherjs/gopherjs/issues/1130"},
 	"fixedbugs/issue53600.go": {category: lowLevelRuntimeDifference, desc: "GopherJS println format is different from Go's"},
+
+	// These are new tests in Go 1.19
+	"fixedbugs/issue50672.go": {category: usesUnsupportedGenerics, desc: "Checking function nesting with one function having a type parameter."},
+	"fixedbugs/issue53137.go": {category: usesUnsupportedGenerics, desc: "Checking setting type parameter of struct in parameter of a generic function."},
+	"fixedbugs/issue53309.go": {category: usesUnsupportedGenerics, desc: "Checking unused type parameter in method call to interface"},
+	"fixedbugs/issue53635.go": {category: usesUnsupportedGenerics, desc: "Checking switch type against nil type with unsupported type parameters"},
+	"fixedbugs/issue53653.go": {category: lowLevelRuntimeDifference, desc: "GopherJS println format of int64 is different from Go's"},
 }
 
 type failCategory uint8
@@ -164,6 +170,7 @@ const (
 	neverTerminates                       // Test never terminates (so avoid starting it).
 	usesUnsupportedPackage                // Test fails because it imports an unsupported package, e.g., "unsafe".
 	requiresSourceMapSupport              // Test fails without source map support (as configured in CI), because it tries to check filename/line number via runtime.Caller.
+	usesUnsupportedGenerics               // Test uses generics (type parameters) that are not currently supported.
 	compilerPanic
 	unsureIfGopherJSSupportsThisFeature
 	lowLevelRuntimeDifference // JavaScript runtime behaves differently from Go in ways that are difficult to work around.


### PR DESCRIPTION
This PR has three changes:

1. Fixed a problem when removing/keeping imports in the parse and augment phase. The problem comes from when a file imports something without using the blank (`_`) name (e.g. `import "unsafe"` or `import us "unsafe"`) , then augmentation removes all usages of that import except for one or more directives (e.g. `//go:linkname`). In this case leaving the import as is will cause an "unused import" error but removing the import will result in a "directive X needs import Y" error. To solve this I made this specific case change the name of the import to be a blank import (e.g. `import _ "unsafe"`).

2. Chocolatey doesn't have go1.19.13 so the Windows CI fails. I changed the Chocolatey to the nearest version it defines, go1.19.9. This fixes the problems for the Windows' CI.

3. I updated the known fails list for fixed bugs to include new known fails for tests with generics (type parameters) and removed issues which function correctly under go1.19 without generics. 