### PR TITLE
[go1.20] Moving DCE to isolate filter naming

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gopherjs/gopherjs/compiler/internal/dce"
 	"github.com/gopherjs/gopherjs/compiler/prelude"
 	"golang.org/x/tools/go/gcexportdata"
 )
@@ -125,12 +126,6 @@ func ImportDependencies(archive *Archive, importPkg func(string) (*Archive, erro
 	return deps, nil
 }
 
-type dceInfo struct {
-	decl         *Decl
-	objectFilter string
-	methodFilter string
-}
-
 func WriteProgramCode(pkgs []*Archive, w *SourceMapFilter, goVersion string) error {
 	mainPkg := pkgs[len(pkgs)-1]
 	minify := mainPkg.Minified
@@ -141,61 +136,21 @@ func WriteProgramCode(pkgs []*Archive, w *SourceMapFilter, goVersion string) err
 		gls.Add(pkg.GoLinknames)
 	}
 
-	byFilter := make(map[string][]*dceInfo)
-	var pendingDecls []*Decl // A queue of live decls to find other live decls.
+	sel := &dce.Selector[*Decl]{}
 	for _, pkg := range pkgs {
 		for _, d := range pkg.Declarations {
-			if d.DceObjectFilter == "" && d.DceMethodFilter == "" {
-				// This is an entry point (like main() or init() functions) or a variable
-				// initializer which has a side effect, consider it live.
-				pendingDecls = append(pendingDecls, d)
-				continue
-			}
+			implementsLink := false
 			if gls.IsImplementation(d.LinkingName) {
 				// If a decl is referenced by a go:linkname directive, we just assume
 				// it's not dead.
 				// TODO(nevkontakte): This is a safe, but imprecise assumption. We should
 				// try and trace whether the referencing functions are actually live.
-				pendingDecls = append(pendingDecls, d)
+				implementsLink = true
 			}
-			info := &dceInfo{decl: d}
-			if d.DceObjectFilter != "" {
-				info.objectFilter = pkg.ImportPath + "." + d.DceObjectFilter
-				byFilter[info.objectFilter] = append(byFilter[info.objectFilter], info)
-			}
-			if d.DceMethodFilter != "" {
-				info.methodFilter = pkg.ImportPath + "." + d.DceMethodFilter
-				byFilter[info.methodFilter] = append(byFilter[info.methodFilter], info)
-			}
+			sel.Include(d, implementsLink)
 		}
 	}
-
-	dceSelection := make(map[*Decl]struct{}) // Known live decls.
-	for len(pendingDecls) != 0 {
-		d := pendingDecls[len(pendingDecls)-1]
-		pendingDecls = pendingDecls[:len(pendingDecls)-1]
-
-		dceSelection[d] = struct{}{} // Mark the decl as live.
-
-		// Consider all decls the current one is known to depend on and possible add
-		// them to the live queue.
-		for _, dep := range d.DceDeps {
-			if infos, ok := byFilter[dep]; ok {
-				delete(byFilter, dep)
-				for _, info := range infos {
-					if info.objectFilter == dep {
-						info.objectFilter = ""
-					}
-					if info.methodFilter == dep {
-						info.methodFilter = ""
-					}
-					if info.objectFilter == "" && info.methodFilter == "" {
-						pendingDecls = append(pendingDecls, info.decl)
-					}
-				}
-			}
-		}
-	}
+	dceSelection := sel.AliveDecls()
 
 	if _, err := w.Write([]byte("\"use strict\";\n(function() {\n\n")); err != nil {
 		return err

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -592,7 +592,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 			return fc.formatExpr(`$methodVal(%s, "%s")`, fc.makeReceiver(e), sel.Obj().(*types.Func).Name())
 		case types.MethodExpr:
 			if !sel.Obj().Exported() {
-				fc.DeclareDCEDep(sel.Obj())
+				fc.pkgCtx.DeclareDCEDep(sel.Obj())
 			}
 			if _, ok := sel.Recv().Underlying().(*types.Interface); ok {
 				return fc.formatExpr(`$ifaceMethodExpr("%s")`, sel.Obj().(*types.Func).Name())
@@ -911,7 +911,7 @@ func (fc *funcContext) delegatedCall(expr *ast.CallExpr) (callable *expression, 
 func (fc *funcContext) makeReceiver(e *ast.SelectorExpr) *expression {
 	sel, _ := fc.selectionOf(e)
 	if !sel.Obj().Exported() {
-		fc.DeclareDCEDep(sel.Obj())
+		fc.pkgCtx.DeclareDCEDep(sel.Obj())
 	}
 
 	x := e.X

--- a/compiler/internal/dce/collector.go
+++ b/compiler/internal/dce/collector.go
@@ -1,0 +1,46 @@
+package dce
+
+import (
+	"errors"
+	"go/types"
+)
+
+// Decl is any code declaration that has dead-code elimination (DCE)
+// information attached to it.
+type Decl interface {
+	Dce() *Info
+}
+
+// Collector is a tool to collect dependencies for a declaration
+// that'll be used in dead-code elimination (DCE).
+type Collector struct {
+	dependencies map[types.Object]struct{}
+}
+
+// CollectDCEDeps captures a list of Go objects (types, functions, etc.)
+// the code translated inside f() depends on. Then sets those objects
+// as dependencies of the given dead-code elimination info.
+//
+// Only one CollectDCEDeps call can be active at a time.
+// This will overwrite any previous dependencies collected for the given DCE.
+func (c *Collector) CollectDCEDeps(decl Decl, f func()) {
+	if c.dependencies != nil {
+		panic(errors.New(`called CollectDCEDeps inside another CollectDCEDeps call`))
+	}
+
+	c.dependencies = make(map[types.Object]struct{})
+	defer func() { c.dependencies = nil }()
+
+	f()
+
+	decl.Dce().setDeps(c.dependencies)
+}
+
+// DeclareDCEDep records that the code that is currently being transpiled
+// depends on a given Go object.
+func (c *Collector) DeclareDCEDep(o types.Object) {
+	if c.dependencies == nil {
+		return // Dependencies are not being collected.
+	}
+	c.dependencies[o] = struct{}{}
+}

--- a/compiler/internal/dce/dce_test.go
+++ b/compiler/internal/dce/dce_test.go
@@ -1,0 +1,631 @@
+package dce
+
+import (
+	"fmt"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+func Test_Collector_CalledOnce(t *testing.T) {
+	var c Collector
+	decl1 := &testDecl{}
+	decl2 := &testDecl{}
+
+	err := capturePanic(t, func() {
+		c.CollectDCEDeps(decl1, func() {
+			c.CollectDCEDeps(decl2, func() {
+				t.Fatal(`the nested collect function was called`)
+			})
+		})
+	})
+	errorMatches(t, err, `^called CollectDCEDeps inside another`)
+}
+
+func Test_Collector_Collecting(t *testing.T) {
+	pkg := testPackage(`tristan`)
+	obj1 := quickVar(pkg, `Primus`)
+	obj2 := quickVar(pkg, `Secundus`)
+	obj3 := quickVar(pkg, `Tertius`)
+	obj4 := quickVar(pkg, `Quartus`)
+	obj5 := quickVar(pkg, `Quintus`)
+	obj6 := quickVar(pkg, `Sextus`)
+	obj7 := quickVar(pkg, `Una`)
+
+	decl1 := quickTestDecl(obj1)
+	decl2 := quickTestDecl(obj2)
+	var c Collector
+
+	c.DeclareDCEDep(obj1) // no effect since a collection isn't running.
+	depCount(t, decl1, 0)
+	depCount(t, decl2, 0)
+
+	c.CollectDCEDeps(decl1, func() {
+		c.DeclareDCEDep(obj2)
+		c.DeclareDCEDep(obj3)
+		c.DeclareDCEDep(obj3) // already added so has no effect.
+	})
+	depCount(t, decl1, 2)
+	depCount(t, decl2, 0)
+
+	c.DeclareDCEDep(obj4) // no effect since a collection isn't running.
+	depCount(t, decl1, 2)
+	depCount(t, decl2, 0)
+
+	c.CollectDCEDeps(decl2, func() {
+		c.DeclareDCEDep(obj5)
+		c.DeclareDCEDep(obj6)
+		c.DeclareDCEDep(obj7)
+	})
+	depCount(t, decl1, 2)
+	depCount(t, decl2, 3)
+
+	// The second collection overwrites the first collection.
+	c.CollectDCEDeps(decl2, func() {
+		c.DeclareDCEDep(obj5)
+	})
+	depCount(t, decl1, 2)
+	depCount(t, decl2, 1)
+}
+
+func Test_Info_SetNameAndDep(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     types.Object
+		want    Info   // expected Info after SetName
+		wantDep string // expected dep after addDep
+	}{
+		{
+			name: `package`,
+			obj: parseObject(t, `Sarah`,
+				`package jim
+				import Sarah "fmt"`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Sarah`,
+			},
+			wantDep: `jim.Sarah`,
+		},
+		{
+			name: `exposed var`,
+			obj: parseObject(t, `Toby`,
+				`package jim
+				var Toby float64`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Toby`,
+			},
+			wantDep: `jim.Toby`,
+		},
+		{
+			name: `exposed const`,
+			obj: parseObject(t, `Ludo`,
+				`package jim
+				const Ludo int = 42`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Ludo`,
+			},
+			wantDep: `jim.Ludo`,
+		},
+		{
+			name: `label`,
+			obj: parseObject(t, `Gobo`,
+				`package jim
+				func main() {
+					i := 0
+				Gobo:
+					i++
+					if i < 10 {
+						goto Gobo
+					}
+				}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Gobo`,
+			},
+			wantDep: `jim.Gobo`,
+		},
+		{
+			name: `exposed specific type`,
+			obj: parseObject(t, `Jen`,
+				`package jim
+				type Jen struct{}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Jen`,
+			},
+			wantDep: `jim.Jen`,
+		},
+		{
+			name: `exposed generic type`,
+			obj: parseObject(t, `Henson`,
+				`package jim
+				type Henson[T comparable] struct{}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Henson`,
+			},
+			wantDep: `jim.Henson`,
+		},
+		{
+			name: `exposed specific function`,
+			obj: parseObject(t, `Jareth`,
+				`package jim
+				func Jareth() {}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Jareth`,
+			},
+			wantDep: `jim.Jareth`,
+		},
+		{
+			name: `exposed generic function`,
+			obj: parseObject(t, `Didymus`,
+				`package jim
+				func Didymus[T comparable]() {}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Didymus`,
+			},
+			wantDep: `jim.Didymus`,
+		},
+		{
+			name: `exposed specific method`,
+			obj: parseObject(t, `Kira`,
+				`package jim
+				type Fizzgig string
+				func (f Fizzgig) Kira() {}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Fizzgig`,
+			},
+			wantDep: `jim.Kira~`,
+		},
+		{
+			name: `unexposed specific method`,
+			obj: parseObject(t, `frank`,
+				`package jim
+				type Aughra int
+				func (a Aughra) frank() {}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `Aughra`,
+				methodFilter: `frank~`,
+			},
+			wantDep: `jim.frank~`,
+		},
+		{
+			name: `specific method on unexposed type`,
+			obj: parseObject(t, `Red`,
+				`package jim
+				type wembley struct{}
+				func (w wembley) Red() {}`),
+			want: Info{
+				importPath:   `jim`,
+				objectFilter: `wembley`,
+			},
+			wantDep: `jim.Red~`,
+		},
+	}
+
+	t.Run(`SetName`, func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				d := &testDecl{}
+				equal(t, d.Dce().unnamed(), true)
+				equal(t, d.Dce().String(), `[unnamed] . -> []`)
+				t.Log(`object:`, types.ObjectString(tt.obj, nil))
+
+				d.Dce().SetName(tt.obj)
+				equal(t, d.Dce().unnamed(), tt.want.unnamed())
+				equal(t, d.Dce().importPath, tt.want.importPath)
+				equal(t, d.Dce().objectFilter, tt.want.objectFilter)
+				equal(t, d.Dce().methodFilter, tt.want.methodFilter)
+				equal(t, d.Dce().String(), tt.want.String())
+			})
+		}
+	})
+
+	t.Run(`addDep`, func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				d := &testDecl{}
+				t.Log(`object:`, types.ObjectString(tt.obj, nil))
+
+				d.Dce().setDeps(map[types.Object]struct{}{
+					tt.obj: {},
+				})
+				equal(t, len(d.Dce().deps), 1)
+				equal(t, d.Dce().deps[0], tt.wantDep)
+			})
+		}
+	})
+}
+
+func Test_Info_SetNameOnlyOnce(t *testing.T) {
+	pkg := testPackage(`mogwai`)
+	obj1 := quickVar(pkg, `Gizmo`)
+	obj2 := quickVar(pkg, `Stripe`)
+
+	decl := &testDecl{}
+	decl.Dce().SetName(obj1)
+
+	err := capturePanic(t, func() {
+		decl.Dce().SetName(obj2)
+	})
+	errorMatches(t, err, `^may only set the name once for path/to/mogwai\.Gizmo .*$`)
+}
+
+func Test_Info_SetAsAlive(t *testing.T) {
+	pkg := testPackage(`fantasia`)
+
+	t.Run(`set alive prior to naming`, func(t *testing.T) {
+		obj := quickVar(pkg, `Falkor`)
+		decl := &testDecl{}
+		equal(t, decl.Dce().isAlive(), true) // unnamed is automatically alive
+		equal(t, decl.Dce().String(), `[unnamed] . -> []`)
+
+		decl.Dce().SetAsAlive()
+		equal(t, decl.Dce().isAlive(), true) // still alive but now explicitly alive
+		equal(t, decl.Dce().String(), `[alive] [unnamed] . -> []`)
+
+		decl.Dce().SetName(obj)
+		equal(t, decl.Dce().isAlive(), true) // alive because SetAsAlive was called
+		equal(t, decl.Dce().String(), `[alive] path/to/fantasia.Falkor -> []`)
+	})
+
+	t.Run(`set alive after naming`, func(t *testing.T) {
+		obj := quickVar(pkg, `Artax`)
+		decl := &testDecl{}
+		equal(t, decl.Dce().isAlive(), true) // unnamed is automatically alive
+		equal(t, decl.Dce().String(), `[unnamed] . -> []`)
+
+		decl.Dce().SetName(obj)
+		equal(t, decl.Dce().isAlive(), false) // named so no longer automatically alive
+		equal(t, decl.Dce().String(), `path/to/fantasia.Artax -> []`)
+
+		decl.Dce().SetAsAlive()
+		equal(t, decl.Dce().isAlive(), true) // alive because SetAsAlive was called
+		equal(t, decl.Dce().String(), `[alive] path/to/fantasia.Artax -> []`)
+	})
+}
+
+func Test_Selector_JustVars(t *testing.T) {
+	pkg := testPackage(`tolkien`)
+	frodo := quickTestDecl(quickVar(pkg, `Frodo`))
+	samwise := quickTestDecl(quickVar(pkg, `Samwise`))
+	meri := quickTestDecl(quickVar(pkg, `Meri`))
+	pippin := quickTestDecl(quickVar(pkg, `Pippin`))
+	aragorn := quickTestDecl(quickVar(pkg, `Aragorn`))
+	boromir := quickTestDecl(quickVar(pkg, `Boromir`))
+	gimli := quickTestDecl(quickVar(pkg, `Gimli`))
+	legolas := quickTestDecl(quickVar(pkg, `Legolas`))
+	gandalf := quickTestDecl(quickVar(pkg, `Gandalf`))
+	fellowship := []*testDecl{
+		frodo, samwise, meri, pippin, aragorn,
+		boromir, gimli, legolas, gandalf,
+	}
+
+	c := Collector{}
+	c.CollectDCEDeps(frodo, func() {
+		c.DeclareDCEDep(samwise.obj)
+		c.DeclareDCEDep(meri.obj)
+		c.DeclareDCEDep(pippin.obj)
+	})
+	c.CollectDCEDeps(pippin, func() {
+		c.DeclareDCEDep(meri.obj)
+	})
+	c.CollectDCEDeps(aragorn, func() {
+		c.DeclareDCEDep(boromir.obj)
+	})
+	c.CollectDCEDeps(gimli, func() {
+		c.DeclareDCEDep(legolas.obj)
+	})
+	c.CollectDCEDeps(legolas, func() {
+		c.DeclareDCEDep(gimli.obj)
+	})
+	c.CollectDCEDeps(gandalf, func() {
+		c.DeclareDCEDep(frodo.obj)
+		c.DeclareDCEDep(aragorn.obj)
+		c.DeclareDCEDep(gimli.obj)
+		c.DeclareDCEDep(legolas.obj)
+	})
+
+	for _, decl := range fellowship {
+		equal(t, decl.Dce().isAlive(), false)
+	}
+
+	tests := []struct {
+		name string
+		init []*testDecl // which decls to set explicitly alive
+		want []*testDecl // which decls should be determined as alive
+	}{
+		{
+			name: `all alive`,
+			init: fellowship,
+			want: fellowship,
+		},
+		{
+			name: `all dead`,
+			init: []*testDecl{},
+			want: []*testDecl{},
+		},
+		{
+			name: `Frodo`,
+			init: []*testDecl{frodo},
+			want: []*testDecl{frodo, samwise, meri, pippin},
+		},
+		{
+			name: `Sam and Pippin`,
+			init: []*testDecl{samwise, pippin},
+			want: []*testDecl{samwise, meri, pippin},
+		},
+		{
+			name: `Gandalf`,
+			init: []*testDecl{gandalf},
+			want: fellowship,
+		},
+		{
+			name: `Legolas`,
+			init: []*testDecl{legolas},
+			want: []*testDecl{legolas, gimli},
+		},
+		{
+			name: `Gimli`,
+			init: []*testDecl{gimli},
+			want: []*testDecl{legolas, gimli},
+		},
+		{
+			name: `Boromir`,
+			init: []*testDecl{boromir},
+			want: []*testDecl{boromir},
+		},
+		{
+			name: `Aragorn`,
+			init: []*testDecl{aragorn},
+			want: []*testDecl{aragorn, boromir},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, decl := range fellowship {
+				decl.Dce().alive = false
+			}
+			for _, decl := range tt.init {
+				decl.Dce().SetAsAlive()
+			}
+
+			s := &Selector[*testDecl]{}
+			for _, decl := range fellowship {
+				s.Include(decl, false)
+			}
+
+			selected := s.AliveDecls()
+			for _, decl := range tt.want {
+				if _, ok := selected[decl]; !ok {
+					t.Errorf(`expected %q to be alive`, decl.obj.String())
+				}
+				delete(selected, decl)
+			}
+			for decl := range selected {
+				t.Errorf(`expected %q to be dead`, decl.obj.String())
+			}
+		})
+	}
+}
+
+func Test_Selector_SpecificMethods(t *testing.T) {
+	objects := parseObjects(t,
+		`package pratchett
+
+		type rincewind struct{}
+		func (r rincewind) Run() {}
+		func (r rincewind) hide() {}
+
+		type Vimes struct{}
+		func (v Vimes) Run() {}
+		func (v Vimes) Read() {}
+
+		func Vetinari() {}`)
+
+	var (
+		// Objects are in read order so pick the objects we want for this test
+		// while skipping over `r rincewind` and `v Vimes`.
+		rincewind     = quickTestDecl(objects[0])
+		rincewindRun  = quickTestDecl(objects[2])
+		rincewindHide = quickTestDecl(objects[4])
+		vimes         = quickTestDecl(objects[5])
+		vimesRun      = quickTestDecl(objects[7])
+		vimesRead     = quickTestDecl(objects[9])
+		vetinari      = quickTestDecl(objects[10])
+	)
+	allDecls := []*testDecl{rincewind, rincewindRun, rincewindHide, vimes, vimesRun, vimesRead, vetinari}
+
+	c := Collector{}
+	c.CollectDCEDeps(rincewindRun, func() {
+		c.DeclareDCEDep(rincewind.obj)
+	})
+	c.CollectDCEDeps(rincewindHide, func() {
+		c.DeclareDCEDep(rincewind.obj)
+	})
+	c.CollectDCEDeps(vimesRun, func() {
+		c.DeclareDCEDep(vimes.obj)
+	})
+	c.CollectDCEDeps(vimesRead, func() {
+		c.DeclareDCEDep(vimes.obj)
+	})
+	vetinari.Dce().SetAsAlive()
+
+	tests := []struct {
+		name string
+		deps []*testDecl // which decls are vetinari dependent on
+		want []*testDecl // which decls should be determined as alive
+	}{
+		{
+			name: `no deps`,
+			deps: []*testDecl{},
+			want: []*testDecl{vetinari},
+		},
+		{
+			name: `structs`,
+			deps: []*testDecl{rincewind, vimes},
+			// rincewindHide is not included because it is not exported and not used.
+			want: []*testDecl{rincewind, rincewindRun, vimes, vimesRun, vimesRead, vetinari},
+		},
+		{
+			name: `exposed method`,
+			deps: []*testDecl{rincewind, rincewindRun},
+			want: []*testDecl{rincewind, rincewindRun, vetinari},
+		},
+		{
+			name: `unexposed method`,
+			deps: []*testDecl{rincewind, rincewindHide},
+			want: []*testDecl{rincewind, rincewindRun, rincewindHide, vetinari},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c.CollectDCEDeps(vetinari, func() {
+				for _, decl := range tt.deps {
+					c.DeclareDCEDep(decl.obj)
+				}
+			})
+
+			s := Selector[*testDecl]{}
+			for _, decl := range allDecls {
+				s.Include(decl, false)
+			}
+			selected := s.AliveDecls()
+			for _, decl := range tt.want {
+				if _, ok := selected[decl]; !ok {
+					t.Errorf(`expected %q to be alive`, decl.obj.String())
+				}
+				delete(selected, decl)
+			}
+			for decl := range selected {
+				t.Errorf(`expected %q to be dead`, decl.obj.String())
+			}
+		})
+	}
+}
+
+type testDecl struct {
+	obj types.Object // should match the object used in Dce.SetName when set
+	dce Info
+}
+
+func (d *testDecl) Dce() *Info {
+	return &d.dce
+}
+
+func testPackage(name string) *types.Package {
+	return types.NewPackage(`path/to/`+name, name)
+}
+
+func quickTestDecl(o types.Object) *testDecl {
+	d := &testDecl{obj: o}
+	d.Dce().SetName(o)
+	return d
+}
+
+func quickVar(pkg *types.Package, name string) *types.Var {
+	return types.NewVar(token.NoPos, pkg, name, types.Typ[types.Int])
+}
+
+func parseObject(t *testing.T, name, source string) types.Object {
+	t.Helper()
+	objects := parseObjects(t, source)
+	for _, obj := range objects {
+		if obj.Name() == name {
+			return obj
+		}
+	}
+	t.Fatalf(`object %q not found`, name)
+	return nil
+}
+
+func parseObjects(t *testing.T, source string) []types.Object {
+	t.Helper()
+	info := &types.Info{
+		Defs: map[*ast.Ident]types.Object{},
+	}
+	parseInfo(t, source, info)
+	objects := make([]types.Object, 0, len(info.Defs))
+	for _, obj := range info.Defs {
+		if obj != nil {
+			objects = append(objects, obj)
+		}
+	}
+	sort.Slice(objects, func(i, j int) bool {
+		return objects[i].Pos() < objects[j].Pos()
+	})
+	return objects
+}
+
+func parseInfo(t *testing.T, source string, info *types.Info) *types.Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, `test.go`, source, 0)
+	if err != nil {
+		t.Fatal(`parsing source:`, err)
+	}
+
+	conf := types.Config{
+		Importer:                 importer.Default(),
+		DisableUnusedImportCheck: true,
+	}
+	pkg, err := conf.Check(f.Name.Name, fset, []*ast.File{f}, info)
+	if err != nil {
+		t.Fatal(`type checking:`, err)
+	}
+	return pkg
+}
+
+func capturePanic(t *testing.T, f func()) (err error) {
+	t.Helper()
+	defer func() {
+		t.Helper()
+		if r := recover(); r != nil {
+			if err2, ok := r.(error); ok {
+				err = err2
+				return
+			}
+			t.Errorf(`expected an error to be panicked but got (%[1]T) %[1]#v`, r)
+			return
+		}
+		t.Error(`expected a panic but got none`)
+	}()
+
+	f()
+	return nil
+}
+
+func errorMatches(t *testing.T, err error, wantPattern string) {
+	t.Helper()
+	re := regexp.MustCompile(wantPattern)
+	if got := fmt.Sprint(err); !re.MatchString(got) {
+		t.Errorf(`expected error %q to match %q`, got, re.String())
+	}
+}
+
+func depCount(t *testing.T, decl *testDecl, want int) {
+	t.Helper()
+	if got := len(decl.Dce().deps); got != want {
+		t.Errorf(`expected %d deps but got %d`, want, got)
+	}
+}
+
+func equal[T comparable](t *testing.T, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf(`expected %#v but got %#v`, want, got)
+	}
+}

