### PR TITLE
[go1.20] Updating generics overrides for crypto

### DIFF
--- a/compiler/natives/src/crypto/ecdh/nist.go
+++ b/compiler/natives/src/crypto/ecdh/nist.go
@@ -1,0 +1,58 @@
+//go:build js
+// +build js
+
+package ecdh
+
+import (
+	"crypto/internal/nistec"
+	"io"
+)
+
+//gopherjs:purge for go1.20 without generics
+type nistPoint[T any] interface{}
+
+// temporarily replacement of `nistCurve[Point nistPoint[Point]]` for go1.20 without generics.
+type nistCurve struct {
+	name        string
+	newPoint    func() nistec.WrappedPoint
+	scalarOrder []byte
+}
+
+//gopherjs:override-signature
+func (c *nistCurve) String() string
+
+//gopherjs:override-signature
+func (c *nistCurve) GenerateKey(rand io.Reader) (*PrivateKey, error)
+
+//gopherjs:override-signature
+func (c *nistCurve) NewPrivateKey(key []byte) (*PrivateKey, error)
+
+//gopherjs:override-signature
+func (c *nistCurve) privateKeyToPublicKey(key *PrivateKey) *PublicKey
+
+//gopherjs:override-signature
+func (c *nistCurve) NewPublicKey(key []byte) (*PublicKey, error)
+
+//gopherjs:override-signature
+func (c *nistCurve) ecdh(local *PrivateKey, remote *PublicKey) ([]byte, error)
+
+// temporarily replacement for go1.20 without generics.
+var p256 = &nistCurve{
+	name:        "P-256",
+	newPoint:    nistec.NewP256WrappedPoint,
+	scalarOrder: p256Order,
+}
+
+// temporarily replacement for go1.20 without generics.
+var p384 = &nistCurve{
+	name:        "P-384",
+	newPoint:    nistec.NewP384WrappedPoint,
+	scalarOrder: p384Order,
+}
+
+// temporarily replacement for go1.20 without generics.
+var p521 = &nistCurve{
+	name:        "P-521",
+	newPoint:    nistec.NewP521WrappedPoint,
+	scalarOrder: p521Order,
+}

--- a/compiler/natives/src/crypto/ecdsa/ecdsa.go
+++ b/compiler/natives/src/crypto/ecdsa/ecdsa.go
@@ -1,0 +1,98 @@
+//go:build js
+// +build js
+
+package ecdsa
+
+import (
+	"crypto/elliptic"
+	"crypto/internal/bigmod"
+	"crypto/internal/nistec"
+	"io"
+	"math/big"
+)
+
+//gopherjs:override-signature
+func generateNISTEC(c *nistCurve, rand io.Reader) (*PrivateKey, error)
+
+//gopherjs:override-signature
+func randomPoint(c *nistCurve, rand io.Reader) (k *bigmod.Nat, p nistec.WrappedPoint, err error)
+
+//gopherjs:override-signature
+func signNISTEC(c *nistCurve, priv *PrivateKey, csprng io.Reader, hash []byte) (sig []byte, err error)
+
+//gopherjs:override-signature
+func inverse(c *nistCurve, kInv, k *bigmod.Nat)
+
+//gopherjs:override-signature
+func hashToNat(c *nistCurve, e *bigmod.Nat, hash []byte)
+
+//gopherjs:override-signature
+func verifyNISTEC(c *nistCurve, pub *PublicKey, hash, sig []byte) bool
+
+//gopherjs:purge for go1.20 without generics
+type nistPoint[T any] interface{}
+
+// temporarily replacement of `nistCurve[Point nistPoint[Point]]` for go1.20 without generics.
+type nistCurve struct {
+	newPoint func() nistec.WrappedPoint
+	curve    elliptic.Curve
+	N        *bigmod.Modulus
+	nMinus2  []byte
+}
+
+//gopherjs:override-signature
+func (curve *nistCurve) pointFromAffine(x, y *big.Int) (p nistec.WrappedPoint, err error)
+
+//gopherjs:override-signature
+func (curve *nistCurve) pointToAffine(p nistec.WrappedPoint) (x, y *big.Int, err error)
+
+var _p224 *nistCurve
+
+func p224() *nistCurve {
+	p224Once.Do(func() {
+		_p224 = &nistCurve{
+			newPoint: nistec.NewP224WrappedPoint,
+		}
+		precomputeParams(_p224, elliptic.P224())
+	})
+	return _p224
+}
+
+var _p256 *nistCurve
+
+func p256() *nistCurve {
+	p256Once.Do(func() {
+		_p256 = &nistCurve{
+			newPoint: nistec.NewP256WrappedPoint,
+		}
+		precomputeParams(_p256, elliptic.P256())
+	})
+	return _p256
+}
+
+var _p384 *nistCurve
+
+func p384() *nistCurve {
+	p384Once.Do(func() {
+		_p384 = &nistCurve{
+			newPoint: nistec.NewP384WrappedPoint,
+		}
+		precomputeParams(_p384, elliptic.P384())
+	})
+	return _p384
+}
+
+var _p521 *nistCurve
+
+func p521() *nistCurve {
+	p521Once.Do(func() {
+		_p521 = &nistCurve{
+			newPoint: nistec.NewP521WrappedPoint,
+		}
+		precomputeParams(_p521, elliptic.P521())
+	})
+	return _p521
+}
+
+//gopherjs:override-signature
+func precomputeParams(c *nistCurve, curve elliptic.Curve)

