### PR TITLE
[go1.19] Limiting when pruneImports is run

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -486,10 +486,11 @@ func pruneImports(file *ast.File) {
 			// since the import is otherwise unused set the name to blank.
 			in.Name = ast.NewIdent(`_`)
 			delete(unused, name)
+			if len(unused) == 0 {
+				return
+			}
+			break
 		}
-	}
-	if len(unused) == 0 {
-		return
 	}
 
 	// Remove all unused import specifications

--- a/build/build.go
+++ b/build/build.go
@@ -178,10 +178,14 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 	}
 	delete(overrides, "init")
 
-	// If there are no overrides, don't augment original files
+	// Adjust imports for all original files
+	for _, file := range originalFiles {
+		augmentOriginalImports(pkg.ImportPath, file)
+	}
+
+	// Augment original files if there are any overrides
 	if len(overrides) > 0 {
 		for _, file := range originalFiles {
-			augmentOriginalImports(pkg.ImportPath, file)
 			if augmentOriginalFile(file, overrides) {
 				pruneImports(file)
 			}

--- a/build/build.go
+++ b/build/build.go
@@ -178,10 +178,14 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 	}
 	delete(overrides, "init")
 
-	for _, file := range originalFiles {
-		augmentOriginalImports(pkg.ImportPath, file)
-		augmentOriginalFile(file, overrides)
-		pruneImports(file)
+	// If there are no overrides, don't augment original files
+	if len(overrides) > 0 {
+		for _, file := range originalFiles {
+			augmentOriginalImports(pkg.ImportPath, file)
+			if augmentOriginalFile(file, overrides) {
+				pruneImports(file)
+			}
+		}
 	}
 
 	return append(overlayFiles, originalFiles...), jsFiles, nil
@@ -333,11 +337,13 @@ func augmentOriginalImports(importPath string, file *ast.File) {
 // augmentOriginalFile is the part of parseAndAugment that processes an
 // original file AST to augment the source code using the overrides from
 // the overlay files.
-func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
+func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) bool {
+	anyChange := false
 	for i, decl := range file.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:
 			if info, ok := overrides[astutil.FuncKey(d)]; ok {
+				anyChange = true
 				removeFunc := true
 				if info.keepOriginal {
 					// Allow overridden function calls
@@ -358,6 +364,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			} else if recvKey := astutil.FuncReceiverKey(d); len(recvKey) > 0 {
 				// check if the receiver has been purged, if so, remove the method too.
 				if info, ok := overrides[recvKey]; ok && info.purgeMethods {
+					anyChange = true
 					file.Decls[i] = nil
 				}
 			}
@@ -366,6 +373,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 				switch s := spec.(type) {
 				case *ast.TypeSpec:
 					if _, ok := overrides[s.Name.Name]; ok {
+						anyChange = true
 						d.Specs[j] = nil
 					}
 				case *ast.ValueSpec:
@@ -378,6 +386,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						// to be run, add the call into the overlay.
 						for k, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
+								anyChange = true
 								s.Names[k] = nil
 								s.Values[k] = nil
 							}
@@ -392,6 +401,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						nameRemoved := false
 						for _, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
+								anyChange = true
 								nameRemoved = true
 								name.Name = `_`
 							}
@@ -405,6 +415,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 								}
 							}
 							if removeSpec {
+								anyChange = true
 								d.Specs[j] = nil
 							}
 						}
@@ -413,7 +424,11 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			}
 		}
 	}
-	finalizeRemovals(file)
+	if anyChange {
+		finalizeRemovals(file)
+		return true
+	}
+	return false
 }
 
 // isOnlyImports determines if this file is empty except for imports.
