### PR TITLE
[go1.20] Added temporary generics override for sync.Map

### DIFF
--- a/compiler/natives/src/sync/map.go
+++ b/compiler/natives/src/sync/map.go
@@ -1,0 +1,48 @@
+//go:build js
+// +build js
+
+package sync
+
+type Map struct {
+	mu Mutex
+
+	// replaced atomic.Pointer[readOnly] for go1.20 without generics.
+	read atomicReadOnlyPointer
+
+	dirty  map[any]*entry
+	misses int
+}
+
+type atomicReadOnlyPointer struct {
+	v *readOnly
+}
+
+func (x *atomicReadOnlyPointer) Load() *readOnly     { return x.v }
+func (x *atomicReadOnlyPointer) Store(val *readOnly) { x.v = val }
+
+type entry struct {
+
+	// replaced atomic.Pointer[any] for go1.20 without generics.
+	p atomicAnyPointer
+}
+
+type atomicAnyPointer struct {
+	v *any
+}
+
+func (x *atomicAnyPointer) Load() *any     { return x.v }
+func (x *atomicAnyPointer) Store(val *any) { x.v = val }
+
+func (x *atomicAnyPointer) Swap(new *any) *any {
+	old := x.v
+	x.v = new
+	return old
+}
+
+func (x *atomicAnyPointer) CompareAndSwap(old, new *any) bool {
+	if x.v == old {
+		x.v = new
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This is a temporary change to quiet complaints from natives using `sync` since `sync.Map` uses the `atomic.Pointer[T]` that was removed for generic-less go1.19.

CI will still be failing because of `sync/atomic/type.go:40:10: undefined: Pointer` where `var _ = &Pointer[int]{}` got added. If that wasn't there then after this change the tests should no longer be failing for an undefined `atomic.Pointer` from `sync.Map` when importing `sync`.