### PR TITLE
[go1.20] Override cypto/subtle XORBytes

### DIFF
--- a/compiler/natives/src/crypto/subtle/xor.go
+++ b/compiler/natives/src/crypto/subtle/xor.go
@@ -1,0 +1,48 @@
+//go:build js
+// +build js
+
+package subtle
+
+func XORBytes(dst, x, y []byte) int {
+	n := len(x)
+	if len(y) < n {
+		n = len(y)
+	}
+	if n == 0 {
+		return 0
+	}
+	if n > len(dst) {
+		panic("subtle.XORBytes: dst too short")
+	}
+
+	// xorBytes(&dst[0], &x[0], &y[0], n) // arch-specific
+	// The above uses unsafe and generics for specific architecture
+	// to pack registers full instead of doing one byte at a time.
+	// We can't do the unsafe conversions from []byte to []uintptr
+	// so we'll simply do it one byte at a time.
+
+	x = x[:len(dst)] // remove bounds check in loop
+	y = y[:len(dst)] // remove bounds check in loop
+	for i := range dst {
+		dst[i] = x[i] ^ y[i]
+	}
+	return n
+}
+
+//gopherjs:purge
+const (
+	wordSize          = 0
+	supportsUnaligned = false
+)
+
+//gopherjs:purge
+func xorBytes(dstb, xb, yb *byte, n int)
+
+//gopherjs:purge
+func aligned(dst, x, y *byte) bool
+
+//gopherjs:purge
+func words(x []byte) []uintptr
+
+//gopherjs:purge
+func xorLoop[T byte | uintptr](dst, x, y []T) {}


### PR DESCRIPTION
The crypto/subtle package added the `XORBytes` in go1.20. This method XOR's the content of two slices into a third. This is done using unsafe slices to cast `[]byte` slices to `[]uintptr` slices (done to pack registers as full as possible to reduce the number of XOR's being done) or use an architecture specific method for XOR'ing the data.

I added native overrides to just XOR one byte at a time. I didn't find a better way using `Uint8Array` but there maybe one that I just am not aware of.