### PR TITLE
Fixing issue in `len` with string concatenation in argument

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -982,6 +982,10 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 	case "len":
 		switch argType := fc.typeOf(args[0]).Underlying().(type) {
 		case *types.Basic:
+			// If the argument is a concatenation of strings, then add parentheses.
+			if _, ok := args[0].(*ast.BinaryExpr); ok {
+				return fc.formatExpr("(%e).length", args[0])
+			}
 			return fc.formatExpr("%e.length", args[0])
 		case *types.Slice:
 			return fc.formatExpr("%e.$length", args[0])


### PR DESCRIPTION
This is a fix for #841 

I added a check to see if the expression used as the argument inside the `len` contains binary expressions. If a binary expression exists, then the expression is parenthesized. For example, `len(a)` will still be translated to `a.length` without the parenthesis. `len(a +b)` was getting translated to `a + b.lengh` (which was the problem), but now get translated into `(a + b).length` with parenthesis. We don't want to add parenthesis all the time to avoid making the resulting JS larger when not needed.

This will cover any combination of concatenations of variable and literal strings, e.g. `len(a + b)`, `len(a + ":" + b)`. The issue exists only when a basic type is used in `len`, i.e. `string`. I didn't limit the check to only being additions (`+`) for concatenation of strings, even though no other binary operator applies to a string, to allow more robustness for future changes (e.g. if Go suddenly decides to be more like python and add `-` and `*` as operators allowed to use on strings). This work does not need to be carried over to `cap` since `cap` is not valid for strings.
