### PR TITLE
[go1.20] Fixing reflect Value.Grow

### DIFF
--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1325,6 +1325,26 @@ func getJsTag(tag string) string {
 	return ""
 }
 
+func (v Value) grow(n int) {
+	if n < 0 {
+		panic(`reflect.Value.Grow: negative len`)
+	}
+
+	s := v.object()
+	len := s.Get(`$length`).Int()
+	if len+n < 0 {
+		panic(`reflect.Value.Grow: slice overflow`)
+	}
+
+	cap := s.Get(`$capacity`).Int()
+	if len+n > cap {
+		ns := js.Global.Call("$growSlice", s, len+n)
+		s.Set(`$capacity`, ns.Get(`$capacity`))
+		s.Set(`$array`, ns.Get(`$array`))
+		s.Set(`$offset`, ns.Get(`$offset`))
+	}
+}
+
 func (v Value) Index(i int) Value {
 	switch k := v.kind(); k {
 	case Array:

--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1830,3 +1830,13 @@ func verifyNotInHeapPtr(p uintptr) bool {
 	// always return true.
 	return true
 }
+
+// typedslicecopy is implemented in prelude.js as $copySlice
+//
+//gopherjs:purge
+func typedslicecopy(elemType *rtype, dst, src unsafeheader.Slice) int
+
+// growslice is implemented in prelude.js as $growSlice.
+//
+//gopherjs:purge
+func growslice(t *rtype, old unsafeheader.Slice, num int) unsafeheader.Slice

--- a/compiler/natives/src/reflect/reflect.go
+++ b/compiler/natives/src/reflect/reflect.go
@@ -1339,9 +1339,7 @@ func (v Value) grow(n int) {
 	cap := s.Get(`$capacity`).Int()
 	if len+n > cap {
 		ns := js.Global.Call("$growSlice", s, len+n)
-		s.Set(`$capacity`, ns.Get(`$capacity`))
-		s.Set(`$array`, ns.Get(`$array`))
-		s.Set(`$offset`, ns.Get(`$offset`))
+		js.InternalObject(v.ptr).Call("$set", ns)
 	}
 }
 

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -428,55 +428,75 @@ var $appendSlice = (slice, toAppend) => {
     return $internalAppend(slice, toAppend.$array, toAppend.$offset, toAppend.$length);
 };
 
+// Internal helper function for appending to a slice.
+// The given slice will not be modified.
+//
+// If no values are being appended, the original slice will be returned.
+// Otherwise, a new slice will be created with the appended values.
+//
+// If the underlying array has enough capacity, it will be used.
+// Otherwise, a new array will be allocated with enough capacity to hold
+// the new values and the original array will not be modified.
 var $internalAppend = (slice, array, offset, length) => {
     if (length === 0) {
         return slice;
     }
 
-    var newLength = slice.$length + length;
-    slice = $growSlice(slice, newLength);
+    let newLength = slice.$length + length;
+    let newSlice = $growSlice(slice, newLength);
     
-    var newArray = slice.$array;
-    $copyArray(newArray, array, slice.$offset + slice.$length, offset, length, slice.constructor.elem);
-
-    var newSlice = new slice.constructor(newArray);
-    newSlice.$offset = slice.$offset;
+    let newArray = newSlice.$array;
+    $copyArray(newArray, array, newSlice.$offset + newSlice.$length, offset, length, newSlice.constructor.elem);
+   
     newSlice.$length = newLength;
-    newSlice.$capacity = slice.$capacity;
     return newSlice;
 };
 
+// Calculates the new capacity for a slice that is expected to grow to at least
+// the given minCapacity. This follows the Go runtime's growth strategy.
+// The oldCapacity is the current capacity of the slice that is being grown.
 const $calculateNewCapacity = (minCapacity, oldCapacity) => {
     return Math.max(minCapacity, oldCapacity < 1024 ? oldCapacity * 2 : Math.floor(oldCapacity * 5 / 4));
 };
 
+// Potentially grows the slice to have a capacity of at least minCapacity.
+//
+// A new slice will always be returned, even if the given slice had the required capacity.
+// If the slice didn't have enough capacity, the new slice will have a
+// new array created for it with the required minimum capacity.
+//
+// This takes the place of the growSlice function in the reflect package.
 var $growSlice = (slice, minCapacity) => {
-    const oldCapacity = slice.$capacity;
-    if (minCapacity <= oldCapacity) {
-        return slice
-    }
-     
-    const newCapacity = $calculateNewCapacity(minCapacity, oldCapacity);
-    
-    let newArray;
-    if (slice.$array.constructor === Array) {
-        newArray = slice.$array.slice( slice.$offset,  slice.$offset + slice.$length);
-        newArray.length = newCapacity;
-        let zero = slice.constructor.elem.zero;
-        for (let i = slice.$length; i < newCapacity; i++) {
-            newArray[i] = zero();
+    let array = slice.$array;
+    let offset = slice.$offset;
+    const length = slice.$length;
+    let capacity = slice.$capacity;
+
+    if (minCapacity > capacity) {
+        capacity = $calculateNewCapacity(minCapacity, capacity);
+        
+        let newArray;
+        if (array.constructor === Array) {
+            newArray = array.slice(offset, offset + length);
+            newArray.length = capacity;
+            const zero = slice.constructor.elem.zero;
+            for (let i = slice.$length; i < capacity; i++) {
+                newArray[i] = zero();
+            }
+        } else {
+            newArray = new array.constructor(capacity);
+            newArray.set(array.subarray(offset, offset + length));
         }
-    } else {
-        newArray = new slice.$array.constructor(newCapacity);
-        newArray.set(slice.$array.subarray( slice.$offset,  slice.$offset + slice.$length));
+
+        array = newArray;
+        offset = 0;
     }
 
-    const oldLength = slice.$length;
-    slice = new slice.constructor(newArray);
-    slice.$offset = 0;
-    slice.$length = oldLength;
-    slice.$capacity = newCapacity;
-    return slice;
+    let newSlice = new slice.constructor(array);
+    newSlice.$offset = offset;
+    newSlice.$length = length;
+    newSlice.$capacity = capacity;
+    return newSlice;
 };
 
 var $equal = (a, b, type) => {

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -433,35 +433,50 @@ var $internalAppend = (slice, array, offset, length) => {
         return slice;
     }
 
-    var newArray = slice.$array;
-    var newOffset = slice.$offset;
     var newLength = slice.$length + length;
-    var newCapacity = slice.$capacity;
-
-    if (newLength > newCapacity) {
-        newOffset = 0;
-        newCapacity = Math.max(newLength, slice.$capacity < 1024 ? slice.$capacity * 2 : Math.floor(slice.$capacity * 5 / 4));
-
-        if (slice.$array.constructor === Array) {
-            newArray = slice.$array.slice(slice.$offset, slice.$offset + slice.$length);
-            newArray.length = newCapacity;
-            var zero = slice.constructor.elem.zero;
-            for (var i = slice.$length; i < newCapacity; i++) {
-                newArray[i] = zero();
-            }
-        } else {
-            newArray = new slice.$array.constructor(newCapacity);
-            newArray.set(slice.$array.subarray(slice.$offset, slice.$offset + slice.$length));
-        }
-    }
-
-    $copyArray(newArray, array, newOffset + slice.$length, offset, length, slice.constructor.elem);
+    slice = $growSlice(slice, newLength);
+    
+    var newArray = slice.$array;
+    $copyArray(newArray, array, slice.$offset + slice.$length, offset, length, slice.constructor.elem);
 
     var newSlice = new slice.constructor(newArray);
-    newSlice.$offset = newOffset;
+    newSlice.$offset = slice.$offset;
     newSlice.$length = newLength;
-    newSlice.$capacity = newCapacity;
+    newSlice.$capacity = slice.$capacity;
     return newSlice;
+};
+
+const $calculateNewCapacity = (minCapacity, oldCapacity) => {
+    return Math.max(minCapacity, oldCapacity < 1024 ? oldCapacity * 2 : Math.floor(oldCapacity * 5 / 4));
+};
+
+var $growSlice = (slice, minCapacity) => {
+    const oldCapacity = slice.$capacity;
+    if (minCapacity <= oldCapacity) {
+        return slice
+    }
+     
+    const newCapacity = $calculateNewCapacity(minCapacity, oldCapacity);
+    
+    let newArray;
+    if (slice.$array.constructor === Array) {
+        newArray = slice.$array.slice( slice.$offset,  slice.$offset + slice.$length);
+        newArray.length = newCapacity;
+        let zero = slice.constructor.elem.zero;
+        for (let i = slice.$length; i < newCapacity; i++) {
+            newArray[i] = zero();
+        }
+    } else {
+        newArray = new slice.$array.constructor(newCapacity);
+        newArray.set(slice.$array.subarray( slice.$offset,  slice.$offset + slice.$length));
+    }
+
+    const oldLength = slice.$length;
+    slice = new slice.constructor(newArray);
+    slice.$offset = 0;
+    slice.$length = oldLength;
+    slice.$capacity = newCapacity;
+    return slice;
 };
 
 var $equal = (a, b, type) => {

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -231,6 +231,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.comparable = false;
                 typ.nativeArray = $nativeArray(elem.kind);
                 typ.nil = new typ([]);
+                Object.freeze(typ.nil);
             };
             break;
 

--- a/tests/arrays_test.go
+++ b/tests/arrays_test.go
@@ -83,3 +83,41 @@ func TestReflectArraySize(t *testing.T) {
 		t.Errorf("array type size gave %v, want %v", got, want)
 	}
 }
+
+func TestNilPrototypeNotModifiedByPointer(t *testing.T) {
+	const growth = 3
+
+	s1 := []int(nil)
+	p1 := &s1
+	*p1 = make([]int, 0, growth)
+	if c := cap(s1); c != growth {
+		t.Errorf(`expected capacity of nil to increase to %d, got %d`, growth, c)
+		println("s1:", s1)
+	}
+
+	s2 := []int(nil)
+	if c := cap(s2); c != 0 {
+		t.Errorf(`the capacity of nil must always be zero, it was %d`, c)
+		println("s1:", s1)
+		println("s2:", s2)
+	}
+}
+
+func TestNilPrototypeNotModifiedByReflectGrow(t *testing.T) {
+	const growth = 3
+
+	s1 := []int(nil)
+	v1 := reflect.ValueOf(&s1).Elem()
+	v1.Grow(growth)
+	if c := cap(s1); c != growth {
+		t.Errorf(`expected capacity of nil to increase to %d, got %d`, growth, c)
+		println("s1:", s1)
+	}
+
+	s2 := []int(nil)
+	if c := cap(s2); c != 0 {
+		t.Errorf(`the capacity of nil must always be zero, it was %d`, c)
+		println("s1:", s1)
+		println("s2:", s2)
+	}
+}


### PR DESCRIPTION
Fixing the `reflect` method `Value.Grow` that grows a slice to a contain a minimum specified capacity. This required the [`grow`](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/reflect/value.go;l=2795-2807) method to be updated so that it can call into JS. I split the `append` method to create a `growSlice` method which functions similar to [`reflect.growslice`](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/reflect/value.go;l=3846).

CI will still fail right now because `internal/godebug.setUpdate` needs to be implemented. It is implemented in another PR. With both this and the `setUpdate` change the `TestGrow` tests pass.

This does not fix the issue with `Value.extendSlice` used by `Value.Append`. I'm fixing that in another PR.

This is part of #1270