### PR TITLE
Remove extra pruneImport

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -174,7 +174,6 @@ func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *toke
 	overrides := make(map[string]overrideInfo)
 	for _, file := range overlayFiles {
 		augmentOverlayFile(file, overrides)
-		pruneImports(file)
 	}
 	delete(overrides, "init")
 


### PR DESCRIPTION
During one of the updates to the parse and augmentation code, I accidentally left this extra `pruneImport` call. It isn't needed because inside of `augmentOverlayFile` [`pruneImport` (seen here)](https://github.com/gopherjs/gopherjs/blob/master/build/build.go#L322) will be called when the overlay file changes. So this left over one doesn't affect the result, it just wastes time.