### PR TITLE
Fixing internalization of null slice and array fields

### DIFF
--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -236,6 +236,9 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
         case $kindFloat64:
             return parseFloat(v);
         case $kindArray:
+            if (v === null || v === undefined) {
+                $throwRuntimeError("cannot internalize "+v+" as a "+t.string);
+            }
             if (v.length !== t.len) {
                 $throwRuntimeError("got array with wrong size from JavaScript native");
             }
@@ -331,6 +334,9 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
                 return $internalize(v, t.elem, makeWrapper);
             }
         case $kindSlice:
+            if (v == null) {
+                return t.zero();
+            }
             return new t($mapArray(v, e => { return $internalize(e, t.elem, makeWrapper); }));
         case $kindString:
             v = String(v);

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -829,6 +829,45 @@ func TestExternalize(t *testing.T) {
 	}
 }
 
+func TestInternalizeSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		init []int
+		want string
+	}{
+		{
+			name: `nil slice`,
+			init: []int(nil),
+			want: `[]int(nil)`,
+		},
+		{
+			name: `empty slice`,
+			init: []int{},
+			want: `[]int{}`,
+		},
+		{
+			name: `non-empty slice`,
+			init: []int{42, 53, 64},
+			want: `[]int{42, 53, 64}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := struct {
+				*js.Object
+				V []int `js:"V"` // V is externalized
+			}{Object: js.Global.Get("Object").New()}
+			b.V = tt.init
+
+			result := fmt.Sprintf(`%#v`, b.V) // internalize b.V
+			if result != tt.want {
+				t.Errorf(`Unexpected result %q != %q`, result, tt.want)
+			}
+		})
+	}
+}
+
 func TestInternalizeExternalizeNull(t *testing.T) {
 	type S struct {
 		*js.Object


### PR DESCRIPTION
This is a fix for https://github.com/gopherjs/gopherjs/issues/1300

Now that externalization work better for `nil` or `zero` to `null` (done in https://github.com/gopherjs/gopherjs/pull/1194 as part of https://github.com/gopherjs/gopherjs/issues/617), we need to be able to internalize `null` values into `nil` or `zero`. Currently we get an exception because internalization isn't expecting a `null` value for a slice or array.

Internalization of an externalized array creates a copy making the value unassignable (see https://github.com/gopherjs/gopherjs/issues/1302). Until that is fixed, trying to internalize a null array will simply throw an exception. This is favorable over returning a zero value which will quietly hide the array problem and still not be assignable.