### PR TITLE
[go1.19] Updating more natives for go1.19

### DIFF
--- a/compiler/natives/src/crypto/internal/boring/bcache/cache.go
+++ b/compiler/natives/src/crypto/internal/boring/bcache/cache.go
@@ -1,0 +1,30 @@
+//go:build js
+// +build js
+
+package bcache
+
+import "unsafe"
+
+// Cache relies on GC to periodically clear the cache.
+// Since GopherJS doesn't have the same GC hooks, it currently can not
+// register this cache with the GC.
+// Without this cache Boring crypto, in particular public and private
+// RSA and ECDSA keys, will be slower because the cache will always miss.
+type Cache struct{}
+
+func (c *Cache) Register()                           {}
+func (c *Cache) Clear()                              {}
+func (c *Cache) Get(k unsafe.Pointer) unsafe.Pointer { return nil }
+func (c *Cache) Put(k, v unsafe.Pointer)             {}
+
+//gopherjs:purge
+func (c *Cache) table() *[cacheSize]unsafe.Pointer
+
+//gopherjs:purge
+type cacheEntry struct{}
+
+//gopherjs:purge
+func registerCache(unsafe.Pointer)
+
+//gopherjs:purge
+const cacheSize = 1021

--- a/compiler/natives/src/crypto/internal/boring/bcache/cache_test.go
+++ b/compiler/natives/src/crypto/internal/boring/bcache/cache_test.go
@@ -1,0 +1,10 @@
+//go:build js
+// +build js
+
+package bcache
+
+import "testing"
+
+func TestCache(t *testing.T) {
+	t.Skip(`This test uses runtime.GC(), which GopherJS doesn't support`)
+}

--- a/compiler/natives/src/crypto/internal/boring/sig/sig.go
+++ b/compiler/natives/src/crypto/internal/boring/sig/sig.go
@@ -1,0 +1,13 @@
+//go:build js
+// +build js
+
+package sig
+
+// Setting to no-op
+func BoringCrypto() {}
+
+// Setting to no-op
+func FIPSOnly() {}
+
+// Setting to no-op
+func StandardCrypto() {}

