### PR TITLE
Final round of refactoring ported from the original generics branch.

### DIFF
--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -345,7 +345,7 @@ func (fc *funcContext) newFuncDecl(fun *ast.FuncDecl, inst typeparams.Instance) 
 	}
 
 	d.DceDeps = fc.CollectDCEDeps(func() {
-		d.DeclCode = fc.translateTopLevelFunction(fun, inst)
+		d.DeclCode = fc.namedFuncContext(inst).translateTopLevelFunction(fun)
 	})
 	return d
 }

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -201,7 +201,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		}
 
 	case *ast.FuncLit:
-		fun := fc.nestedFunctionContext(fc.pkgCtx.FuncLitInfos[e], exprType.(*types.Signature), typeparams.Instance{}).translateFunctionBody(e.Type, nil, e.Body, "")
+		fun := fc.literalFuncContext(e).translateFunctionBody(e.Type, nil, e.Body)
 		if len(fc.pkgCtx.escapingVars) != 0 {
 			names := make([]string, 0, len(fc.pkgCtx.escapingVars))
 			for obj := range fc.pkgCtx.escapingVars {

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -730,10 +730,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 					}
 				}
 
-				methodName := sel.Obj().Name()
-				if reservedKeywords[methodName] {
-					methodName += "$"
-				}
+				methodName := fc.methodName(sel.Obj().(*types.Func))
 				return fc.translateCall(e, sig, fc.formatExpr("%s.%s", recv, methodName))
 
 			case types.FieldVal:

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -121,15 +121,7 @@ func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl, inst typepar
 		return code.Bytes()
 	}
 
-	if ptr, isPointer := sig.Recv().Type().(*types.Pointer); isPointer {
-		if _, isArray := ptr.Elem().Underlying().(*types.Array); isArray {
-			// Pointer-to-array is another special case.
-			// TODO(nevkontakte) Find out and document why.
-			code.Write(primaryFunction(prototypeVar))
-			code.Write(proxyFunction(ptrPrototypeVar, fmt.Sprintf("(new %s(this.$get()))", recvInstName)))
-			return code.Bytes()
-		}
-
+	if _, isPointer := sig.Recv().Type().(*types.Pointer); isPointer {
 		// Methods with pointer-receiver are only attached to the pointer-receiver
 		// type.
 		return primaryFunction(ptrPrototypeVar)

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -18,18 +18,21 @@ import (
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
 )
 
-// newFunctionContext creates a new nested context for a function corresponding
+// nestedFunctionContext creates a new nested context for a function corresponding
 // to the provided info and instance.
-func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, sig *types.Signature, inst typeparams.Instance) *funcContext {
+func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, inst typeparams.Instance) *funcContext {
 	if info == nil {
 		panic(errors.New("missing *analysis.FuncInfo"))
 	}
-	if sig == nil {
-		panic(errors.New("missing *types.Signature"))
+	if inst.Object == nil {
+		panic(errors.New("missing inst.Object"))
 	}
+	o := inst.Object.(*types.Func)
+	sig := o.Type().(*types.Signature)
 
 	c := &funcContext{
 		FuncInfo:     info,
+		instance:     inst,
 		pkgCtx:       fc.pkgCtx,
 		parent:       fc,
 		allVars:      make(map[string]int, len(fc.allVars)),
@@ -54,43 +57,73 @@ func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, sig *types
 		c.objectNames = map[types.Object]string{}
 	}
 
+	// Synthesize an identifier by which the function may reference itself. Since
+	// it appears in the stack trace, it's useful to include the receiver type in
+	// it.
+	funcRef := o.Name()
+	if recvType := typesutil.RecvType(sig); recvType != nil {
+		funcRef = recvType.Obj().Name() + midDot + funcRef
+	}
+	c.funcRef = c.newVariable(funcRef, true /*pkgLevel*/)
+
+	return c
+}
+
+// namedFuncContext creates a new funcContext for a named Go function
+// (standalone or method).
+func (fc *funcContext) namedFuncContext(inst typeparams.Instance) *funcContext {
+	info := fc.pkgCtx.FuncDeclInfos[inst.Object.(*types.Func)]
+	c := fc.nestedFunctionContext(info, inst)
+
+	return c
+}
+
+// literalFuncContext creates a new funcContext for a function literal. Since
+// go/types doesn't generate *types.Func objects for function literals, we
+// generate a synthetic one for it.
+func (fc *funcContext) literalFuncContext(fun *ast.FuncLit) *funcContext {
+	info := fc.pkgCtx.FuncLitInfos[fun]
+	sig := fc.pkgCtx.TypeOf(fun).(*types.Signature)
+	o := types.NewFunc(fun.Pos(), fc.pkgCtx.Pkg, fc.newLitFuncName(), sig)
+	inst := typeparams.Instance{Object: o}
+
+	c := fc.nestedFunctionContext(info, inst)
 	return c
 }
 
 // translateTopLevelFunction translates a top-level function declaration
-// (standalone function or method) into a corresponding JS function.
+// (standalone function or method) into a corresponding JS function. Must be
+// called on the function context created for the function corresponding instance.
 //
 // Returns a string with JavaScript statements that define the function or
 // method. For methods it returns declarations for both value- and
 // pointer-receiver (if appropriate).
-func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl, inst typeparams.Instance) []byte {
+func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl) []byte {
 	if fun.Recv == nil {
-		return fc.translateStandaloneFunction(fun, inst)
+		return fc.translateStandaloneFunction(fun)
 	}
 
-	return fc.translateMethod(fun, inst)
+	return fc.translateMethod(fun)
 }
 
 // translateStandaloneFunction translates a package-level function.
 //
 // It returns JS statements which define the corresponding function in a
 // package context. Exported functions are also assigned to the `$pkg` object.
-func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl, inst typeparams.Instance) []byte {
-	o := inst.Object.(*types.Func)
-	info := fc.pkgCtx.FuncDeclInfos[o]
-	sig := o.Type().(*types.Signature)
+func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl) []byte {
+	o := fc.instance.Object.(*types.Func)
 
 	if fun.Recv != nil {
 		panic(fmt.Errorf("expected standalone function, got method: %s", o))
 	}
 
-	lvalue := fc.instName(inst)
+	lvalue := fc.instName(fc.instance)
 
 	if fun.Body == nil {
 		return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, fc.unimplementedFunction(o)))
 	}
 
