### PR TITLE
[go1.20] Removing remaining uses of `unsafeheader.Slice` from reflect

### DIFF
--- a/compiler/natives/src/internal/unsafeheader/unsafeheader.go
+++ b/compiler/natives/src/internal/unsafeheader/unsafeheader.go
@@ -1,0 +1,16 @@
+//go:build js
+// +build js
+
+package unsafeheader
+
+// Slice and String is Go's runtime representations which is different
+// from GopherJS's runtime representations. By purging these types,
+// it will prevent failures in JS where the code compiles fine but
+// expects there to be a constructor which doesn't exist when casting
+// from GopherJS's representation into Go's representation.
+
+//gopherjs:purge
+type Slice struct{}
+
+//gopherjs:purge
+type String struct{}

--- a/compiler/natives/src/internal/unsafeheader/unsafeheader_test.go
+++ b/compiler/natives/src/internal/unsafeheader/unsafeheader_test.go
@@ -5,6 +5,16 @@ package unsafeheader_test
 
 import "testing"
 
+func TestTypeMatchesReflectType(t *testing.T) {
+	t.Skip("GopherJS uses different slice and string implementation than internal/unsafeheader.")
+}
+
+//gopherjs:purge
+func testHeaderMatchesReflect()
+
+//gopherjs:purge
+func typeCompatible()
+
 func TestWriteThroughHeader(t *testing.T) {
 	t.Skip("GopherJS uses different slice and string implementation than internal/unsafeheader.")
 }

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -185,7 +185,7 @@ var $sliceToNativeArray = slice => {
     return slice.$array.slice(slice.$offset, slice.$offset + slice.$length);
 };
 
-// Convert Go slice to a pointer to an underlying Go array.
+// Convert Go slice to a pointer to an underlying Go array, `[]T -> *[N]T`.
 // 
 // Note that an array pointer can be represented by an "unwrapped" native array
 // type, and it will be wrapped back into its Go type when necessary.


### PR DESCRIPTION
Overrode the remaining uses of `unsafeheader.Slice` since GopherJS implemented slices differently. The remaining use was in `cvtSliceArray` used by methods like [Value.Convert](https://pkg.go.dev/reflect@go1.20.14#Value.Convert).

The CI will still not pass yet, but this will fix the tests like `TestConvert` so they pass. With the prior tickets for reflect merged, this should also get the `reflect` package to pass.

This is a follow up to #1321. This is part of #1270