### PR TITLE
[go1.20] Add SemacquireRWMutex

### DIFF
--- a/compiler/natives/src/sync/sync.go
+++ b/compiler/natives/src/sync/sync.go
@@ -46,6 +46,14 @@ func runtime_SemacquireMutex(s *uint32, lifo bool, skipframes int) {
 	*s--
 }
 
+func runtime_SemacquireRWMutexR(s *uint32, lifo bool, skipframes int) {
+	runtime_SemacquireMutex(s, lifo, skipframes)
+}
+
+func runtime_SemacquireRWMutex(s *uint32, lifo bool, skipframes int) {
+	runtime_SemacquireMutex(s, lifo, skipframes)
+}
+
 func runtime_Semrelease(s *uint32, handoff bool, skipframes int) {
 	// TODO: Use handoff if needed/possible.
 	*s++


### PR DESCRIPTION
Add in the `runtime_SemacquireRWMutexR` and `runtime_SemacquireRWMutex` methods. I routed them both through the existing `runtime_SemacquireMutex` since "they're functionally identical." according to below.

From the [source](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/sync/runtime.go;l=16-26)...
```Go
// Semacquire(RW)Mutex(R) is like Semacquire, but for profiling contended
// Mutexes and RWMutexes.
// If lifo is true, queue waiter at the head of wait queue.
// skipframes is the number of frames to omit during tracing, counting from
// runtime_SemacquireMutex's caller.
// The different forms of this function just tell the runtime how to present
// the reason for waiting in a backtrace, and is used to compute some metrics.
// Otherwise they're functionally identical.
func runtime_SemacquireMutex(s *uint32, lifo bool, skipframes int)
func runtime_SemacquireRWMutexR(s *uint32, lifo bool, skipframes int)
func runtime_SemacquireRWMutex(s *uint32, lifo bool, skipframes int)
```

The CI will still not pass for go1.20 but it will no longer complain about these two methods not being implemented.

This is part of #1270 