-	body := fc.nestedFunctionContext(info, sig, inst).translateFunctionBody(fun.Type, nil, fun.Body, lvalue)
+	body := fc.translateFunctionBody(fun.Type, nil, fun.Body)
 	code := bytes.NewBuffer(nil)
 	fmt.Fprintf(code, "\t%s = %s;\n", lvalue, body)
 	if fun.Name.IsExported() {
@@ -103,12 +136,10 @@ func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl, inst typep
 //
 // It returns one or more JS statements which define the method. Methods with
 // non-pointer receiver are automatically defined for the pointer-receiver type.
-func (fc *funcContext) translateMethod(fun *ast.FuncDecl, inst typeparams.Instance) []byte {
-	o := inst.Object.(*types.Func)
-	info := fc.pkgCtx.FuncDeclInfos[o]
+func (fc *funcContext) translateMethod(fun *ast.FuncDecl) []byte {
+	o := fc.instance.Object.(*types.Func)
 	funName := fc.methodName(o)
 
-	sig := o.Type().(*types.Signature)
 	// primaryFunction generates a JS function equivalent of the current Go function
 	// and assigns it to the JS expression defined by lvalue.
 	primaryFunction := func(lvalue string) []byte {
@@ -120,11 +151,11 @@ func (fc *funcContext) translateMethod(fun *ast.FuncDecl, inst typeparams.Instan
 		if fun.Recv != nil && fun.Recv.List[0].Names != nil {
 			recv = fun.Recv.List[0].Names[0]
 		}
-		fun := fc.nestedFunctionContext(info, sig, inst).translateFunctionBody(fun.Type, recv, fun.Body, lvalue)
+		fun := fc.translateFunctionBody(fun.Type, recv, fun.Body)
 		return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, fun))
 	}
 
-	recvInst := inst.Recv()
+	recvInst := fc.instance.Recv()
 	recvInstName := fc.instName(recvInst)
 	recvType := recvInst.Object.Type().(*types.Named)
 
@@ -134,7 +165,7 @@ func (fc *funcContext) translateMethod(fun *ast.FuncDecl, inst typeparams.Instan
 	ptrPrototypeVar := fmt.Sprintf("$ptrType(%s).prototype.%s", recvInstName, funName)
 
 	// Methods with pointer-receiver are only attached to the pointer-receiver type.
-	if _, isPointer := sig.Recv().Type().(*types.Pointer); isPointer {
+	if _, isPointer := fc.sig.Sig.Recv().Type().(*types.Pointer); isPointer {
 		return primaryFunction(ptrPrototypeVar)
 	}
 
@@ -185,7 +216,7 @@ func (fc *funcContext) unimplementedFunction(o *types.Func) string {
 // It returns a JS function expression that represents the given Go function.
 // Function receiver must have been created with nestedFunctionContext() to have
 // required metadata set up.
-func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt, funcRef string) string {
+func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident, body *ast.BlockStmt) string {
 	prevEV := fc.pkgCtx.escapingVars
 
 	// Generate a list of function argument variables. Since Go allows nameless
@@ -239,7 +270,7 @@ func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident,
 
 	sort.Strings(fc.localVars)
 
-	var prefix, suffix, functionName string
+	var prefix, suffix string
 
 	if len(fc.Flattened) != 0 {
 		// $s contains an index of the switch case a blocking function reached
@@ -260,21 +291,19 @@ func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident,
 	localVarDefs := "" // Function-local var declaration at the top.
 
 	if len(fc.Blocking) != 0 {
-		if funcRef == "" {
-			funcRef = "$b"
-			functionName = " $b"
-		}
-
 		localVars := append([]string{}, fc.localVars...)
 		// There are several special variables involved in handling blocking functions:
 		// $r is sometimes used as a temporary variable to store blocking call result.
 		// $c indicates that a function is being resumed after a blocking call when set to true.
 		// $f is an object used to save and restore function context for blocking calls.
 		localVars = append(localVars, "$r")
+		// funcRef identifies the function object itself, so it doesn't need to be saved
+		// or restored.
+		localVars = removeMatching(localVars, fc.funcRef)
 		// If a blocking function is being resumed, initialize local variables from the saved context.
 		localVarDefs = fmt.Sprintf("var {%s, $c} = $restore(this, {%s});\n", strings.Join(localVars, ", "), strings.Join(args, ", "))
 		// If the function gets blocked, save local variables for future.
-		saveContext := fmt.Sprintf("var $f = {$blk: "+funcRef+", $c: true, $r, %s};", strings.Join(fc.localVars, ", "))
+		saveContext := fmt.Sprintf("var $f = {$blk: "+fc.funcRef+", $c: true, $r, %s};", strings.Join(fc.localVars, ", "))
 
 		suffix = " " + saveContext + "return $f;" + suffix
 	} else if len(fc.localVars) > 0 {
@@ -322,5 +351,5 @@ func (fc *funcContext) translateFunctionBody(typ *ast.FuncType, recv *ast.Ident,
 
 	fc.pkgCtx.escapingVars = prevEV
 
-	return fmt.Sprintf("function%s(%s) {\n%s%s}", functionName, strings.Join(args, ", "), bodyOutput, fc.Indentation(0))
+	return fmt.Sprintf("function %s(%s) {\n%s%s}", fc.funcRef, strings.Join(args, ", "), bodyOutput, fc.Indentation(0))
 }

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -75,7 +75,7 @@ func (fc *funcContext) translateTopLevelFunction(fun *ast.FuncDecl, inst typepar
 	// and assigns it to the JS expression defined by lvalue.
 	primaryFunction := func(lvalue string) []byte {
 		if fun.Body == nil {
-			return []byte(fmt.Sprintf("\t%s = function() {\n\t\t$throwRuntimeError(\"native function not implemented: %s\");\n\t};\n", lvalue, o.FullName()))
+			return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, fc.unimplementedFunction(o)))
 		}
 
 		var recv *ast.Ident
@@ -162,7 +162,7 @@ func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl, inst typep
 	lvalue := fc.instName(inst)
 
 	if fun.Body == nil {
-		return []byte(fmt.Sprintf("\t%s = function() {\n\t\t$throwRuntimeError(\"native function not implemented: %s\");\n\t};\n", lvalue, o.FullName()))
+		return []byte(fmt.Sprintf("\t%s = %s;\n", lvalue, fc.unimplementedFunction(o)))
 	}
 
 	body := fc.nestedFunctionContext(info, sig, inst).translateFunctionBody(fun.Type, nil, fun.Body, lvalue)
@@ -172,6 +172,15 @@ func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl, inst typep
 		fmt.Fprintf(code, "\t$pkg.%s = %s;\n", encodeIdent(fun.Name.Name), lvalue)
 	}
 	return code.Bytes()
+}
+
+// unimplementedFunction returns a JS function expression for a Go function
+// without a body, which would throw an exception if called.
+//
+// In Go such functions are either used with a //go:linkname directive or with
+// assembler intrinsics, only former of which is supported by GopherJS.
+func (fc *funcContext) unimplementedFunction(o *types.Func) string {
+	return fmt.Sprintf("function() {\n\t\t$throwRuntimeError(\"native function not implemented: %s\");\n\t}", o.FullName())
 }
 
 // translateFunctionBody translates body of a top-level or literal function.

--- a/compiler/natives/src/reflect/reflect_test.go
+++ b/compiler/natives/src/reflect/reflect_test.go
@@ -298,3 +298,23 @@ func TestIssue50208(t *testing.T) {
 func TestStructOfTooLarge(t *testing.T) {
 	t.Skip("This test is dependent on field alignment to determine if a struct size would exceed virtual address space.")
 }
+
+func TestSetLenCap(t *testing.T) {
+	t.Skip("Test depends on call stack function names: https://github.com/gopherjs/gopherjs/issues/1085")
+}
+
+func TestSetPanic(t *testing.T) {
+	t.Skip("Test depends on call stack function names: https://github.com/gopherjs/gopherjs/issues/1085")
+}
+
+func TestCallPanic(t *testing.T) {
+	t.Skip("Test depends on call stack function names: https://github.com/gopherjs/gopherjs/issues/1085")
+}
+
+func TestValuePanic(t *testing.T) {
+	t.Skip("Test depends on call stack function names: https://github.com/gopherjs/gopherjs/issues/1085")
+}
+
+func TestSetIter(t *testing.T) {
+	t.Skip("Test depends on call stack function names: https://github.com/gopherjs/gopherjs/issues/1085")
+}

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -53,6 +53,15 @@ func (pc *pkgContext) isMain() bool {
 // JavaScript code (as defined for `var` declarations).
 type funcContext struct {
 	*analysis.FuncInfo
+	// Function instance this context corresponds to, or zero if the context is
+	// top-level or doesn't correspond to a function. For function literals, this
+	// is a synthetic object that assigns a unique identity to the function.
+	instance typeparams.Instance
+	// JavaScript identifier assigned to the function object (the word after the
+	// "function" keyword in the generated code). This identifier can be used
+	// within the function scope to reference the function object. It will also
+	// appear in the stack trace.
+	funcRef string
 	// Surrounding package context.
 	pkgCtx *pkgContext
 	// Function context, surrounding this function definition. For package-level
@@ -104,6 +113,8 @@ type funcContext struct {
 	typeResolver *typeparams.Resolver
 	// Mapping from function-level objects to JS variable names they have been assigned.
 	objectNames map[types.Object]string
+	// Number of function literals encountered within the current function context.
+	funcLitCounter int
 }
 
 func newRootCtx(tContext *types.Context, srcs sources, typesInfo *types.Info, typesPkg *types.Package, isBlocking func(*types.Func) bool, minify bool) *funcContext {

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -474,6 +474,21 @@ func (fc *funcContext) instName(inst typeparams.Instance) string {
 	return fmt.Sprintf("%s[%d /* %v */]", objName, fc.pkgCtx.instanceSet.ID(inst), inst.TArgs)
 }
 
+// methodName returns a JS identifier (specifically, object property name)
+// corresponding to the given method.
+func (fc *funcContext) methodName(fun *types.Func) string {
+	if fun.Type().(*types.Signature).Recv() == nil {
+		panic(fmt.Errorf("expected a method, got a standalone function %v", fun))
+	}
+	name := fun.Name()
+	// Method names are scoped to their receiver type and guaranteed to be
+	// unique within that, so we only need to make sure it's not a reserved keyword
+	if reservedKeywords[name] {
+		name += "$"
+	}
+	return name
+}
+
 func (fc *funcContext) varPtrName(o *types.Var) string {
 	if isPkgLevel(o) && o.Exported() {
 		return fc.pkgVar(o.Pkg()) + "." + o.Name() + "$ptr"

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -23,6 +23,11 @@ import (
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
 )
 
+// We use this character as a separator in synthetic identifiers instead of a
+// regular dot. This character is safe for use in JS identifiers and helps to
+// visually separate components of the name when it appears in a stack trace.
+const midDot = "·"
+
 // root returns the topmost function context corresponding to the package scope.
 func (fc *funcContext) root() *funcContext {
 	if fc.isRoot() {
@@ -374,6 +379,25 @@ func (fc *funcContext) newTypeIdent(name string, obj types.Object) *ast.Ident {
 	ident := ast.NewIdent(name)
 	fc.pkgCtx.Info.Uses[ident] = obj
 	return ident
+}
+
+// newLitFuncName generates a new synthetic name for a function literal.
+func (fc *funcContext) newLitFuncName() string {
+	fc.funcLitCounter++
+	name := &strings.Builder{}
+
+	// If function literal is defined inside another function, qualify its
+	// synthetic name with the outer function to make it easier to identify.
+	if fc.instance.Object != nil {
+		if recvType := typesutil.RecvType(fc.sig.Sig); recvType != nil {
+			name.WriteString(recvType.Obj().Name())
+			name.WriteString(midDot)
+		}
+		name.WriteString(fc.instance.Object.Name())
+		name.WriteString(midDot)
+	}
+	fmt.Fprintf(name, "func%d", fc.funcLitCounter)
+	return name.String()
 }
 
 func (fc *funcContext) setType(e ast.Expr, t types.Type) ast.Expr {
@@ -909,7 +933,15 @@ func rangeCheck(pattern string, constantIndex, array bool) string {
 }
 
 func encodeIdent(name string) string {
-	return strings.Replace(url.QueryEscape(name), "%", "$", -1)
+	// Quick-and-dirty way to make any string safe for use as an identifier in JS.
+	name = url.QueryEscape(name)
+	// We use unicode middle dot as a visual separator in synthetic identifiers.
+	// It is safe for use in a JS identifier, so we un-encode it for readability.
+	name = strings.ReplaceAll(name, "%C2%B7", midDot)
+	// QueryEscape uses '%' before hex-codes of escaped characters, which is not
+	// allowed in a JS identifier, use '$' instead.
+	name = strings.ReplaceAll(name, "%", "$")
+	return name
 }
 
 // formatJSStructTagVal returns JavaScript code for accessing an object's property
@@ -994,4 +1026,14 @@ func bailout(cause interface{}) *FatalError {
 func bailingOut(err interface{}) (*FatalError, bool) {
 	fe, ok := err.(*FatalError)
 	return fe, ok
+}
+
+func removeMatching[T comparable](haystack []T, needle T) []T {
+	var result []T
+	for _, el := range haystack {
+		if el != needle {
+			result = append(result, el)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
- Factor out unimplemented function body generation into a helper.
- Remove an unnecessary special case for methods with array-pointer receivers.
- Move method translation logic into its own method, similar to the existing one for standalone functions.
- Assign identities to all function literals and use them as funcRefs. This unifies translation logic between named and literal functions and reduces the number of arguments we have to pass around.
- Add some comments to the existing code.

Updates #1013 