### PR TITLE
[go1.20] More known fails and a fix

### DIFF
--- a/compiler/linkname_test.go
+++ b/compiler/linkname_test.go
@@ -190,8 +190,8 @@ func TestParseGoLinknames(t *testing.T) {
 			`,
 			wantDirectives: []GoLinkname{
 				{
-					Reference:      SymName{PkgPath: `testcase`, Name: `a`},
-					Implementation: SymName{PkgPath: `other/package`, Name: `b.a`},
+					Reference:      symbol.Name{PkgPath: `testcase`, Name: `a`},
+					Implementation: symbol.Name{PkgPath: `other/package`, Name: `b.a`},
 				},
 			},
 		}, {
@@ -206,8 +206,8 @@ func TestParseGoLinknames(t *testing.T) {
 			`,
 			wantDirectives: []GoLinkname{
 				{
-					Reference:      SymName{PkgPath: `testcase`, Name: `a`},
-					Implementation: SymName{PkgPath: `other/package`, Name: `*b.a`},
+					Reference:      symbol.Name{PkgPath: `testcase`, Name: `a`},
+					Implementation: symbol.Name{PkgPath: `other/package`, Name: `*b.a`},
 				},
 			},
 		},

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -151,6 +151,9 @@ var knownFails = map[string]failReason{
 	// These are new tests in Go 1.20
 	"fixedbugs/issue25897a.go": {category: neverTerminates, desc: "does for { runtime.GC() }"},
 	"fixedbugs/issue54343.go":  {category: notApplicable, desc: "uses runtime.SetFinalizer() and runtime.GC()."},
+	"fixedbugs/issue57823.go":  {category: notApplicable, desc: "uses runtime.SetFinalizer() and runtime.GC()."},
+	"fixedbugs/issue59293.go":  {category: usesUnsupportedPackage, desc: "uses unsafe.SliceData() and unsafe.StringData()."},
+	"fixedbugs/issue43942.go":  {category: other, desc: "https://github.com/gopherjs/gopherjs/issues/1126"},
 }
 
 type failCategory uint8


### PR DESCRIPTION
This adds some more known fails for go1.20

This also fixes some `SymName` --> `symbol.Name` that I missed when merging master into go1.20

This is part of https://github.com/gopherjs/gopherjs/issues/1270