### PR TITLE
[go1.20] Update test run example native override

### DIFF
--- a/compiler/natives/src/testing/example.go
+++ b/compiler/natives/src/testing/example.go
@@ -6,12 +6,11 @@ package testing
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 )
 
 func runExample(eg InternalExample) (ok bool) {
-	if *chatty {
+	if chatty.on {
 		fmt.Printf("=== RUN   %s\n", eg.Name)
 	}
 
@@ -24,12 +23,12 @@ func runExample(eg InternalExample) (ok bool) {
 	}
 	os.Stdout = w
 
+	finished := false
 	start := time.Now()
-	ok = true
 
 	// Clean up in a deferred call so we can recover if the example panics.
 	defer func() {
-		dstr := fmtDuration(time.Now().Sub(start))
+		timeSpent := time.Since(start)
 
 		// Close file, restore stdout, get output.
 		w.Close()
@@ -41,31 +40,12 @@ func runExample(eg InternalExample) (ok bool) {
 			os.Exit(1)
 		}
 
-		var fail string
 		err := recover()
-		got := strings.TrimSpace(string(out))
-		want := strings.TrimSpace(eg.Output)
-		if eg.Unordered {
-			if sortLines(got) != sortLines(want) && err == nil {
-				fail = fmt.Sprintf("got:\n%s\nwant (unordered):\n%s\n", string(out), eg.Output)
-			}
-		} else {
-			if got != want && err == nil {
-				fail = fmt.Sprintf("got:\n%s\nwant:\n%s\n", got, want)
-			}
-		}
-		if fail != "" || err != nil {
-			fmt.Printf("--- FAIL: %s (%s)\n%s", eg.Name, dstr, fail)
-			ok = false
-		} else if *chatty {
-			fmt.Printf("--- PASS: %s (%s)\n", eg.Name, dstr)
-		}
-		if err != nil {
-			panic(err)
-		}
+		ok = eg.processRunResult(string(out), timeSpent, finished, err)
 	}()
 
 	// Run example.
 	eg.F()
+	finished = true
 	return
 }


### PR DESCRIPTION
Fixing an indirection error on `*chatty`. The [`chatty` value](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/testing/testing.go;l=454) is now [`struct{ on, json bool }`](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/testing/testing.go;l=486-489). The native override of `runExample` needed to be updated to match the changes to [go repo version (moved to `run_example.go`)](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/testing/run_example.go;l=22) while retaining the original override reason, [use temporary file rather than os.Pipe for testing examples](https://github.com/gopherjs/gopherjs/commit/7d94d732be268c4904141f8b8604eb2d6d6544a1). This is part of https://github.com/gopherjs/gopherjs/issues/1270