--- a/compiler/internal/dce/info.go
+++ b/compiler/internal/dce/info.go
@@ -1,0 +1,108 @@
+package dce
+
+import (
+	"fmt"
+	"go/types"
+	"sort"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/typesutil"
+)
+
+// Info contains information used by the dead-code elimination (DCE) logic to
+// determine whether a declaration is alive or dead.
+type Info struct {
+
+	// alive indicates if the declaration is marked as alive
+	// and will not be eliminated.
+	alive bool
+
+	// importPath is the package path of the package the declaration is in.
+	importPath string
+
+	// Symbol's identifier used by the dead-code elimination logic, not including
+	// package path. If empty, the symbol is assumed to be alive and will not be
+	// eliminated. For methods it is the same as its receiver type identifier.
+	objectFilter string
+
+	// The second part of the identified used by dead-code elimination for methods.
+	// Empty for other types of symbols.
+	methodFilter string
+
+	// List of fully qualified (including package path) DCE symbol identifiers the
+	// symbol depends on for dead code elimination purposes.
+	deps []string
+}
+
+// String gets a human-readable representation of the DCE info.
+func (d *Info) String() string {
+	tags := ``
+	if d.alive {
+		tags += `[alive] `
+	}
+	if d.unnamed() {
+		tags += `[unnamed] `
+	}
+	fullName := d.importPath + `.` + d.objectFilter
+	if len(d.methodFilter) > 0 {
+		fullName += `.` + d.methodFilter
+	}
+	return tags + fullName + ` -> [` + strings.Join(d.deps, `, `) + `]`
+}
+
+// unnamed returns true if SetName has not been called for this declaration.
+// This indicates that the DCE is not initialized.
+func (d *Info) unnamed() bool {
+	return d.objectFilter == `` && d.methodFilter == ``
+}
+
+// isAlive returns true if the declaration is marked as alive.
+//
+// Returns true if SetAsAlive was called on this declaration or
+// if SetName was not called meaning the DCE is not initialized.
+func (d *Info) isAlive() bool {
+	return d.alive || d.unnamed()
+}
+
+// SetAsAlive marks the declaration as alive, meaning it will not be eliminated.
+//
+// This should be called by an entry point (like main() or init() functions)
+// or a variable initializer which has a side effect, consider it live.
+func (d *Info) SetAsAlive() {
+	d.alive = true
+}
+
+// SetName sets the name used by DCE to represent the declaration
+// this DCE info is attached to.
+func (d *Info) SetName(o types.Object) {
+	if !d.unnamed() {
+		panic(fmt.Errorf(`may only set the name once for %s`, d.String()))
+	}
+
+	d.importPath = o.Pkg().Path()
+	if typesutil.IsMethod(o) {
+		recv := typesutil.RecvType(o.Type().(*types.Signature)).Obj()
+		d.objectFilter = recv.Name()
+		if !o.Exported() {
+			d.methodFilter = o.Name() + `~`
+		}
+	} else {
+		d.objectFilter = o.Name()
+	}
+}
+
+// setDeps sets the declaration dependencies used by DCE
+// for the declaration this DCE info is attached to.
+// This overwrites any prior set dependencies.
+func (d *Info) setDeps(objectSet map[types.Object]struct{}) {
+	deps := make([]string, 0, len(objectSet))
+	for o := range objectSet {
+		qualifiedName := o.Pkg().Path() + "." + o.Name()
+		if typesutil.IsMethod(o) {
+			qualifiedName += "~"
+		}
+		deps = append(deps, qualifiedName)
+	}
+	sort.Strings(deps)
+	d.deps = deps
+}

