### PR TITLE
[go1.20] Update runtime_beforeExit to have exit code parameter.

### DIFF
--- a/compiler/natives/src/os/os.go
+++ b/compiler/natives/src/os/os.go
@@ -30,7 +30,7 @@ func init() {
 	}
 }
 
-func runtime_beforeExit() {}
+func runtime_beforeExit(exitCode int) {}
 
 func executable() (string, error) {
 	return "", errors.New("Executable not implemented for GOARCH=js")


### PR DESCRIPTION
Between go1.19 ([here](https://cs.opensource.google/go/go/+/refs/tags/go1.19.13:src/os/proc.go;l=78)) and go1.20 ([here](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/os/proc.go;l=80)), the `os` link to the runtime beforeExit got a parameter containing the exitCode. Since a JS app doesn't shutdown like an executable, this method was no-op'ed in the native overrides.

This PR is just to add that missing parameter. This is part of [#1270](https://github.com/gopherjs/gopherjs/issues/1270).