@@ -437,6 +452,14 @@ func isOnlyImports(file *ast.File) bool {
 // If the removal of code causes an import to be removed, the init's from that
 // import may not be run anymore. If we still need to run an init for an import
 // which is no longer used, add it to the overlay as a blank (`_`) import.
+//
+// This uses the given name or guesses at the name using the import path,
+// meaning this doesn't work for packages which have a different package name
+// from the path, including those paths which are versioned
+// (e.g. `github.com/foo/bar/v2` where the package name is `bar`)
+// or if the import is defined using a relative path (e.g. `./..`).
+// Those cases don't exist in the native for Go, so we should only run
+// this pruning when we have native overlays, but not for unknown packages.
 func pruneImports(file *ast.File) {
 	if isOnlyImports(file) && !astutil.HasDirectivePrefix(file, `//go:linkname `) {
 		// The file is empty, remove all imports including any `.` or `_` imports.

--- a/build/build.go
+++ b/build/build.go
@@ -273,7 +273,7 @@ func parserOriginalFiles(pkg *PackageData, fileSet *token.FileSet) ([]*ast.File,
 // an overlay file AST to collect information such as compiler directives
 // and perform any initial augmentation needed to the overlay.
 func augmentOverlayFile(file *ast.File, overrides map[string]overrideInfo) {
-	anyChange := false
+	//anyChange := false
 	for i, decl := range file.Decls {
 		purgeDecl := astutil.Purge(decl)
 		switch d := decl.(type) {
@@ -301,20 +301,20 @@ func augmentOverlayFile(file *ast.File, overrides map[string]overrideInfo) {
 					}
 				}
 				if purgeSpec {
-					anyChange = true
+					//anyChange = true
 					d.Specs[j] = nil
 				}
 			}
 		}
 		if purgeDecl {
-			anyChange = true
+			//anyChange = true
 			file.Decls[i] = nil
 		}
 	}
-	if anyChange {
-		finalizeRemovals(file)
-		pruneImports(file)
-	}
+	//if anyChange {
+	finalizeRemovals(file)
+	pruneImports(file)
+	//}
 }
 
 // augmentOriginalImports is the part of parseAndAugment that processes
@@ -338,17 +338,17 @@ func augmentOriginalImports(importPath string, file *ast.File) {
 // original file AST to augment the source code using the overrides from
 // the overlay files.
 func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
-	if len(overrides) <= 0 {
-		// If there are no overrides, there is nothing to augment here.
-		return
-	}
+	//if len(overrides) == 0 {
+	//	// If there are no overrides, there is nothing to augment here.
+	//	return
+	//}
 
-	anyChange := false
+	//anyChange := false
 	for i, decl := range file.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:
 			if info, ok := overrides[astutil.FuncKey(d)]; ok {
-				anyChange = true
+				//anyChange = true
 				removeFunc := true
 				if info.keepOriginal {
 					// Allow overridden function calls
@@ -369,7 +369,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			} else if recvKey := astutil.FuncReceiverKey(d); len(recvKey) > 0 {
 				// check if the receiver has been purged, if so, remove the method too.
 				if info, ok := overrides[recvKey]; ok && info.purgeMethods {
-					anyChange = true
+					//anyChange = true
 					file.Decls[i] = nil
 				}
 			}
@@ -378,7 +378,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 				switch s := spec.(type) {
 				case *ast.TypeSpec:
 					if _, ok := overrides[s.Name.Name]; ok {
-						anyChange = true
+						//anyChange = true
 						d.Specs[j] = nil
 					}
 				case *ast.ValueSpec:
@@ -391,7 +391,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						// to be run, add the call into the overlay.
 						for k, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
-								anyChange = true
+								//anyChange = true
 								s.Names[k] = nil
 								s.Values[k] = nil
 							}
@@ -406,7 +406,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						nameRemoved := false
 						for _, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
-								anyChange = true
+								//anyChange = true
 								nameRemoved = true
 								name.Name = `_`
 							}
@@ -420,7 +420,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 								}
 							}
 							if removeSpec {
-								anyChange = true
+								//anyChange = true
 								d.Specs[j] = nil
 							}
 						}
@@ -429,10 +429,10 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			}
 		}
 	}
-	if anyChange {
-		finalizeRemovals(file)
-		pruneImports(file)
-	}
+	//if anyChange {
+	finalizeRemovals(file)
+	pruneImports(file)
+	//}
 }
 
 // isOnlyImports determines if this file is empty except for imports.