--- a/compiler/internal/dce/selector.go
+++ b/compiler/internal/dce/selector.go
@@ -1,0 +1,93 @@
+package dce
+
+// DeclConstraint is type constraint for any code declaration that has
+// dead-code elimination (DCE) information attached to it and will be
+// used in a set.
+type DeclConstraint interface {
+	Decl
+	comparable
+}
+
+// Selector gathers all declarations that are still alive after dead-code elimination.
+type Selector[D DeclConstraint] struct {
+	byFilter map[string][]*declInfo[D]
+
+	// A queue of live decls to find other live decls.
+	pendingDecls []D
+}
+
+type declInfo[D DeclConstraint] struct {
+	decl         D
+	objectFilter string
+	methodFilter string
+}
+
+// Include will add a new declaration to be checked as alive or not.
+func (s *Selector[D]) Include(decl D, implementsLink bool) {
+	if s.byFilter == nil {
+		s.byFilter = make(map[string][]*declInfo[D])
+	}
+
+	dce := decl.Dce()
+
+	if dce.isAlive() {
+		s.pendingDecls = append(s.pendingDecls, decl)
+		return
+	}
+
+	if implementsLink {
+		s.pendingDecls = append(s.pendingDecls, decl)
+	}
+
+	info := &declInfo[D]{decl: decl}
+
+	if dce.objectFilter != `` {
+		info.objectFilter = dce.importPath + `.` + dce.objectFilter
+		s.byFilter[info.objectFilter] = append(s.byFilter[info.objectFilter], info)
+	}
+
+	if dce.methodFilter != `` {
+		info.methodFilter = dce.importPath + `.` + dce.methodFilter
+		s.byFilter[info.methodFilter] = append(s.byFilter[info.methodFilter], info)
+	}
+}
+
+func (s *Selector[D]) popPending() D {
+	max := len(s.pendingDecls) - 1
+	d := s.pendingDecls[max]
+	s.pendingDecls = s.pendingDecls[:max]
+	return d
+}
+
+// AliveDecls returns a set of declarations that are still alive
+// after dead-code elimination.
+// This should only be called once all declarations have been included.
+func (s *Selector[D]) AliveDecls() map[D]struct{} {
+	dceSelection := make(map[D]struct{}) // Known live decls.
+	for len(s.pendingDecls) != 0 {
+		d := s.popPending()
+		dce := d.Dce()
+
+		dceSelection[d] = struct{}{} // Mark the decl as live.
+
+		// Consider all decls the current one is known to depend on and possible add
+		// them to the live queue.
+		for _, dep := range dce.deps {
+			if infos, ok := s.byFilter[dep]; ok {
+				delete(s.byFilter, dep)
+				for _, info := range infos {
+					if info.objectFilter == dep {
+						info.objectFilter = ``
+					}
+					if info.methodFilter == dep {
+						info.methodFilter = ``
+					}
+					if info.objectFilter == `` && info.methodFilter == `` {
+						s.pendingDecls = append(s.pendingDecls, info.decl)
+					}
+				}
+			}
+		}
+	}
+	return dceSelection
+}

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gopherjs/gopherjs/compiler/analysis"
+	"github.com/gopherjs/gopherjs/compiler/internal/dce"
 	"github.com/gopherjs/gopherjs/compiler/internal/typeparams"
 	"github.com/gopherjs/gopherjs/compiler/typesutil"
 	"github.com/gopherjs/gopherjs/internal/experiments"
