### PR TITLE
Remove npm dependencies we don't need anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,7 @@ _Note: GopherJS will try to write compiled object files of the core packages to 
 
 #### gopherjs run, gopherjs test
 
-If you want to use `gopherjs run` or `gopherjs test` to run the generated code locally, install Node.js 10.0.0 (or newer), and the `source-map-support` module:
-
-```
-npm install --global source-map-support
-```
+If you want to use `gopherjs run` or `gopherjs test` to run the generated code locally, install Node.js 18 (or newer).
 
 On supported `GOOS` platforms, it's possible to make system calls (file system access, etc.) available. See [doc/syscalls.md](https://github.com/gopherjs/gopherjs/blob/master/doc/syscalls.md) for instructions on how to do so.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "name": "gopherjs",
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "source-map-support": "^0.5.19"
-      },
       "optionalDependencies": {
         "syscall": "file:./node-syscall"
       }
@@ -139,11 +136,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/cacache": {
       "version": "15.3.0",
@@ -872,23 +864,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/sprintf-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "dependencies": {
         "source-map-support": "^0.5.19"
       },
-      "devDependencies": {
-        "uglify-es": "^3.3.9"
-      },
       "optionalDependencies": {
         "syscall": "file:./node-syscall"
       }
@@ -203,12 +200,6 @@
       "bin": {
         "color-support": "bin.js"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -983,23 +974,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
-      "dev": true,
-      "dependencies": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -1061,6 +1035,7 @@
       "optional": true
     },
     "node-syscall": {
+      "name": "syscall",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "gopherjs",
   "license": "BSD-2-Clause",
-  "dependencies": {
-    "source-map-support": "^0.5.19"
-  },
   "optionalDependencies": {
     "syscall": "file:./node-syscall"
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "gopherjs",
   "license": "BSD-2-Clause",
-  "devDependencies": {
-    "uglify-es": "^3.3.9"
-  },
   "dependencies": {
     "source-map-support": "^0.5.19"
   },

--- a/tool.go
+++ b/tool.go
@@ -838,13 +838,7 @@ func sprintError(err error) string {
 func runNode(script string, args []string, dir string, quiet bool, out io.Writer) error {
 	var allArgs []string
 	if b, _ := strconv.ParseBool(os.Getenv("SOURCE_MAP_SUPPORT")); os.Getenv("SOURCE_MAP_SUPPORT") == "" || b {
-		allArgs = []string{"--require", "source-map-support/register"}
-		if err := exec.Command("node", "--require", "source-map-support/register", "--eval", "").Run(); err != nil {
-			if !quiet {
-				fmt.Fprintln(os.Stderr, "gopherjs: Source maps disabled. Install source-map-support module for nice stack traces. See https://github.com/gopherjs/gopherjs#gopherjs-run-gopherjs-test.")
-			}
-			allArgs = []string{}
-		}
+		allArgs = []string{"--enable-source-maps"}
 	}
 
 	if runtime.GOOS != "windows" {


### PR DESCRIPTION
- We aren't using uglify-es since we switched to esbuild for prelude minification.
- We no longer need source-map-support module since Node supports the equivalent functionality natively.

Our only NPM dependency at this point is the node-syscall module, which is deprecated and will be removed at some future point (https://github.com/gopherjs/gopherjs/issues/1328).