--- a/build/build.go
+++ b/build/build.go
@@ -273,7 +273,7 @@ func parserOriginalFiles(pkg *PackageData, fileSet *token.FileSet) ([]*ast.File,
 // an overlay file AST to collect information such as compiler directives
 // and perform any initial augmentation needed to the overlay.
 func augmentOverlayFile(file *ast.File, overrides map[string]overrideInfo) {
-	//anyChange := false
+	// anyChange := false
 	for i, decl := range file.Decls {
 		purgeDecl := astutil.Purge(decl)
 		switch d := decl.(type) {
@@ -301,17 +301,17 @@ func augmentOverlayFile(file *ast.File, overrides map[string]overrideInfo) {
 					}
 				}
 				if purgeSpec {
-					//anyChange = true
+					// anyChange = true
 					d.Specs[j] = nil
 				}
 			}
 		}
 		if purgeDecl {
-			//anyChange = true
+			// anyChange = true
 			file.Decls[i] = nil
 		}
 	}
-	//if anyChange {
+	// if anyChange {
 	finalizeRemovals(file)
 	pruneImports(file)
 	//}
@@ -343,12 +343,12 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 	//	return
 	//}
 
-	//anyChange := false
+	// anyChange := false
 	for i, decl := range file.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:
 			if info, ok := overrides[astutil.FuncKey(d)]; ok {
-				//anyChange = true
+				// anyChange = true
 				removeFunc := true
 				if info.keepOriginal {
 					// Allow overridden function calls
@@ -369,7 +369,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			} else if recvKey := astutil.FuncReceiverKey(d); len(recvKey) > 0 {
 				// check if the receiver has been purged, if so, remove the method too.
 				if info, ok := overrides[recvKey]; ok && info.purgeMethods {
-					//anyChange = true
+					// anyChange = true
 					file.Decls[i] = nil
 				}
 			}
@@ -378,7 +378,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 				switch s := spec.(type) {
 				case *ast.TypeSpec:
 					if _, ok := overrides[s.Name.Name]; ok {
-						//anyChange = true
+						// anyChange = true
 						d.Specs[j] = nil
 					}
 				case *ast.ValueSpec:
@@ -391,7 +391,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						// to be run, add the call into the overlay.
 						for k, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
-								//anyChange = true
+								// anyChange = true
 								s.Names[k] = nil
 								s.Values[k] = nil
 							}
@@ -406,7 +406,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 						nameRemoved := false
 						for _, name := range s.Names {
 							if _, ok := overrides[name.Name]; ok {
-								//anyChange = true
+								// anyChange = true
 								nameRemoved = true
 								name.Name = `_`
 							}
@@ -420,7 +420,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 								}
 							}
 							if removeSpec {
-								//anyChange = true
+								// anyChange = true
 								d.Specs[j] = nil
 							}
 						}
@@ -429,7 +429,7 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
 			}
 		}
 	}
-	//if anyChange {
+	// if anyChange {
 	finalizeRemovals(file)
 	pruneImports(file)
 	//}

