### PR TITLE
[go1.20] Native overrides for go1.20 (not generics related)

### DIFF
--- a/compiler/natives/src/internal/coverage/slicereader/slicereader.go
+++ b/compiler/natives/src/internal/coverage/slicereader/slicereader.go
@@ -1,0 +1,9 @@
+//go:build js
+// +build js
+
+package slicereader
+
+// Overwritten to avoid `unsafe.String`
+func toString(b []byte) string {
+	return string(b)
+}

--- a/compiler/natives/src/math/rand/rand.go
+++ b/compiler/natives/src/math/rand/rand.go
@@ -1,0 +1,9 @@
+//go:build js
+// +build js
+
+package rand
+
+import _ "unsafe"
+
+//go:linkname fastrand64 runtime.fastrand64
+func fastrand64() uint64

--- a/compiler/natives/src/net/http/client_test.go
+++ b/compiler/natives/src/net/http/client_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 )
 
-func testClientTimeout(t *testing.T, h2 bool) {
+func testClientTimeout(t *testing.T, mode testMode) {
 	// The original test expects Client.Timeout error to be returned, but under
 	// GopherJS an "i/o timeout" error is frequently returned. Otherwise the test
 	// seems to be working correctly.
 	t.Skip("Flaky test under GopherJS.")
 }
 
-func testClientTimeout_Headers(t *testing.T, h2 bool) {
+func testClientTimeout_Headers(t *testing.T, mode testMode) {
 	// The original test expects Client.Timeout error to be returned, but under
 	// GopherJS an "i/o timeout" error is frequently returned. Otherwise the test
 	// seems to be working correctly.

--- a/compiler/natives/src/net/http/clientserver_test.go
+++ b/compiler/natives/src/net/http/clientserver_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-func testTransportGCRequest(t *testing.T, h2, body bool) {
+func testTransportGCRequest(t *testing.T, mode testMode, body bool) {
 	t.Skip("The test relies on runtime.SetFinalizer(), which is not supported by GopherJS.")
 }
 
-func testWriteHeaderAfterWrite(t *testing.T, h2, hijack bool) {
+func testWriteHeaderAfterWrite(t *testing.T, mode testMode, hijack bool) {
 	t.Skip("GopherJS source maps don't preserve original function names in stack traces, which this test relied on.")
 }

--- a/compiler/natives/src/strings/strings_test.go
+++ b/compiler/natives/src/strings/strings_test.go
@@ -18,5 +18,9 @@ func TestCompareStrings(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	t.Skip("conversion to reflect.StringHeader is not supported in GopherJS")
+	t.Skip("conversion to unsafe.StringData is not supported in GopherJS")
+}
+
+func TestMap(t *testing.T) {
+	t.Skip("identity test uses unsafe.StringData is not supported in GopherJS")
 }

--- a/compiler/natives/src/syscall/syscall_js_wasm.go
+++ b/compiler/natives/src/syscall/syscall_js_wasm.go
@@ -22,6 +22,14 @@ func runtime_envs() []string {
 	return envs
 }
 
+func runtimeSetenv(k, v string) {
+	setenv_c(k, v)
+}
+
+func runtimeUnsetenv(k string) {
+	unsetenv_c(k)
+}
+
 func setenv_c(k, v string) {
 	process := js.Global().Get("process")
 	if process.IsUndefined() {


### PR DESCRIPTION
This is a collection of native overrides needed for go1.20.
These changes are not related to the generics work.

The CI will continue to fail for go1.20 after this change but this will remove several errors from the failures. You may only see the type check error in atomics from [go1.20.14:src/sync/atomic/type.go:40](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/sync/atomic/type.go;l=40) depending on if the other override tickets have gotten in yet or not.

This is part of #1270