### PR TITLE
[go1.20] Adding experimental generics flag to measure-size.yml for go1.20

### DIFF
--- a/.github/workflows/measure-size.yml
+++ b/.github/workflows/measure-size.yml
@@ -4,6 +4,7 @@ on: ['pull_request']
 
 env:
   GO_VERSION: '~1.20.14'
+  GOPHERJS_EXPERIMENT: generics
 
 jobs:
   measure:


### PR DESCRIPTION
When I was bumping the Go version in CI to 1.20.14, I forgot to also include `GOPHERJS_EXPERIMENT: generics` in `measure-size.yml`. Without generics enabled for go1.20, the [type check in atomic](https://cs.opensource.google/go/go/+/refs/tags/go1.20.14:src/sync/atomic/type.go;l=40) causes GopherJS to fail the build that is being measured.

This change should get `measure-size.yml` CI to pass for go1.20 branch. (The go1.20 branch doesn't have the CI improvements from master yet so they will take some time to run.)

This is part of #1270 