### PR TITLE
[go1.20] Added support for unsafe.SliceData

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1059,11 +1059,8 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 		sel, _ := fc.selectionOf(astutil.RemoveParens(args[0]).(*ast.SelectorExpr))
 		return fc.formatExpr("%d", typesutil.OffsetOf(sizes32, sel))
 	case "SliceData":
-		// SliceData returns nil if the slice is nil, otherwise returns a pointer to the first index of the array, &s[0].
-		// If the slice is empty (cap == 0), it returns an "unspecified memory address" or in our case, a pointer to the empty array.
 		t := fc.typeOf(args[0]).Underlying().(*types.Slice)
-		elemPtrType := types.NewPointer(t.Elem())
-		return fc.formatExpr("(%1e === %2s.nil) ? %3s.nil : $indexPtr(%1e.$array, %1e.$offset, %3s)", args[0], fc.typeName(t), fc.typeName(elemPtrType))
+		return fc.formatExpr(`$sliceData(%e, %s)`, args[0], fc.typeName(t))
 	default:
 		panic(fmt.Sprintf("Unhandled builtin: %s\n", name))
 	}

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1058,6 +1058,12 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 	case "Offsetof":
 		sel, _ := fc.selectionOf(astutil.RemoveParens(args[0]).(*ast.SelectorExpr))
 		return fc.formatExpr("%d", typesutil.OffsetOf(sizes32, sel))
+	case "SliceData":
+		// SliceData returns nil if the slice is nil, otherwise returns a pointer to the first index of the array, &s[0].
+		// If the slice is empty (cap == 0), it returns an "unspecified memory address" or in our case, a pointer to the empty array.
+		t := fc.typeOf(args[0]).Underlying().(*types.Slice)
+		elemPtrType := types.NewPointer(t.Elem())
+		return fc.formatExpr("(%1e === %2s.nil) ? %3s.nil : $indexPtr(%1e.$array, %1e.$offset, %3s)", args[0], fc.typeName(t), fc.typeName(elemPtrType))
 	default:
 		panic(fmt.Sprintf("Unhandled builtin: %s\n", name))
 	}

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -569,3 +569,10 @@ var $instanceOf = (x, y) => {
 var $typeOf = x => {
     return typeof (x);
 };
+
+var $sliceData = (slice, typ) => {
+    if (slice === typ.nil) {
+        return $ptrType(typ.elem).nil;
+    }
+    return $indexPtr(slice.$array, slice.$offset, typ.elem);
+};

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gopherjs/gopherjs/js"
@@ -934,5 +935,43 @@ func TestStructWithNonIdentifierJSTag(t *testing.T) {
 	got = s.Get("@&\"'<>//my name").String()
 	if want := "Paul"; got != want {
 		t.Errorf("value via js.Object.Get gave %q, want %q", got, want)
+	}
+}
+
+func TestSliceData(t *testing.T) {
+	var (
+		s0 = []int(nil)
+		s1 = []int{}
+		s2 = []int{1, 2, 3}
+		s3 = s2[1:]
+		s4 = []int{4, 5, 6}
+
+		sd0 = unsafe.SliceData(s0)
+		sd1 = unsafe.SliceData(s1)
+		sd2 = unsafe.SliceData(s2)
+		sd3 = unsafe.SliceData(s3)
+		sd4 = unsafe.SliceData(s4)
+	)
+
+	if sd0 != nil {
+		t.Errorf("slice data for nil slice was not nil")
+	}
+	if sd1 == nil {
+		t.Errorf("slice data for empty slice was nil")
+	}
+	if sd2 == nil {
+		t.Errorf("slice data for non-empty slice was nil")
+	}
+	if sd3 == nil {
+		t.Errorf("slice data for sub-slice was nil")
+	}
+	if sd1 == sd2 {
+		t.Errorf("slice data for empty and non-empty slices were the same")
+	}
+	if sd2 == sd3 {
+		t.Errorf("slice data for slice and sub-slice were the same")
+	}
+	if sd2 == sd4 {
+		t.Errorf("slice data for different slices were the same")
 	}
 }


### PR DESCRIPTION
go1.20 added [`unsafe.SlideData`](https://pkg.go.dev/unsafe@go1.22.2#SliceData), [`unsafe.String`](https://pkg.go.dev/unsafe@go1.22.2#String), and [`unsafe.StringData`](https://pkg.go.dev/unsafe@go1.22.2#StringData).

For the following reasons, this PR only adds `unsafe.SliceData`. The tests for this change are in the Go repo tests of this builtin function. This is part of https://github.com/gopherjs/gopherjs/issues/1270

### SliceData

`unsafe.SliceData` is something that GopherJS can handle because of how, even when empty, GopherJS slices have an array that can be pointed to.

The only thing we can't handle is how using the "unspecified memory address" works right now, [seen in this playground](https://goplay.tools/snippet/vr02QEJUWAG), but there are no promises for how that should work and no one should be using that pointer like that. In GopherJS assigning to the pointer of the empty slice simply writes to `[0]` on the empty slice which then isn't visible, always returns zero, and is a pointless, but doesn't break anything.

The Go compiler ensures that the argument into `SliceData` will be a slice.

### String

`unsafe.String` may be possible to support with `Buffer` but would require copying the data into a string. We should probably override it where possible because the point of this function is to not require a copy to be faster than simply performing a conversion, `string([]byte{...})`.

We may need to we can add this later (with the copy) since it seams like some natives are using this instead of the cast to save memory and/or time. Instead of overriding each location, we could just stub out the cast (kind of like how we didn't override all the atomics but just stubbed out the atomic methods).

### StringData

`unsafe.StringData` may be possible via a copy to a byte array first but is the same as above, doing the copy makes this no better than a conversion. Or we could make some JS code similar to `$indexPtr` that wraps a string into a byte pointer. Until then we should probably override them instead.

Also, this is super unsafe because in Go if you get the string data for a literal and attempt to modify it (despite the comment in the docs saying `*byte` should be treated as immutable) it causes a segmentation fault because you can't modify the literal stored in the memory with the opcode. The fault signal can not be recovered from. [Here's a playground with that](https://goplay.tools/snippet/4BvMksBpaKa).