--- a/compiler/natives/src/crypto/internal/nistec/nistec_test.go
+++ b/compiler/natives/src/crypto/internal/nistec/nistec_test.go
@@ -4,8 +4,10 @@
 package nistec_test
 
 import (
-	"crypto/elliptic"
 	"testing"
+
+	"crypto/elliptic"
+	"crypto/internal/nistec"
 )
 
 func TestAllocations(t *testing.T) {
@@ -31,7 +33,7 @@ func TestEquivalents(t *testing.T) {
 }
 
 //gopherjs:override-signature
-func testEquivalents(t *testing.T, newPoint, newGenerator func() WrappedPoint, c elliptic.Curve) {}
+func testEquivalents(t *testing.T, newPoint, newGenerator func() nistec.WrappedPoint, c elliptic.Curve)
 
 func TestScalarMult(t *testing.T) {
 	t.Run("P224", func(t *testing.T) {
@@ -49,14 +51,14 @@ func TestScalarMult(t *testing.T) {
 }
 
 //gopherjs:override-signature
-func testScalarMult(t *testing.T, newPoint, newGenerator func() WrappedPoint, c elliptic.Curve)
+func testScalarMult(t *testing.T, newPoint, newGenerator func() nistec.WrappedPoint, c elliptic.Curve)
 
 func BenchmarkScalarMult(b *testing.B) {
 	b.Run("P224", func(b *testing.B) {
 		benchmarkScalarMult(b, nistec.NewP224WrappedGenerator(), 28)
 	})
 	b.Run("P256", func(b *testing.B) {
-		benchmarkScalarMult(b, nistec.NewP256GWrappedenerator(), 32)
+		benchmarkScalarMult(b, nistec.NewP256WrappedGenerator(), 32)
 	})
 	b.Run("P384", func(b *testing.B) {
 		benchmarkScalarMult(b, nistec.NewP384WrappedGenerator(), 48)
@@ -67,11 +69,11 @@ func BenchmarkScalarMult(b *testing.B) {
 }
 
 //gopherjs:override-signature
-func benchmarkScalarMult(b *testing.B, p WrappedPoint, scalarSize int)
+func benchmarkScalarMult(b *testing.B, p nistec.WrappedPoint, scalarSize int)
 
 func BenchmarkScalarBaseMult(b *testing.B) {
 	b.Run("P224", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP22Wrapped4Generator(), 28)
+		benchmarkScalarBaseMult(b, nistec.NewP224WrappedGenerator(), 28)
 	})
 	b.Run("P256", func(b *testing.B) {
 		benchmarkScalarBaseMult(b, nistec.NewP256WrappedGenerator(), 32)
@@ -80,9 +82,9 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 		benchmarkScalarBaseMult(b, nistec.NewP384WrappedGenerator(), 48)
 	})
 	b.Run("P521", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP521GWrappedenerator(), 66)
+		benchmarkScalarBaseMult(b, nistec.NewP521WrappedGenerator(), 66)
 	})
 }
 
 //gopherjs:override-signature
-func benchmarkScalarBaseMult(b *testing.B, p WrappedPoint, scalarSize int)
+func benchmarkScalarBaseMult(b *testing.B, p nistec.WrappedPoint, scalarSize int)

--- a/compiler/natives/src/debug/pe/symbol.go
+++ b/compiler/natives/src/debug/pe/symbol.go
@@ -1,0 +1,119 @@
+//go:build js
+// +build js
+
+package pe
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// bytesBufferLite is a simplified bytes.Buffer to avoid
+// including `bytes` as a new import into the pe package.
+type bytesBufferLite struct {
+	data []byte
+	off  int
+}
+
+func (buf *bytesBufferLite) Write(p []byte) (int, error) {
+	buf.data = append(buf.data, p...)
+	return len(p), nil
+}
+
+func (buf *bytesBufferLite) Read(p []byte) (int, error) {
+	n := copy(p, buf.data[buf.off:])
+	buf.off += n
+	return n, nil
+}
+
+func copyToAuxFormat5(sym *COFFSymbol) (*COFFSymbolAuxFormat5, error) {
+	buf := &bytesBufferLite{data: make([]byte, 0, 20)}
+	if err := binary.Write(buf, binary.LittleEndian, sym); err != nil {
+		return nil, err
+	}
+	aux := &COFFSymbolAuxFormat5{}
+	if err := binary.Read(buf, binary.LittleEndian, aux); err != nil {
+		return nil, err
+	}
+	return aux, nil
+}
+
+func copyFromAuxFormat5(aux *COFFSymbolAuxFormat5) (*COFFSymbol, error) {
+	buf := &bytesBufferLite{data: make([]byte, 0, 20)}
+	if err := binary.Write(buf, binary.LittleEndian, aux); err != nil {
+		return nil, err
+	}
+	sym := &COFFSymbol{}
+	if err := binary.Read(buf, binary.LittleEndian, sym); err != nil {
+		return nil, err
+	}
+	return sym, nil
+}
+
+func readCOFFSymbols(fh *FileHeader, r io.ReadSeeker) ([]COFFSymbol, error) {
+	if fh.PointerToSymbolTable == 0 {
+		return nil, nil
+	}
+	if fh.NumberOfSymbols <= 0 {
+		return nil, nil
+	}
+	_, err := r.Seek(int64(fh.PointerToSymbolTable), seekStart)
+	if err != nil {
+		return nil, fmt.Errorf("fail to seek to symbol table: %v", err)
+	}
+	syms := make([]COFFSymbol, fh.NumberOfSymbols)
+	naux := 0
+	for k := range syms {
+		if naux == 0 {
+			err = binary.Read(r, binary.LittleEndian, &syms[k])
+			if err != nil {
+				return nil, fmt.Errorf("fail to read symbol table: %v", err)
+			}
+			naux = int(syms[k].NumberOfAuxSymbols)
+		} else {
+			naux--
+			// The following was reading into one struct with the same memory
+			// footprint as another struck. This doesn't work in JS so the
+			// `syms` value is left with a bunch of defaults. So replace
+			// aux := (*COFFSymbolAuxFormat5)(unsafe.Pointer(&syms[k]))
+			// (an in memory remap) with the following read and then copy.
+			aux := &COFFSymbolAuxFormat5{}
+			err = binary.Read(r, binary.LittleEndian, aux)
+			if err != nil {
+				return nil, fmt.Errorf("fail to read symbol table: %v", err)
+			}
+			pesymn, err := copyFromAuxFormat5(aux)
+			if err != nil {
+				return nil, err
+			}
+			syms[k] = *pesymn
+		}
+	}
+	if naux != 0 {
+		return nil, fmt.Errorf("fail to read symbol table: %d aux symbols unread", naux)
+	}
+	return syms, nil
+}
+
+func (f *File) COFFSymbolReadSectionDefAux(idx int) (*COFFSymbolAuxFormat5, error) {
+	var rv *COFFSymbolAuxFormat5
+	if idx < 0 || idx >= len(f.COFFSymbols) {
+		return rv, fmt.Errorf("invalid symbol index")
+	}
+	pesym := &f.COFFSymbols[idx]
+	const IMAGE_SYM_CLASS_STATIC = 3
+	if pesym.StorageClass != uint8(IMAGE_SYM_CLASS_STATIC) {
+		return rv, fmt.Errorf("incorrect symbol storage class")
+	}
+	if pesym.NumberOfAuxSymbols == 0 || idx+1 >= len(f.COFFSymbols) {
+		return rv, fmt.Errorf("aux symbol unavailable")
+	}
+	pesymn := &f.COFFSymbols[idx+1]
+	// The following was reading one struct as another struct with
+	// the same memory footprint. This doesn't work in JS so the
+	// `rv` value is left with a bunch of `undefined`s. So replace
+	// rv = (*COFFSymbolAuxFormat5)(unsafe.Pointer(pesymn))
+	// (an in memory remap) with the following copy.
+	return copyToAuxFormat5(pesymn)
+}

--- a/compiler/natives/src/go/token/position.go
+++ b/compiler/natives/src/go/token/position.go
@@ -3,24 +3,20 @@
 
 package token
 
-import (
-	"sync"
-	"sync/atomic"
-	"unsafe"
-)
+import "sync"
 
 type FileSet struct {
 	mutex sync.RWMutex
 	base  int
 	files []*File
 
-	// replaced atomic.Pointer[File] for go1.19 without generics
+	// replaced atomic.Pointer[File] for go1.19 without generics.
 	last atomicFilePointer
 }
 
 type atomicFilePointer struct {
-	v unsafe.Pointer
+	v *File
 }
 
-func (x *atomicFilePointer) Load() *File     { return (*File)(atomic.LoadPointer(&x.v)) }
-func (x *atomicFilePointer) Store(val *File) { atomic.StorePointer(&x.v, unsafe.Pointer(val)) }
+func (x *atomicFilePointer) Load() *File     { return x.v }
+func (x *atomicFilePointer) Store(val *File) { x.v = val }

--- a/compiler/natives/src/hash/maphash/maphash.go
+++ b/compiler/natives/src/hash/maphash/maphash.go
@@ -3,30 +3,57 @@
 
 package maphash
 
-// used in hash{32,64}.go to seed the hash function
-var hashkey [4]uint32
+import (
+	_ "unsafe" // for linkname
+)
+
+// hashkey is similar how it is defined in runtime/alg.go for Go 1.19
+// to be used in hash{32,64}.go to seed the hash function as part of
+// runtime_memhash. We're using locally defined memhash so it got moved here.
+var hashkey [3]uint32
 
 func init() {
 	for i := range hashkey {
-		hashkey[i] = uint32(runtime_fastrand64())
+		hashkey[i] = runtime_fastrand() | 1
+		// The `| 1` is to make sure these numbers are odd
 	}
-	hashkey[0] |= 1 // make sure these numbers are odd
-	hashkey[1] |= 1
-	hashkey[2] |= 1
-	hashkey[3] |= 1
 }
 
-func _rthash(b []byte, seed uint64) uint64 {
+//go:linkname runtime_fastrand runtime.fastrand
+func runtime_fastrand() uint32
+
+// Bytes uses less efficient equivalent to avoid using unsafe.
+func Bytes(seed Seed, b []byte) uint64 {
+	var h Hash
+	h.SetSeed(seed)
+	_, _ = h.Write(b)
+	return h.Sum64()
+}
+
+// String uses less efficient equivalent to avoid using unsafe.
+func String(seed Seed, s string) uint64 {
+	var h Hash
+	h.SetSeed(seed)
+	_, _ = h.WriteString(s)
+	return h.Sum64()
+}
+
+// rthash is similar to the Go 1.19.13 version
+// with the call to memhash changed to not use unsafe pointers.
+func rthash(b []byte, seed uint64) uint64 {
 	if len(b) == 0 {
 		return seed
 	}
 	// The runtime hasher only works on uintptr. Since GopherJS implements a
 	// 32-bit environment, we use two parallel hashers on the lower and upper 32
 	// bits.
-	lo := memhash(b, uint32(seed), uint32(len(b)))
-	hi := memhash(b, uint32(seed>>32), uint32(len(b)))
+	lo := memhash(b, uint32(seed))
+	hi := memhash(b, uint32(seed>>32))
 	return uint64(hi)<<32 | uint64(lo)
 }
+
+//gopherjs:purge to remove link using unsafe pointers, use memhash instead.
+func runtime_memhash()
 
 // The implementation below is adapted from the upstream runtime/hash32.go
 // and avoids use of unsafe, which GopherJS doesn't support well and leads to
@@ -38,8 +65,9 @@ func _rthash(b []byte, seed uint64) uint64 {
 //
 // Hashing algorithm inspired by wyhash:
 // https://github.com/wangyi-fudan/wyhash/blob/ceb019b530e2c1c14d70b79bfa2bc49de7d95bc1/Modern%20Non-Cryptographic%20Hash%20Function%20and%20Pseudorandom%20Number%20Generator.pdf
-func memhash(p []byte, seed uint32, s uint32) uintptr {
-	a, b := mix32(uint32(seed), uint32(s^hashkey[0]))
+func memhash(p []byte, seed uint32) uintptr {
+	s := len(p)
+	a, b := mix32(uint32(seed), uint32(s)^hashkey[0])
 	if s == 0 {
 		return uintptr(a ^ b)
 	}
@@ -63,7 +91,7 @@ func memhash(p []byte, seed uint32, s uint32) uintptr {
 	return uintptr(a ^ b)
 }
 
-func add(p []byte, x uint32) []byte {
+func add(p []byte, x int) []byte {
 	return p[x:]
 }
 
@@ -80,51 +108,59 @@ func mix32(a, b uint32) (uint32, uint32) {
 /*
 	The following functions were modified in Go 1.17 to improve performance,
 	but at the expense of being unsafe, and thus incompatible with GopherJS.
-	To compensate, we have reverted these to the unoptimized Go 1.16 versions
-	for now.
+	See https://cs.opensource.google/go/go/+/refs/tags/go1.19.13:src/hash/maphash/maphash.go;
+	To compensate, we use a simplified version of each method from Go 1.19.13,
+	similar to Go 1.16's versions, with the call to rthash changed to not use unsafe pointers.
 
 	See upstream issue https://github.com/golang/go/issues/47342 to implement
 	a purego version of this package, which should render this hack (and
 	likely this entire file) obsolete.
 */
 
-// Write is borrowed from Go 1.16.
+// Write is a simplification from Go 1.19 changed to not use unsafe.
 func (h *Hash) Write(b []byte) (int, error) {
 	size := len(b)
-	for h.n+len(b) > len(h.buf) {
-		k := copy(h.buf[h.n:], b)
-		h.n = len(h.buf)
-		b = b[k:]
-		h.flush()
+	if h.n+len(b) > bufSize {
+		h.initSeed()
+		for h.n+len(b) > bufSize {
+			k := copy(h.buf[h.n:], b)
+			h.state.s = rthash(h.buf[:], h.state.s)
+			b = b[k:]
+			h.n = 0
+		}
 	}
 	h.n += copy(h.buf[h.n:], b)
 	return size, nil
 }
 
-// WriteString is borrowed from Go 1.16.
+// WriteString is a simplification from Go 1.19 changed to not use unsafe.
 func (h *Hash) WriteString(s string) (int, error) {
 	size := len(s)
-	for h.n+len(s) > len(h.buf) {
-		k := copy(h.buf[h.n:], s)
-		h.n = len(h.buf)
-		s = s[k:]
-		h.flush()
+	if h.n+len(s) > bufSize {
+		h.initSeed()
+		for h.n+len(s) > bufSize {
+			k := copy(h.buf[h.n:], s)
+			h.state.s = rthash(h.buf[:], h.state.s)
+			s = s[k:]
+			h.n = 0
+		}
 	}
 	h.n += copy(h.buf[h.n:], s)
 	return size, nil
 }
 
+// flush is the Go 1.19 version changed to not use unsafe.
 func (h *Hash) flush() {
 	if h.n != len(h.buf) {
 		panic("maphash: flush of partially full buffer")
 	}
 	h.initSeed()
-	h.state.s = _rthash(h.buf[:], h.state.s)
+	h.state.s = rthash(h.buf[:], h.state.s)
 	h.n = 0
 }
 
-// Sum64 is borrowed from Go 1.16.
+// Sum64 is the Go 1.19 version changed to not use unsafe.
 func (h *Hash) Sum64() uint64 {
 	h.initSeed()
-	return _rthash(h.buf[:h.n], h.state.s)
+	return rthash(h.buf[:h.n], h.state.s)
 }

--- a/compiler/natives/src/internal/reflectlite/all_test.go
+++ b/compiler/natives/src/internal/reflectlite/all_test.go
@@ -21,3 +21,27 @@ func TestTypes(t *testing.T) {
 func TestNameBytesAreAligned(t *testing.T) {
 	t.Skip("TestNameBytesAreAligned")
 }
+
+// `A` is used with `B[T any]` and is otherwise not needed.
+//
+//gopherjs:purge for go1.19 without generics
+type (
+	A        struct{}
+	B[T any] struct{}
+)
+
+// removing the name tests using `B[T any]` for go1.19 without generics
+var nameTests = []nameTest{
+	{(*int32)(nil), "int32"},
+	{(*D1)(nil), "D1"},
+	{(*[]D1)(nil), ""},
+	{(*chan D1)(nil), ""},
+	{(*func() D1)(nil), ""},
+	{(*<-chan D1)(nil), ""},
+	{(*chan<- D1)(nil), ""},
+	{(*any)(nil), ""},
+	{(*interface {
+		F()
+	})(nil), ""},
+	{(*TheNameOfThisTypeIsExactly255BytesLongSoWhenTheCompilerPrependsTheReflectTestPackageNameAndExtraStarTheLinkerRuntimeAndReflectPackagesWillHaveToCorrectlyDecodeTheSecondLengthByte0123456789_0123456789_0123456789_0123456789_0123456789_012345678)(nil), "TheNameOfThisTypeIsExactly255BytesLongSoWhenTheCompilerPrependsTheReflectTestPackageNameAndExtraStarTheLinkerRuntimeAndReflectPackagesWillHaveToCorrectlyDecodeTheSecondLengthByte0123456789_0123456789_0123456789_0123456789_0123456789_012345678"},
+}

--- a/compiler/natives/src/net/fastrand.go
+++ b/compiler/natives/src/net/fastrand.go
@@ -7,5 +7,5 @@ import (
 	_ "unsafe" // For go:linkname
 )
 
-//go:linkname fastrand runtime.fastrand
-func fastrand() uint32
+//go:linkname fastrandu runtime.fastrandu
+func fastrandu() uint

--- a/compiler/natives/src/net/netip/export_test.go
+++ b/compiler/natives/src/net/netip/export_test.go
@@ -1,4 +1,5 @@
 //go:build js
+// +build js
 
 package netip
 
@@ -8,7 +9,6 @@ import (
 	"internal/intern"
 )
 
-//gopherjs:prune-original
 func MkAddr(u Uint128, z any) Addr {
 	switch z := z.(type) {
 	case *intern.Value:

--- a/compiler/natives/src/net/netip/fuzz_test.go
+++ b/compiler/natives/src/net/netip/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build js
+// +build js
 
 package netip_test
 

--- a/compiler/natives/src/net/netip/netip.go
+++ b/compiler/natives/src/net/netip/netip.go
@@ -1,4 +1,5 @@
 //go:build js
+// +build js
 
 package netip
 
@@ -17,7 +18,6 @@ var (
 	z6noz = "\x00ipv6noz"
 )
 
-//gopherjs:prune-original
 func (ip Addr) Zone() string {
 	if ip.z == z4 || ip.z == z6noz {
 		return ""
@@ -25,7 +25,6 @@ func (ip Addr) Zone() string {
 	return ip.z
 }
 
-//gopherjs:prune-original
 func (ip Addr) WithZone(zone string) Addr {
 	if !ip.Is6() {
 		return ip

--- a/compiler/natives/src/net/netip/netip_test.go
+++ b/compiler/natives/src/net/netip/netip_test.go
@@ -1,0 +1,10 @@
+//go:build js
+// +build js
+
+package netip_test
+
+import "testing"
+
+func TestAddrStringAllocs(t *testing.T) {
+	t.Skip("testing.AllocsPerRun not supported in GopherJS")
+}

--- a/compiler/natives/src/reflect/reflect_test.go
+++ b/compiler/natives/src/reflect/reflect_test.go
@@ -285,9 +285,16 @@ func TestMethodCallValueCodePtr(t *testing.T) {
 	t.Skip("methodValueCallCodePtr() is not applicable in GopherJS")
 }
 
-type B struct{}
+//gopherjs:purge for go1.19 without generics
+type (
+	A        struct{}
+	B[T any] struct{}
+)
 
-//gopherjs:prune-original
 func TestIssue50208(t *testing.T) {
 	t.Skip("This test required generics, which are not yet supported: https://github.com/gopherjs/gopherjs/issues/1013")
+}
+
+func TestStructOfTooLarge(t *testing.T) {
+	t.Skip("This test is dependent on field alignment to determine if a struct size would exceed virtual address space.")
 }

--- a/compiler/natives/src/runtime/fastrand.go
+++ b/compiler/natives/src/runtime/fastrand.go
@@ -13,3 +13,15 @@ func fastrand() uint32 {
 	// similar distribution.
 	return uint32(js.Global.Get("Math").Call("random").Float() * (1<<32 - 1))
 }
+
+func fastrandn(n uint32) uint32 {
+	return fastrand() % n
+}
+
+func fastrand64() uint64 {
+	return uint64(fastrand())<<32 | uint64(fastrand())
+}
+
+func fastrandu() uint {
+	return uint(fastrand())
+}

--- a/compiler/natives/src/sync/atomic/atomic_test.go
+++ b/compiler/natives/src/sync/atomic/atomic_test.go
@@ -57,9 +57,21 @@ func TestUnaligned64(t *testing.T) {
 	t.Skip("GopherJS emulates atomics, which makes alignment irrelevant.")
 }
 
+unc TestAutoAligned64(t *testing.T) {
+	t.Skip("GopherJS emulates atomics, which makes alignment irrelevant.")
+}
+
 func TestNilDeref(t *testing.T) {
 	t.Skip("GopherJS does not support generics yet.")
 }
 
 //gopherjs:purge for go1.19 without generics
 type List struct{}
+
+func TestHammer32(t *testing.T) {
+	t.Skip("use of unsafe")
+}
+
+func TestHammer64(t *testing.T) {
+	t.Skip("use of unsafe")
+}

--- a/compiler/natives/src/sync/atomic/atomic_test.go
+++ b/compiler/natives/src/sync/atomic/atomic_test.go
@@ -57,7 +57,7 @@ func TestUnaligned64(t *testing.T) {
 	t.Skip("GopherJS emulates atomics, which makes alignment irrelevant.")
 }
 
-unc TestAutoAligned64(t *testing.T) {
+func TestAutoAligned64(t *testing.T) {
 	t.Skip("GopherJS emulates atomics, which makes alignment irrelevant.")
 }
 

--- a/compiler/natives/src/syscall/js/export_test.go
+++ b/compiler/natives/src/syscall/js/export_test.go
@@ -4,6 +4,5 @@
 package js
 
 // Defined to avoid a compile error in the original TestGarbageCollection()
-// body. Can't use gopherjs:prune-original on it, since it causes an unused
-// import error.
+// body.
 var JSGo Value

--- a/compiler/natives/src/syscall/js/js_test.go
+++ b/compiler/natives/src/syscall/js/js_test.go
@@ -5,7 +5,6 @@ package js_test
 
 import "testing"
 
-//gopherjs:prune-original
 func TestIntConversion(t *testing.T) {
 	// Same as upstream, but only test cases appropriate for a 32-bit environment.
 	testIntConversion(t, 0)


### PR DESCRIPTION
Updating more natives for go1.19 without generics:

1. Updated `crypto`: It had a copy/paste issue and had to remove the cache. The cache hooks into the GC to clear periodically. I wasn't sure if there was a JS equivalent or if we wanted to use a timer, so I just removed the cache, and now it is treated as if it was always a cache miss.
2. Added fix for `debug/pe`: It had some unsafe pointers for casting one struct into another struct's memory footprint.
3. Updated `go/token/position`: Was getting issues with finding most recent file so changed the fix to use `*File` directly.
4. Updated `hash/maphash`: It had parts from go1.16 which could be updated to match closer to go1.19. It had some new methods, `Bytes` and `String`, that were using unsafe pointer.
5. Updated `reflect` and `reflectlite`: It has some minor changes with some notable changes to `Cap` and `Len` to allow for pointers to arrays and to `valueMethodName` to try to get the correct function name.
6. Updated `fastrand` and a usage of a `fastrandu` in `net`: Added the other `fastrand` methods (`fastrandn`, `fastrand64`, and `fastrandu`) to the runtime.
7. Updated `net/netip`: Just some touchups and skipping a test.
8. Updated `sync/atomic`: Skipping some tests.
9. Updated `syscall/js`: Tiny cleanup

After this update go1.19 should be getting very close.