### PR TITLE
[go1.20] Fixing a encoding/gob override

### DIFF
--- a/compiler/natives/src/encoding/gob/gob.go
+++ b/compiler/natives/src/encoding/gob/gob.go
@@ -26,9 +26,9 @@ func (x *atomicEncEnginePointer) Store(val *encEngine) { x.v = val }
 
 // temporarily replacement of growSlice[E any] for go1.20 without generics.
 func growSlice(v reflect.Value, ps any, length int) {
-	vps := reflect.ValueOf(ps)
-	vs := vps.Elem()
-	zero := reflect.Zero(vs.Elem().Type())
+	vps := reflect.ValueOf(ps) // *[]E
+	vs := vps.Elem()           // []E
+	zero := reflect.Zero(vs.Type().Elem())
 	vs.Set(reflect.Append(vs, zero))
 	cp := vs.Cap()
 	if cp > length {
@@ -36,5 +36,4 @@ func growSlice(v reflect.Value, ps any, length int) {
 	}
 	vs.Set(vs.Slice(0, cp))
 	v.Set(vs)
-	vps.Set(vs.Addr())
 }

--- a/compiler/natives/src/encoding/gob/gob_test.go
+++ b/compiler/natives/src/encoding/gob/gob_test.go
@@ -105,3 +105,11 @@ func TestTypeRace(t *testing.T) {
 	// cannot succeed when nosync is used.
 	t.Skip("using nosync")
 }
+
+func TestCountEncodeMallocs(t *testing.T) {
+	t.Skip("testing.AllocsPerRun not supported in GopherJS")
+}
+
+func TestCountDecodeMallocs(t *testing.T) {
+	t.Skip("testing.AllocsPerRun not supported in GopherJS")
+}


### PR DESCRIPTION
When I started working on go1.20 I added an override to encoding/gob `growSlice` to replace it's usage of generics. Once I got the transpile to work other issues popped up that hid a mistake. Those other issues are now taking care of so this issue came back up. I fixed the mistake and skipped some tests checking mallocs. Additionally, I checked `TestEndToEnd` override since it has an old TODO on it. It appears the issue with the Marr field still exist so I left it alone.

The experimental generics can handle encoding/god without the override to `growSlice` now. The unit-tests pass in the same amount of time (within some variance). However, until generics is ready to get out of experimental mode, the overrides for generics are left in. Even after release of generics, this doesn't affect any exported code so can be cleaned up later.

CI will still not pass after this change. However, encoding/gob's unit-tests should pass.

This is part of #1270 