--- a/compiler/natives/src/crypto/ecdsa/ecdsa_test.go
+++ b/compiler/natives/src/crypto/ecdsa/ecdsa_test.go
@@ -1,0 +1,12 @@
+//go:build js
+// +build js
+
+package ecdsa
+
+import "testing"
+
+//gopherjs:override-signature
+func testRandomPoint(t *testing.T, c *nistCurve)
+
+//gopherjs:override-signature
+func testHashToNat(t *testing.T, c *nistCurve)

--- a/compiler/natives/src/crypto/internal/boring/bcache/cache.go
+++ b/compiler/natives/src/crypto/internal/boring/bcache/cache.go
@@ -21,6 +21,9 @@ func (c *Cache) Put(k, v unsafe.Pointer)             {}
 func (c *Cache) table() *[cacheSize]unsafe.Pointer
 
 //gopherjs:purge
+type cacheTable struct{}
+
+//gopherjs:purge
 type cacheEntry struct{}
 
 //gopherjs:purge

--- a/compiler/natives/src/crypto/internal/boring/bcache/cache_test.go
+++ b/compiler/natives/src/crypto/internal/boring/bcache/cache_test.go
@@ -5,6 +5,8 @@ package bcache
 
 import "testing"
 
+var registeredCache Cache
+
 func TestCache(t *testing.T) {
 	t.Skip(`This test uses runtime.GC(), which GopherJS doesn't support`)
 }

--- a/compiler/natives/src/crypto/internal/nistec/nistec_test.go
+++ b/compiler/natives/src/crypto/internal/nistec/nistec_test.go
@@ -18,52 +18,52 @@ type nistPoint[T any] interface{}
 
 func TestEquivalents(t *testing.T) {
 	t.Run("P224", func(t *testing.T) {
-		testEquivalents(t, nistec.NewP224WrappedPoint, nistec.NewP224WrappedGenerator, elliptic.P224())
+		testEquivalents(t, nistec.NewP224WrappedPoint, elliptic.P224())
 	})
 	t.Run("P256", func(t *testing.T) {
-		testEquivalents(t, nistec.NewP256WrappedPoint, nistec.NewP256WrappedGenerator, elliptic.P256())
+		testEquivalents(t, nistec.NewP256WrappedPoint, elliptic.P256())
 	})
 	t.Run("P384", func(t *testing.T) {
-		testEquivalents(t, nistec.NewP384WrappedPoint, nistec.NewP384WrappedGenerator, elliptic.P384())
+		testEquivalents(t, nistec.NewP384WrappedPoint, elliptic.P384())
 	})
 	t.Run("P521", func(t *testing.T) {
-		testEquivalents(t, nistec.NewP521WrappedPoint, nistec.NewP521WrappedGenerator, elliptic.P521())
+		testEquivalents(t, nistec.NewP521WrappedPoint, elliptic.P521())
 	})
 }
 
 //gopherjs:override-signature