@@ -21,6 +22,7 @@ import (
 // pkgContext maintains compiler context for a specific package.
 type pkgContext struct {
 	*analysis.Info
+	dce.Collector
 	additionalSelections map[*ast.SelectorExpr]typesutil.Selection
 
 	typesCtx *types.Context
@@ -35,7 +37,6 @@ type pkgContext struct {
 	anonTypeMap  typeutil.Map
 	escapingVars map[*types.Var]bool
 	indentation  int
-	dependencies map[types.Object]bool
 	minify       bool
 	fileSet      *token.FileSet
 	errList      ErrorList
@@ -125,7 +126,6 @@ func newRootCtx(tContext *types.Context, srcs sources, typesInfo *types.Info, ty
 			varPtrNames:  make(map[*types.Var]string),
 			escapingVars: make(map[*types.Var]bool),
 			indentation:  1,
-			dependencies: nil,
 			minify:       minify,
 			fileSet:      srcs.FileSet,
 			instanceSet:  tc.Instances,

--- a/compiler/statements.go
+++ b/compiler/statements.go
@@ -445,7 +445,7 @@ func (fc *funcContext) translateStmt(stmt ast.Stmt, label *types.Label) {
 			for _, spec := range decl.Specs {
 				o := fc.pkgCtx.Defs[spec.(*ast.TypeSpec).Name].(*types.TypeName)
 				fc.pkgCtx.typeNames.Add(o)
-				fc.DeclareDCEDep(o)
+				fc.pkgCtx.DeclareDCEDep(o)
 			}
 		case token.CONST:
 			// skip, constants are inlined

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -102,43 +102,6 @@ func (fc *funcContext) Delayed(f func()) {
 	fc.delayedOutput = fc.CatchOutput(0, f)
 }
 
-// CollectDCEDeps captures a list of Go objects (types, functions, etc.)
-// the code translated inside f() depends on. The returned list of identifiers
-// can be used in dead-code elimination.
-//
-// Note that calling CollectDCEDeps() inside another CollectDCEDeps() call is
-// not allowed.
-func (fc *funcContext) CollectDCEDeps(f func()) []string {
-	if fc.pkgCtx.dependencies != nil {
-		panic(bailout(fmt.Errorf("called funcContext.CollectDependencies() inside another funcContext.CollectDependencies() call")))
-	}
-
-	fc.pkgCtx.dependencies = make(map[types.Object]bool)
-	defer func() { fc.pkgCtx.dependencies = nil }()
-
-	f()
-
-	var deps []string
-	for o := range fc.pkgCtx.dependencies {
-		qualifiedName := o.Pkg().Path() + "." + o.Name()
-		if typesutil.IsMethod(o) {
-			qualifiedName += "~"
-		}
-		deps = append(deps, qualifiedName)
-	}
-	sort.Strings(deps)
-	return deps
-}
-
-// DeclareDCEDep records that the code that is currently being transpiled
-// depends on a given Go object.
-func (fc *funcContext) DeclareDCEDep(o types.Object) {
-	if fc.pkgCtx.dependencies == nil {
-		return // Dependencies are not being collected.
-	}
-	fc.pkgCtx.dependencies[o] = true
-}
-
 // expandTupleArgs converts a function call which argument is a tuple returned
 // by another function into a set of individual call arguments corresponding to
 // tuple elements.
@@ -428,7 +391,7 @@ func (fc *funcContext) assignedObjectName(o types.Object) (name string, found bo
 // allocated as needed.
 func (fc *funcContext) objectName(o types.Object) string {
 	if isPkgLevel(o) {
-		fc.DeclareDCEDep(o)
+		fc.pkgCtx.DeclareDCEDep(o)
 
 		if o.Pkg() != fc.pkgCtx.Pkg || (isVarOrConst(o) && o.Exported()) {
 			return fc.pkgVar(o.Pkg()) + "." + o.Name()
@@ -523,7 +486,7 @@ func (fc *funcContext) typeName(ty types.Type) string {
 		fc.pkgCtx.anonTypes = append(fc.pkgCtx.anonTypes, anonType)
 		fc.pkgCtx.anonTypeMap.Set(ty, anonType)
 	}
-	fc.DeclareDCEDep(anonType)
+	fc.pkgCtx.DeclareDCEDep(anonType)
 	return anonType.Name()
 }
 


### PR DESCRIPTION
The dead-code elimination (DCE) code has two filter strings and dependencies as a set of strings. The strings have special meanings such as both empty strings indicate always alive. To help facilitate future changes to DCE, I'm moving the DCE code to it's own package. Also I'm making some methods to set a decl's DCE filters and deps to ensure that the names are continued to be set the same as new changes are made.

These changes should have only minor functional changes, everything should continue to function as before. These changes are mostly a minor refactor to encapsulate DCE design decisions. The CI should continue to pass.

This is related to #1270 work since the future changes to DCE is to include removal of dead generic code instantiations, e.g. allow `List[int]` to be alive and `List[string]` be dead separately. 