### PR TITLE
[go1.19] Fixed chocolatey go version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -175,7 +175,7 @@ jobs:
       - run:
           name: Install Go
           command: |
-            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my
+            choco install golang --version="<< pipeline.parameters.chocolatey_go_version >>" -my --force -y
             go version
             (Get-Command go).Path
             [Environment]::SetEnvironmentVariable(

--- a/compiler/natives/src/crypto/internal/boring/bbig/big.go
+++ b/compiler/natives/src/crypto/internal/boring/bbig/big.go
@@ -33,7 +33,7 @@ func Dec(b boring.BigInt) *big.Int {
 		return new(big.Int)
 	}
 	// Replacing original which uses unsafe:
-	//x := unsafe.Slice((*big.Word)(&b[0]), len(b))
+	// x := unsafe.Slice((*big.Word)(&b[0]), len(b))
 	x := make([]big.Word, len(b))
 	for i, w := range b {
 		x[i] = big.Word(w)

--- a/compiler/natives/src/crypto/internal/nistec/nistec_test.go
+++ b/compiler/natives/src/crypto/internal/nistec/nistec_test.go
@@ -4,10 +4,9 @@
 package nistec_test
 
 import (
-	"testing"
-
 	"crypto/elliptic"
 	"crypto/internal/nistec"
+	"testing"
 )
 
 func TestAllocations(t *testing.T) {


### PR DESCRIPTION
For some reason I was getting a failure from Chocolatey which wasn't happening before.

From `windows_smoke` step `Install Go`:

```Plain
Failures
 - golang - A newer version of golang (v1.21.1) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
go version go1.21.1 windows/amd64
```

- I added a force and a confirmation to run the go1.19.9 script to fix this.
- I also ran go formatting to fix some issues in formatting