-func testEquivalents(t *testing.T, newPoint, newGenerator func() nistec.WrappedPoint, c elliptic.Curve)
+func testEquivalents(t *testing.T, newPoint func() nistec.WrappedPoint, c elliptic.Curve)
 
 func TestScalarMult(t *testing.T) {
 	t.Run("P224", func(t *testing.T) {
-		testScalarMult(t, nistec.NewP224WrappedPoint, nistec.NewP224WrappedGenerator, elliptic.P224())
+		testScalarMult(t, nistec.NewP224WrappedPoint, elliptic.P224())
 	})
 	t.Run("P256", func(t *testing.T) {
-		testScalarMult(t, nistec.NewP256WrappedPoint, nistec.NewP256WrappedGenerator, elliptic.P256())
+		testScalarMult(t, nistec.NewP256WrappedPoint, elliptic.P256())
 	})
 	t.Run("P384", func(t *testing.T) {
-		testScalarMult(t, nistec.NewP384WrappedPoint, nistec.NewP384WrappedGenerator, elliptic.P384())
+		testScalarMult(t, nistec.NewP384WrappedPoint, elliptic.P384())
 	})
 	t.Run("P521", func(t *testing.T) {
-		testScalarMult(t, nistec.NewP521WrappedPoint, nistec.NewP521WrappedGenerator, elliptic.P521())
+		testScalarMult(t, nistec.NewP521WrappedPoint, elliptic.P521())
 	})
 }
 
 //gopherjs:override-signature
-func testScalarMult(t *testing.T, newPoint, newGenerator func() nistec.WrappedPoint, c elliptic.Curve)
+func testScalarMult(t *testing.T, newPoint func() nistec.WrappedPoint, c elliptic.Curve)
 
 func BenchmarkScalarMult(b *testing.B) {
 	b.Run("P224", func(b *testing.B) {
-		benchmarkScalarMult(b, nistec.NewP224WrappedGenerator(), 28)
+		benchmarkScalarMult(b, nistec.NewP224WrappedPoint().SetGenerator(), 28)
 	})
 	b.Run("P256", func(b *testing.B) {
-		benchmarkScalarMult(b, nistec.NewP256WrappedGenerator(), 32)
+		benchmarkScalarMult(b, nistec.NewP256WrappedPoint().SetGenerator(), 32)
 	})
 	b.Run("P384", func(b *testing.B) {
-		benchmarkScalarMult(b, nistec.NewP384WrappedGenerator(), 48)
+		benchmarkScalarMult(b, nistec.NewP384WrappedPoint().SetGenerator(), 48)
 	})
 	b.Run("P521", func(b *testing.B) {
-		benchmarkScalarMult(b, nistec.NewP521WrappedGenerator(), 66)
+		benchmarkScalarMult(b, nistec.NewP521WrappedPoint().SetGenerator(), 66)
 	})
 }
 
@@ -72,16 +72,16 @@ func benchmarkScalarMult(b *testing.B, p nistec.WrappedPoint, scalarSize int)
 
 func BenchmarkScalarBaseMult(b *testing.B) {
 	b.Run("P224", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP224WrappedGenerator(), 28)
+		benchmarkScalarBaseMult(b, nistec.NewP224WrappedPoint().SetGenerator(), 28)
 	})
 	b.Run("P256", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP256WrappedGenerator(), 32)
+		benchmarkScalarBaseMult(b, nistec.NewP256WrappedPoint().SetGenerator(), 32)
 	})
 	b.Run("P384", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP384WrappedGenerator(), 48)
+		benchmarkScalarBaseMult(b, nistec.NewP384WrappedPoint().SetGenerator(), 48)
 	})
 	b.Run("P521", func(b *testing.B) {
-		benchmarkScalarBaseMult(b, nistec.NewP521WrappedGenerator(), 66)
+		benchmarkScalarBaseMult(b, nistec.NewP521WrappedPoint().SetGenerator(), 66)
 	})
 }
 

--- a/compiler/natives/src/crypto/internal/nistec/wrapper.go
+++ b/compiler/natives/src/crypto/internal/nistec/wrapper.go
@@ -3,8 +3,11 @@
 
 package nistec
 
