### PR TITLE
[go1.20] internal/godebug env watcher update

### DIFF
--- a/compiler/natives/src/internal/godebug/godebug.go
+++ b/compiler/natives/src/internal/godebug/godebug.go
@@ -5,6 +5,7 @@ package godebug
 
 import (
 	"sync"
+	_ "unsafe" // go:linkname
 )
 
 type Setting struct {
@@ -36,6 +37,9 @@ func (s *Setting) Value() string {
 	})
 	return *s.value.Load()
 }
+
+//go:linkname setUpdate runtime.godebug_setUpdate
+func setUpdate(update func(def, env string))
 
 func update(def, env string) {
 	updateMu.Lock()

--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -492,3 +492,45 @@ func nanotime() int64 {
 	const millisecond = 1_000_000
 	return js.Global.Get("Date").New().Call("getTime").Int64() * millisecond
 }
+
+const godebugEnvKey = `GODEBUG`
+
+var godebugUpdate func(def, env string)
+
+// godebug_setUpdate implements the setUpdate in src/internal/godebug/godebug.go
+func godebug_setUpdate(update func(def, env string)) {
+	godebugUpdate = update
+	godebugEnv := getEnvString(godebugEnvKey)
+	godebug_notify(godebugEnvKey, godebugEnv)
+}
+
+func getEnvString(key string) string {
+	process := js.Global.Get(`process`)
+	if process == js.Undefined {
+		return ``
+	}
+
+	env := process.Get(`env`)
+	if env == js.Undefined {
+		return ``
+	}
+
+	value := env.Get(key)
+	if value == js.Undefined {
+		return ``
+	}
+
+	return value.String()
+}
+
+// godebug_notify is the function is called by syscall anytime an environment
+// variable is set or unset. It emit the GODEBUG setting if it was changed.
+func godebug_notify(key, value string) {
+	update := godebugUpdate
+	if update == nil || key != godebugEnvKey {
+		return
+	}
+
+	godebugDefault := ``
+	update(godebugDefault, value)
+}

--- a/compiler/natives/src/syscall/syscall_js_wasm.go
+++ b/compiler/natives/src/syscall/syscall_js_wasm.go
@@ -2,6 +2,7 @@ package syscall
 
 import (
 	"syscall/js"
+	_ "unsafe" // go:linkname
 )
 
 func runtime_envs() []string {
@@ -36,6 +37,7 @@ func setenv_c(k, v string) {
 		return
 	}
 	process.Get("env").Set(k, v)
+	godebug_notify(k, v)
 }
 
 func unsetenv_c(k string) {
@@ -44,7 +46,11 @@ func unsetenv_c(k string) {
 		return
 	}
 	process.Get("env").Delete(k)
+	godebug_notify(k, ``)
 }
+
+//go:linkname godebug_notify runtime.godebug_notify
+func godebug_notify(key, value string)
 
 func setStat(st *Stat_t, jsSt js.Value) {
 	// This method is an almost-exact copy of upstream, except for 4 places where

--- a/tests/runtime_test.go
+++ b/tests/runtime_test.go
@@ -5,7 +5,10 @@ package tests
 import (
 	"fmt"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
+	_ "unsafe"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gopherjs/gopherjs/js"
@@ -159,4 +162,43 @@ func TestCallers(t *testing.T) {
 		}()
 		panic("panic")
 	})
+}
+
+// Need this to tunnel into `internal/godebug` and run a test
+// without causing a dependency cycle with the `testing` package.
+//
+//go:linkname godebug_setUpdate runtime.godebug_setUpdate
+func godebug_setUpdate(update func(string, string))
+
+func Test_GoDebugInjection(t *testing.T) {
+	buf := []string{}
+	update := func(def, env string) {
+		if def != `` {
+			t.Errorf(`Expected the default value to be empty but got %q`, def)
+		}
+		buf = append(buf, strconv.Quote(env))
+	}
+	check := func(want string) {
+		if got := strings.Join(buf, `, `); got != want {
+			t.Errorf(`Unexpected result: got: %q, want: %q`, got, want)
+		}
+		buf = buf[:0]
+	}
+
+	// Call it multiple times to ensure that the watcher is only injected once.
+	// Each one of these calls should emit an update first, then when GODEBUG is set.
+	godebug_setUpdate(update)
+	godebug_setUpdate(update)
+	check(`"", ""`) // two empty strings for initial update calls.
+
+	t.Setenv(`GODEBUG`, `gopherJSTest=ben`)
+	check(`"gopherJSTest=ben"`) // must only be once for update for new value.
+
+	godebug_setUpdate(update)
+	check(`"gopherJSTest=ben"`) // must only be once for initial update with already set value.
+
+	t.Setenv(`GODEBUG`, `gopherJSTest=tom`)
+	t.Setenv(`GODEBUG`, `gopherJSTest=sam`)
+	t.Setenv(`NOT_GODEBUG`, `gopherJSTest=bob`)
+	check(`"gopherJSTest=tom", "gopherJSTest=sam"`)
 }


### PR DESCRIPTION
In `internal/godebug` the `setUpdate` method is used to watch for changes to the environment variable `GODEBUG`. This is used by tests such as the `archive/zip` test `TestInsecurePaths` or any test using [`t.Setenv`](https://pkg.go.dev/testing@go1.22.3#T.Setenv).

To solve this I added a way to inject a JS `Proxy` into `process.env` that calls a callback when any environment variable is set, the callback will handle the rest of the update and call the function provided to `setUpdate`.

Testing this was a little hard since `godebug` is used by tests. I solved this by creating a go:link from a test that is external to `godebug`.

This is part of #1270 