### PR TITLE
[go1.20] Starting 1.20 updates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.13"
+          go-version: "1.20.14"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/measure-size.yml
+++ b/.github/workflows/measure-size.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.19.13'
+          go-version: '~1.20.14'
       - uses: gopherjs/output-size-action/measure@main
         with:
           name: jQuery TodoMVC

--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ Nearly everything, including Goroutines ([compatibility documentation](https://g
 
 ### Installation and Usage
 
-GopherJS [requires Go 1.19 or newer](https://github.com/gopherjs/gopherjs/blob/master/doc/compatibility.md#go-version-compatibility). If you need an older Go
+GopherJS [requires Go 1.20 or newer](https://github.com/gopherjs/gopherjs/blob/master/doc/compatibility.md#go-version-compatibility). If you need an older Go
 version, you can use an [older GopherJS release](https://github.com/gopherjs/gopherjs/releases).
 
 Install GopherJS with `go install`:
 
 ```
-go install github.com/gopherjs/gopherjs@v1.19.0-beta1  # Or replace 'v1.19.0-beta1' with another version.
+go install github.com/gopherjs/gopherjs@v1.20.0-beta1  # Or replace 'v1.20.0-beta1' with another version.
 ```
 
-If your local Go distribution as reported by `go version` is newer than Go 1.19, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.19 distribution. For example:
+If your local Go distribution as reported by `go version` is newer than Go 1.20, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.20 distribution. For example:
 
 ```
-go install golang.org/dl/go1.19.13@latest
-go1.19.13 download
-export GOPHERJS_GOROOT="$(go1.19.13 env GOROOT)"  # Also add this line to your .profile or equivalent.
+go install golang.org/dl/go1.20.14@latest
+go1.20.14 download
+export GOPHERJS_GOROOT="$(go1.20.14 env GOROOT)"  # Also add this line to your .profile or equivalent.
 ```
 
 Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherjs install [package]` which behave similar to the `go` tool. For `main` packages, these commands create a `.js` file and `.js.map` source map in the current directory or in `$GOPATH/bin`. The generated JavaScript file can be used as usual in a website. Use `gopherjs help [command]` to get a list of possible command line flags, e.g. for minification and automatically watching for changes.

--- a/circle.yml
+++ b/circle.yml
@@ -54,11 +54,11 @@ workflows:
 parameters:
   go_version:
     type: string
-    default: "1.19.13"
+    default: "1.20.14"
   chocolatey_go_version:
     type: string
-    # Chocolatey doesn't have 1.19.13, closest is 1.19.9
-    default: "1.19.9"
+    # Chocolatey doesn't have 1.20.14, closest is 1.20.7
+    default: "1.20.7"
   nvm_version:
     type: string
     default: "0.38.0"

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -1,4 +1,4 @@
-//go:build go1.19
+//go:build go1.20
 
 package compiler
 
@@ -12,10 +12,10 @@ import (
 )
 
 // Version is the GopherJS compiler version string.
-const Version = "1.19.0-beta1+go1.19.13"
+const Version = "1.20.0-beta1+go1.20.14"
 
 // GoVersion is the current Go 1.x version that GopherJS is compatible with.
-const GoVersion = 19
+const GoVersion = 20
 
 // CheckGoVersion checks the version of the Go distribution
 // at goroot, and reports an error if it's not compatible
@@ -49,7 +49,7 @@ func goRootVersion(goroot string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("`go version` command failed: %w", err)
 	}
-	// Expected output: go version go1.18.1 linux/amd64
+	// Expected output: go version go1.20.14 linux/amd64
 	parts := strings.Split(string(out), " ")
 	if len(parts) != 4 {
 		return "", fmt.Errorf("unexpected `go version` output %q, expected 4 words", string(out))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopherjs/gopherjs
 
-go 1.18
+go 1.20
 
 require (
 	github.com/evanw/esbuild v0.18.0


### PR DESCRIPTION
Updating the versions from go1.19.13 to go1.20.14.

go1.20.14 is the most recent update to go1.20 (released 2024-02-06)

⚠️ This will break CI via changes in the natives using generics and unsafe pointers