+// temporarily replacement of `nistPoint[T any]` for go1.20 without generics.
 type WrappedPoint interface {
+	SetGenerator() WrappedPoint
 	Bytes() []byte
+	BytesX() ([]byte, error)
 	SetBytes(b []byte) (WrappedPoint, error)
 	Add(w1, w2 WrappedPoint) WrappedPoint
 	Double(w1 WrappedPoint) WrappedPoint
@@ -24,12 +27,16 @@ func NewP224WrappedPoint() WrappedPoint {
 	return wrapP224(NewP224Point())
 }
 
-func NewP224WrappedGenerator() WrappedPoint {
-	return wrapP224(NewP224Generator())
+func (w p224Wrapper) SetGenerator() WrappedPoint {
+	return wrapP224(w.point.SetGenerator())
 }
 
 func (w p224Wrapper) Bytes() []byte {
 	return w.point.Bytes()
+}
+
+func (w p224Wrapper) BytesX() ([]byte, error) {
+	return w.point.BytesX()
 }
 
 func (w p224Wrapper) SetBytes(b []byte) (WrappedPoint, error) {
@@ -67,12 +74,16 @@ func NewP256WrappedPoint() WrappedPoint {
 	return wrapP256(NewP256Point())
 }
 
-func NewP256WrappedGenerator() WrappedPoint {
-	return wrapP256(NewP256Generator())
+func (w p256Wrapper) SetGenerator() WrappedPoint {
+	return wrapP256(w.point.SetGenerator())
 }
 
 func (w p256Wrapper) Bytes() []byte {
 	return w.point.Bytes()
+}
+
+func (w p256Wrapper) BytesX() ([]byte, error) {
+	return w.point.BytesX()
 }
 
 func (w p256Wrapper) SetBytes(b []byte) (WrappedPoint, error) {
@@ -110,12 +121,16 @@ func NewP521WrappedPoint() WrappedPoint {
 	return wrapP521(NewP521Point())
 }
 
-func NewP521WrappedGenerator() WrappedPoint {
-	return wrapP521(NewP521Generator())
+func (w p521Wrapper) SetGenerator() WrappedPoint {
+	return wrapP521(w.point.SetGenerator())
 }
 
 func (w p521Wrapper) Bytes() []byte {
 	return w.point.Bytes()
+}
+
+func (w p521Wrapper) BytesX() ([]byte, error) {
+	return w.point.BytesX()
 }
 
 func (w p521Wrapper) SetBytes(b []byte) (WrappedPoint, error) {
@@ -153,12 +168,16 @@ func NewP384WrappedPoint() WrappedPoint {
 	return wrapP384(NewP384Point())
 }
 
-func NewP384WrappedGenerator() WrappedPoint {
-	return wrapP384(NewP384Generator())
+func (w p384Wrapper) SetGenerator() WrappedPoint {
+	return wrapP384(w.point.SetGenerator())
 }
 
 func (w p384Wrapper) Bytes() []byte {
 	return w.point.Bytes()
+}
+
+func (w p384Wrapper) BytesX() ([]byte, error) {
+	return w.point.BytesX()
 }
 
 func (w p384Wrapper) SetBytes(b []byte) (WrappedPoint, error) {


### PR DESCRIPTION
I was holding off on these changes until I could figure out what was wrong with a large part of crypto (turns out the issue was in `uint` and unrelated to the native overrides for crypto). Since that is now merged, here is the updates to the generics native overrides for crypto.

In go1.20 crypto the curves were broken up into nearly identical parts. Our original go1.19 overrides could be reused for most of these changes with minor rework, so that's what I did. I imported the shared override implementation each place the curve was needed.

This also includes an update to the cache removal. These are not generics related, we just can't handle the garbage collect hooks for the crypto cache, so we just make it always a cache miss.

CI will still fail for go1.20. We're missing an unrelated method (I'm working on it as part of another PR), but once that's in the build passes. Then this will remove most, but not all, of the problems in crypto. There is still a buffer overflow issue that I haven't looked into yet but felt unrelated to the curves.

This is part of #1270
