### PR TITLE
Refactor srctesting to support parsing and checking multiple packages.

### DIFF
--- a/build/build_test.go
+++ b/build/build_test.go
@@ -418,18 +418,17 @@ func TestOverlayAugmentation(t *testing.T) {
 				test.want = test.src
 			}
 
-			fsetSrc := token.NewFileSet()
-			fileSrc := srctesting.Parse(t, fsetSrc, pkgName+test.src)
+			f := srctesting.New(t)
+			fileSrc := f.Parse("test.go", pkgName+test.src)
 
 			overrides := map[string]overrideInfo{}
 			augmentOverlayFile(fileSrc, overrides)
 			pruneImports(fileSrc)
 
-			got := srctesting.Format(t, fsetSrc, fileSrc)
+			got := srctesting.Format(t, f.FileSet, fileSrc)
 
-			fsetWant := token.NewFileSet()
-			fileWant := srctesting.Parse(t, fsetWant, pkgName+test.want)
-			want := srctesting.Format(t, fsetWant, fileWant)
+			fileWant := f.Parse("test.go", pkgName+test.want)
+			want := srctesting.Format(t, f.FileSet, fileWant)
 
 			if got != want {
 				t.Errorf("augmentOverlayFile and pruneImports got unexpected code:\n"+
@@ -720,18 +719,17 @@ func TestOriginalAugmentation(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			pkgName := "package testpackage\n\n"
 			importPath := `math/rand`
-			fsetSrc := token.NewFileSet()
-			fileSrc := srctesting.Parse(t, fsetSrc, pkgName+test.src)
+			f := srctesting.New(t)
+			fileSrc := f.Parse("test.go", pkgName+test.src)
 
 			augmentOriginalImports(importPath, fileSrc)
 			augmentOriginalFile(fileSrc, test.info)
 			pruneImports(fileSrc)
 
-			got := srctesting.Format(t, fsetSrc, fileSrc)
+			got := srctesting.Format(t, f.FileSet, fileSrc)
 
-			fsetWant := token.NewFileSet()
-			fileWant := srctesting.Parse(t, fsetWant, pkgName+test.want)
-			want := srctesting.Format(t, fsetWant, fileWant)
+			fileWant := f.Parse("test.go", pkgName+test.want)
+			want := srctesting.Format(t, f.FileSet, fileWant)
 
 			if got != want {
 				t.Errorf("augmentOriginalImports, augmentOriginalFile, and pruneImports got unexpected code:\n"+

--- a/compiler/analysis/info_test.go
+++ b/compiler/analysis/info_test.go
@@ -2,7 +2,6 @@ package analysis
 
 import (
 	"go/ast"
-	"go/token"
 	"go/types"
 	"testing"
 
@@ -34,11 +33,11 @@ func notBlocking() {
 	func() { println() } ()
 }
 `
-	fset := token.NewFileSet()
-	file := srctesting.Parse(t, fset, src)
-	typesInfo, typesPkg := srctesting.Check(t, fset, file)
+	f := srctesting.New(t)
+	file := f.Parse("test.go", src)
+	typesInfo, typesPkg := f.Check("pkg/test", file)
 
-	pkgInfo := AnalyzePkg([]*ast.File{file}, fset, typesInfo, typesPkg, func(f *types.Func) bool {
+	pkgInfo := AnalyzePkg([]*ast.File{file}, f.FileSet, typesInfo, typesPkg, func(f *types.Func) bool {
 		panic("isBlocking() should be never called for imported functions in this test.")
 	})
 

--- a/compiler/astutil/astutil_test.go
+++ b/compiler/astutil/astutil_test.go
@@ -2,7 +2,6 @@ package astutil
 
 import (
 	"go/ast"
-	"go/token"
 	"strconv"
 	"testing"
 
@@ -44,8 +43,7 @@ func TestImportsUnsafe(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			src := "package testpackage\n\n" + test.imports
-			fset := token.NewFileSet()
-			file := srctesting.Parse(t, fset, src)
+			file := srctesting.New(t).Parse("test.go", src)
 			got := ImportsUnsafe(file)
 			if got != test.want {
 				t.Fatalf("ImportsUnsafe() returned %t, want %t", got, test.want)
@@ -81,8 +79,7 @@ func TestImportName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			src := "package testpackage\n\n" + test.src
-			fset := token.NewFileSet()
-			file := srctesting.Parse(t, fset, src)
+			file := srctesting.New(t).Parse("test.go", src)
 			if len(file.Imports) != 1 {
 				t.Fatal(`expected one and only one import`)
 			}
@@ -399,8 +396,7 @@ func TestHasDirectiveOnFile(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			const action = `do-stuff`
-			fset := token.NewFileSet()
-			file := srctesting.Parse(t, fset, test.src)
+			file := srctesting.New(t).Parse("test.go", test.src)
 			if got := hasDirective(file, action); got != test.want {
 				t.Errorf(`hasDirective(%T, %q) returned %t, want %t`, file, action, got, test.want)
 			}

--- a/compiler/internal/symbol/symbol_test.go
+++ b/compiler/internal/symbol/symbol_test.go
@@ -1,7 +1,6 @@
 package symbol
 
 import (
-	"go/token"
 	"go/types"
 	"testing"
 
@@ -18,8 +17,8 @@ func TestName(t *testing.T) {
 	var AVariable int32
 	`
 
-	fset := token.NewFileSet()
-	_, pkg := srctesting.Check(t, fset, srctesting.Parse(t, fset, src))
+	f := srctesting.New(t)
+	_, pkg := f.Check("pkg/test", f.Parse("test.go", src))
 
 	tests := []struct {
 		obj  types.Object
@@ -27,19 +26,19 @@ func TestName(t *testing.T) {
 	}{
 		{
 			obj:  pkg.Scope().Lookup("AFunction"),
-			want: Name{PkgPath: "test", Name: "AFunction"},
+			want: Name{PkgPath: "pkg/test", Name: "AFunction"},
 		}, {
 			obj:  pkg.Scope().Lookup("AType"),
-			want: Name{PkgPath: "test", Name: "AType"},
+			want: Name{PkgPath: "pkg/test", Name: "AType"},
 		}, {
 			obj:  types.NewMethodSet(pkg.Scope().Lookup("AType").Type()).Lookup(pkg, "AMethod").Obj(),
-			want: Name{PkgPath: "test", Name: "AType.AMethod"},
+			want: Name{PkgPath: "pkg/test", Name: "AType.AMethod"},
 		}, {
 			obj:  types.NewMethodSet(types.NewPointer(pkg.Scope().Lookup("AType").Type())).Lookup(pkg, "APointerMethod").Obj(),
-			want: Name{PkgPath: "test", Name: "(*AType).APointerMethod"},
+			want: Name{PkgPath: "pkg/test", Name: "(*AType).APointerMethod"},
 		}, {
 			obj:  pkg.Scope().Lookup("AVariable"),
-			want: Name{PkgPath: "test", Name: "AVariable"},
+			want: Name{PkgPath: "pkg/test", Name: "AVariable"},
 		},
 	}
 

--- a/compiler/internal/typeparams/instance_test.go
+++ b/compiler/internal/typeparams/instance_test.go
@@ -1,7 +1,6 @@
 package typeparams
 
 import (
-	"go/token"
 	"go/types"
 	"testing"
 
@@ -38,8 +37,8 @@ func TestInstanceString(t *testing.T) {
 	func Fun[U any, W any](x, y U) {}
 	func fun[U any, W any](x, y U) {}
 	`
-	fset := token.NewFileSet()
-	_, pkg := srctesting.Check(t, fset, srctesting.Parse(t, fset, src))
+	f := srctesting.New(t)
+	_, pkg := f.Check("pkg/test", f.Parse("test.go", src))
 	mustType := testingx.Must[types.Type](t)
 
 	tests := []struct {
@@ -53,7 +52,7 @@ func TestInstanceString(t *testing.T) {
 			Object: pkg.Scope().Lookup("Typ"),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr:        "test.Typ<int, string>",
+		wantStr:        "pkg/test.Typ<int, string>",
 		wantTypeString: "testcase.Typ[int, string]",
 	}, {
 		descr: "exported method",
@@ -61,21 +60,21 @@ func TestInstanceString(t *testing.T) {
 			Object: pkg.Scope().Lookup("Typ").Type().(*types.Named).Method(0),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr: "test.Typ.Method<int, string>",
+		wantStr: "pkg/test.Typ.Method<int, string>",
 	}, {
 		descr: "exported function",
 		instance: Instance{
 			Object: pkg.Scope().Lookup("Fun"),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr: "test.Fun<int, string>",
+		wantStr: "pkg/test.Fun<int, string>",
 	}, {
 		descr: "unexported type",
 		instance: Instance{
 			Object: pkg.Scope().Lookup("typ"),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr:        "test.typ<int, string>",
+		wantStr:        "pkg/test.typ<int, string>",
 		wantTypeString: "testcase.typ[int, string]",
 	}, {
 		descr: "unexported method",
@@ -83,20 +82,20 @@ func TestInstanceString(t *testing.T) {
 			Object: pkg.Scope().Lookup("typ").Type().(*types.Named).Method(0),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr: "test.typ.method<int, string>",
+		wantStr: "pkg/test.typ.method<int, string>",
 	}, {
 		descr: "unexported function",
 		instance: Instance{
 			Object: pkg.Scope().Lookup("fun"),
 			TArgs:  []types.Type{types.Typ[types.Int], types.Typ[types.String]},
 		},
-		wantStr: "test.fun<int, string>",
+		wantStr: "pkg/test.fun<int, string>",
 	}, {
 		descr: "no type params",
 		instance: Instance{
 			Object: pkg.Scope().Lookup("Ints"),
 		},
-		wantStr:        "test.Ints",
+		wantStr:        "pkg/test.Ints",
 		wantTypeString: "testcase.Ints",
 	}, {
 		descr: "complex parameter type",
@@ -110,7 +109,7 @@ func TestInstanceString(t *testing.T) {
 				}, true)),
 			},
 		},
-		wantStr: "test.fun<[]int, test.typ[int, string]>",
+		wantStr: "pkg/test.fun<[]int, pkg/test.typ[int, string]>",
 	}}
 
 	for _, test := range tests {
@@ -134,8 +133,8 @@ func TestInstanceQueue(t *testing.T) {
 	type Typ[T any, V any] []T
 	func Fun[U any, W any](x, y U) {}
 	`
-	fset := token.NewFileSet()
-	_, pkg := srctesting.Check(t, fset, srctesting.Parse(t, fset, src))
+	f := srctesting.New(t)
+	_, pkg := f.Check("pkg/test", f.Parse("test.go", src))
 
 	i1 := Instance{
 		Object: pkg.Scope().Lookup("Typ"),

--- a/compiler/typesutil/typenames_test.go
+++ b/compiler/typesutil/typenames_test.go
@@ -1,7 +1,6 @@
 package typesutil
 
 import (
-	"go/token"
 	"go/types"
 	"testing"
 
@@ -24,8 +23,8 @@ func TestTypeNames(t *testing.T) {
 	type B int
 	type C int
 	`
-	fset := token.NewFileSet()
-	_, pkg := srctesting.Check(t, fset, srctesting.Parse(t, fset, src))
+	f := srctesting.New(t)
+	_, pkg := f.Check("pkg/test", f.Parse("test.go", src))
 	A := srctesting.LookupObj(pkg, "A").(*types.TypeName)
 	B := srctesting.LookupObj(pkg, "B").(*types.TypeName)
 	C := srctesting.LookupObj(pkg, "C").(*types.TypeName)

--- a/internal/srctesting/srctesting_test.go
+++ b/internal/srctesting/srctesting_test.go
@@ -1,0 +1,28 @@
+package srctesting
+
+import "testing"
+
+func TestFixture(t *testing.T) {
+	f := New(t)
+
+	const src1 = `package foo
+	type X int
+	`
+	_, foo := f.Check("pkg/foo", f.Parse("foo.go", src1))
+
+	if !foo.Complete() {
+		t.Fatalf("Got: incomplete package pkg/foo: %s. Want: complete package.", foo)
+	}
+
+	const src2 = `package bar
+	import "pkg/foo"
+	func Fun() foo.X { return 0 }
+	`
+
+	// Should type check successfully with dependency on pkg/foo.
+	_, bar := f.Check("pkg/bar", f.Parse("bar.go", src2))
+
+	if !bar.Complete() {
+		t.Fatalf("Got: incomplete package pkg/bar: %s. Want: complete package.", foo)
+	}
+}


### PR DESCRIPTION
This will be useful for testing cross-package generic instance discovery.

Updated #1013 