### PR TITLE
[go1.20] Context import update for 1.20

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -221,7 +221,11 @@ func main() {
 					}
 
 					if pkg.IsCommand() && !pkg.UpToDate {
-						if err := s.WriteCommandPackage(archive, pkg.InstallPath()); err != nil {
+						pkgObj, err := pkg.InstallPath()
+						if err != nil {
+							return err
+						}
+						if err := s.WriteCommandPackage(archive, pkgObj); err != nil {
 							return err
 						}
 					}


### PR DESCRIPTION
The build.Context.Import method no longer populates build.Package.PkgObj for imports under the Goroot directory. This meant that the unit-tests used the context needed to be updated to no longer check PkgObj and that we needed a way to indicate to users when no install location is defined.

GopherJS only uses PkgObj when finding a location during a `gopherjs install` of a command package (i.e. `package main`) and no other install locations can be found for the current user. It seemed to me that it would be rare for the user to not have access to any other install location, attempt to fall back to PkgObj whilst installing something from Goroot, not impossible, but unlikely.

This is part of [#1270](https://github.com/gopherjs/gopherjs/issues/1270). The CI will continue to fail since we don't fully support go1.20 yet, however the tests in `build/context_test.go` should be now passing after these changes.