### PR TITLE
Fix float64 to uint{8,16,32} conversion.

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1128,8 +1128,6 @@ func (fc *funcContext) translateConversion(expr ast.Expr, desiredType types.Type
 					return fc.fixNumber(fc.formatParenExpr("%1l + ((%1h >> 31) * 4294967296)", expr), t)
 				}
 				return fc.fixNumber(fc.formatExpr("%s.$low", fc.translateExpr(expr)), t)
-			case isFloat(basicExprType):
-				return fc.formatParenExpr("%e >> 0", expr)
 			case types.Identical(exprType, types.Typ[types.UnsafePointer]):
 				return fc.translateExpr(expr)
 			default:

--- a/tests/numeric_test.go
+++ b/tests/numeric_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"testing"
 	"testing/quick"
+
+	"github.com/gopherjs/gopherjs/js"
 )
 
 // naiveMul64 performs 64-bit multiplication without using the multiplication
@@ -90,6 +92,29 @@ func BenchmarkMul64(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			z := xS[i%size] * yS[i%size]
 			runtime.KeepAlive(z)
+		}
+	})
+}
+
+func TestIssue733(t *testing.T) {
+	if runtime.GOOS != "js" {
+		t.Skip("test uses GopherJS-specific features")
+	}
+
+	t.Run("sign", func(t *testing.T) {
+		f := float64(-1)
+		i := uint32(f)
+		underlying := js.InternalObject(i).Float() // Get the raw JS number behind i.
+		if want := float64(4294967295); underlying != want {
+			t.Errorf("Got: uint32(float64(%v)) = %v. Want: %v.", f, underlying, want)
+		}
+	})
+	t.Run("truncation", func(t *testing.T) {
+		f := float64(300)
+		i := uint8(f)
+		underlying := js.InternalObject(i).Float() // Get the raw JS number behind i.
+		if want := float64(44); underlying != want {
+			t.Errorf("Got: uint32(float64(%v)) = %v. Want: %v.", f, underlying, want)
 		}
 	})
 }


### PR DESCRIPTION
Before this change, GopherJS compiler emitted `(f >> 0)` expression to convert a float64 `f` to any non-64-bit unsigned integer type. This is incorrect, because `>>` is a signed bitshift operator in JS, so the returned value remained signed. Moreover, it did not take into account to bit size of the target type.

By removing the switch cause, we make the compiler fall through to the default clause where `fc.fixNumber()` actually does the right thing, taking the target into account.

Fixes #733.

Amazingly, this is what was causing flakiness of the `hash/maphash.TestHashHighBytes` since Go 1.19. There, the 64-bit hash value was computed as `(uint64(hi) << 32) | uint64(lo)`, where `hi` and `lo` were randomly-generated `unit32` values. In turn, those values were generated by converting a random [0, 2^32) float64 value into uint32. As per explanation above, this used to be done with the following JS expression `(f >> 0)`, which meant that for values in the range of [2^31, 2^32) it would return a negative JS number. This would also set all the high bits of that number to 1. So when we come back to `(uint64(hi) << 32) | uint64(lo)`, there was the 50% chance that all higher bits of the right bitwise-or operand would be 1, meaning the result would also have the higher bits set to 1, regardless of what `hi` was. That led to a high likelihood of failing said test 🕵️‍♂️