### PR TITLE
[go1.19] Limit augmentation to native files which need it

### DIFF
--- a/build/build_test.go
+++ b/build/build_test.go
@@ -680,6 +680,39 @@ func TestOriginalAugmentation(t *testing.T) {
 				import _ "unsafe"`,
 			want: `//go:linkname foo bar
 				import _ "unsafe"`,
+		}, {
+			desc: `multiple imports for directives`,
+			info: map[string]overrideInfo{
+				`A`: {},
+				`C`: {},
+			},
+			src: `import "unsafe"
+				import "embed"
+
+				//go:embed hello.txt
+				var A embed.FS
+
+				//go:embed goodbye.txt
+				var B string
+				
+				var C unsafe.Pointer
+				
+				// override Now with hardcoded time for testing
+				//go:linkname timeNow time.Now
+				func timeNow() time.Time {
+					return time.Date(2012, 8, 6, 0, 0, 0, 0, time.UTC)
+				}`,
+			want: `import _ "unsafe"
+				import _ "embed"
+
+				//go:embed goodbye.txt
+				var B string
+
+				// override Now with hardcoded time for testing
+				//go:linkname timeNow time.Now
+				func timeNow() time.Time {
+					return time.Date(2012, 8, 6, 0, 0, 0, 0, time.UTC)
+				}`,
 		},
 	}
 


### PR DESCRIPTION
The part of augmentation that prunes imports based on usage was designed to handle removing imports specific to a type parameter. For example, the import `cmp` might only exist in a file because of the type parameter constraint `cmp.Ordered`. Go doesn't like it if there are unused imports.

However, the code written for pruning imports uses the given name or guesses at the package name via the given path. This does not work for any relative paths (e.g. `./..`), versioned packages (e.g. `github.com/foo/bar/v2` where the package is `bar`), or using the `go.mod` to define a path for one package to an arbitrary path using a `replace`. These problematic paths do not exist in the natives which are being altered by augmentation, but problematic paths may exist in customer code.

Since we only really want to prune imports for files which are augmented, I'm adding some checks so that the prune imports code is only run when overlays exist and those overlays have changed the original file.

I also fixed an issue where a left over `break` was making only the first found directive based import be checked for and none of the following. Added a test that demonstrates the issue and checks the fix.