--- a/build/build.go
+++ b/build/build.go
@@ -338,6 +338,11 @@ func augmentOriginalImports(importPath string, file *ast.File) {
 // original file AST to augment the source code using the overrides from
 // the overlay files.
 func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
+	if len(overrides) <= 0 {
+		// If there are no overrides, there is nothing to augment here.
+		return
+	}
+
 	anyChange := false
 	for i, decl := range file.Decls {
 		switch d := decl.(type) {

--- a/build/build.go
+++ b/build/build.go
@@ -338,11 +338,6 @@ func augmentOriginalImports(importPath string, file *ast.File) {
 // original file AST to augment the source code using the overrides from
 // the overlay files.
 func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo) {
-	if len(overrides) <= 0 {
-		// If there are no overrides, there is nothing to augment here.
-		return
-	}
-
 	anyChange := false
 	for i, decl := range file.Decls {
 		switch d := decl.(type) {

--- a/build/build.go
+++ b/build/build.go
@@ -505,11 +505,10 @@ func pruneImports(file *ast.File) {
 			// since the import is otherwise unused set the name to blank.
 			in.Name = ast.NewIdent(`_`)
 			delete(unused, name)
-			if len(unused) == 0 {
-				return
-			}
-			break
 		}
+	}
+	if len(unused) == 0 {
+		return
 	}
 
 	// Remove all unused import specifications

--- a/circle.yml
+++ b/circle.yml
@@ -175,7 +175,7 @@ jobs:
       - run:
           name: Install Go
           command: |
-            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my
+            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my --force
             go version
             (Get-Command go).Path
             [Environment]::SetEnvironmentVariable(

--- a/circle.yml
+++ b/circle.yml
@@ -175,7 +175,7 @@ jobs:
       - run:
           name: Install Go
           command: |
-            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my --force
+            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my --force -y
             go version
             (Get-Command go).Path
             [Environment]::SetEnvironmentVariable(

--- a/compiler/natives/src/crypto/internal/boring/bbig/big.go
+++ b/compiler/natives/src/crypto/internal/boring/bbig/big.go
@@ -33,7 +33,7 @@ func Dec(b boring.BigInt) *big.Int {
 		return new(big.Int)
 	}
 	// Replacing original which uses unsafe:
-	//x := unsafe.Slice((*big.Word)(&b[0]), len(b))
+	// x := unsafe.Slice((*big.Word)(&b[0]), len(b))
 	x := make([]big.Word, len(b))
 	for i, w := range b {
 		x[i] = big.Word(w)

--- a/compiler/natives/src/crypto/internal/nistec/nistec_test.go
+++ b/compiler/natives/src/crypto/internal/nistec/nistec_test.go
@@ -4,10 +4,9 @@
 package nistec_test
 
 import (
-	"testing"
-
 	"crypto/elliptic"
 	"crypto/internal/nistec"
+	"testing"
 )
 
 func TestAllocations(t *testing.T) {

--- a/tests/linkname_test.go
+++ b/tests/linkname_test.go
@@ -50,8 +50,8 @@ func rtype_nameOff(r *rtype, off nameOff) name
 //go:linkname newName reflect.newName
 func newName(n, tag string, exported bool) name
 
-//go:linkname name_name reflect.(*name).name
-func name_name(n *name) string
+//go:linkname name_name reflect.name.name
+func name_name(name) string
 
 //go:linkname resolveReflectName reflect.resolveReflectName
 func resolveReflectName(n name) nameOff
@@ -60,7 +60,7 @@ func TestLinknameReflectName(t *testing.T) {
 	info := "myinfo"
 	off := resolveReflectName(newName(info, "", false))
 	n := rtype_nameOff(nil, off)
-	if s := name_name(&n); s != info {
+	if s := name_name(n); s != info {
 		t.Fatalf("to reflect.name got %q: want %q", s, info)
 	}
 }

--- a/tests/linkname_test.go
+++ b/tests/linkname_test.go
@@ -50,8 +50,8 @@ func rtype_nameOff(r *rtype, off nameOff) name
 //go:linkname newName reflect.newName
 func newName(n, tag string, exported bool) name
 
-//go:linkname name_name reflect.name.name
-func name_name(name) string
+//go:linkname name_name reflect.(*name).name
+func name_name(n *name) string
 
 //go:linkname resolveReflectName reflect.resolveReflectName
 func resolveReflectName(n name) nameOff
@@ -60,7 +60,7 @@ func TestLinknameReflectName(t *testing.T) {
 	info := "myinfo"
 	off := resolveReflectName(newName(info, "", false))
 	n := rtype_nameOff(nil, off)
-	if s := name_name(n); s != info {
+	if s := name_name(&n); s != info {
 		t.Fatalf("to reflect.name got %q: want %q", s, info)
 	}
 }


### PR DESCRIPTION
## DO NOT MERGE

This is a test branch used for transparency of the work I'm doing and to get feedback from CI.

---

The part of augmentation that prunes imports based on usage was designed to handle removing imports specific to a type parameter. For example, the import `cmp` might only exist in a file because of the type parameter constraint `cmp.Ordered`. Go doesn't like it if there are unused imports.

However, the code written for pruning imports uses the given name or guesses at the package name via the given path. This does not work for any relative paths (e.g. `./..`) or versioned packages (e.g. `github.com/foo/bar/v2` where the package is `bar`). These two types of paths do not exist in the natives which ware being altered by augmentation, but may exist in customer code.

Since we only really want to prune imports for files which are augmented, I'm adding some checks so that the prune imports code is only run when overlays exist and those overlays have changed the original file.