### PR TITLE
Fixing issues in analysis around generics

### DIFF
--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -82,7 +82,7 @@ func (fc *funcContext) namedFuncContext(inst typeparams.Instance) *funcContext {
 // go/types doesn't generate *types.Func objects for function literals, we
 // generate a synthetic one for it.
 func (fc *funcContext) literalFuncContext(fun *ast.FuncLit) *funcContext {
-	info := fc.pkgCtx.FuncLitInfo(fun)
+	info := fc.pkgCtx.FuncLitInfo(fun, fc.TypeArgs())
 	sig := fc.pkgCtx.TypeOf(fun).(*types.Signature)
 	o := types.NewFunc(fun.Pos(), fc.pkgCtx.Pkg, fc.newLitFuncName(), sig)
 	inst := typeparams.Instance{Object: o}

--- a/compiler/internal/analysis/info_test.go
+++ b/compiler/internal/analysis/info_test.go
@@ -156,10 +156,10 @@ func TestBlocking_GoRoutines_WithFuncLiterals(t *testing.T) {
 			}(<-c)
 		}`)
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertBlockingLit(4)
+	bt.assertBlockingLit(4, ``)
 
 	bt.assertBlocking(`blocking`)
-	bt.assertNotBlockingLit(10)
+	bt.assertNotBlockingLit(10, ``)
 }
 
 func TestBlocking_GoRoutines_WithNamedFuncs(t *testing.T) {
@@ -210,13 +210,13 @@ func TestBlocking_Defers_WithoutReturns_WithFuncLiterals(t *testing.T) {
 			}(true)
 		}`)
 	bt.assertBlocking(`blockingBody`)
-	bt.assertBlockingLit(4)
+	bt.assertBlockingLit(4, ``)
 
 	bt.assertBlocking(`blockingArg`)
-	bt.assertNotBlockingLit(10)
+	bt.assertNotBlockingLit(10, ``)
 
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertNotBlockingLit(16)
+	bt.assertNotBlockingLit(16, ``)
 }
 
 func TestBlocking_Defers_WithoutReturns_WithNamedFuncs(t *testing.T) {
@@ -278,13 +278,13 @@ func TestBlocking_Defers_WithReturns_WithFuncLiterals(t *testing.T) {
 			return 42
 		}`)
 	bt.assertBlocking(`blockingBody`)
-	bt.assertBlockingLit(4)
+	bt.assertBlockingLit(4, ``)
 
 	bt.assertBlocking(`blockingArg`)
-	bt.assertNotBlockingLit(11)
+	bt.assertNotBlockingLit(11, ``)
 
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertNotBlockingLit(18)
+	bt.assertNotBlockingLit(18, ``)
 }
 
 func TestBlocking_Defers_WithReturns_WithNamedFuncs(t *testing.T) {
@@ -317,15 +317,15 @@ func TestBlocking_Defers_WithReturns_WithNamedFuncs(t *testing.T) {
 	bt.assertNotBlocking(`nonBlockingPrint`)
 
 	bt.assertBlocking(`blockingBody`)
-	bt.assertBlockingReturn(13)
+	bt.assertBlockingReturn(13, ``)
 
 	bt.assertBlocking(`blockingArg`)
 	// The defer is non-blocking so the return is not blocking
 	// even though the function is blocking.
-	bt.assertNotBlockingReturn(18)
+	bt.assertNotBlockingReturn(18, ``)
 
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertNotBlockingReturn(23)
+	bt.assertNotBlockingReturn(23, ``)
 }
 
 func TestBlocking_Defers_WithMultipleReturns(t *testing.T) {
@@ -363,15 +363,15 @@ func TestBlocking_Defers_WithMultipleReturns(t *testing.T) {
 			return true // line 31
 		}`)
 	bt.assertBlocking(`foo`)
-	bt.assertNotBlockingLit(4)
+	bt.assertNotBlockingLit(4, ``)
 	// Early escape from function without blocking defers is not blocking.
-	bt.assertNotBlockingReturn(11)
-	bt.assertNotBlockingLit(14)
+	bt.assertNotBlockingReturn(11, ``)
+	bt.assertNotBlockingLit(14, ``)
 	// Function has had blocking by this point but no blocking defers yet.
-	bt.assertNotBlockingReturn(20)
-	bt.assertBlockingLit(24)
+	bt.assertNotBlockingReturn(20, ``)
+	bt.assertBlockingLit(24, ``)
 	// The return is blocking because of a blocking defer.
-	bt.assertBlockingReturn(28)
+	bt.assertBlockingReturn(28, ``)
 	// Technically the return on line 31 is not blocking since the defer that
 	// is blocking can only exit through the return on line 28, but it would be
 	// difficult to determine which defers would only affect certain returns
@@ -384,7 +384,7 @@ func TestBlocking_Defers_WithMultipleReturns(t *testing.T) {
 	//
 	// For now we simply build up the list of defers as we go making
 	// the return on line 31 also blocking.
-	bt.assertBlockingReturn(31)
+	bt.assertBlockingReturn(31, ``)
 }
 
 func TestBlocking_Defers_WithReturnsAndDefaultBlocking(t *testing.T) {
@@ -453,12 +453,12 @@ func TestBlocking_Defers_WithReturnsAndDefaultBlocking(t *testing.T) {
 	bt.assertBlocking(`deferMappedFuncCall`)
 
 	// All of these returns are blocking because they have blocking defers.
-	bt.assertBlockingReturn(17)
-	bt.assertBlockingReturn(22)
-	bt.assertBlockingReturn(28)
-	bt.assertBlockingReturn(34)
-	bt.assertBlockingReturn(40)
-	bt.assertBlockingReturn(49)
+	bt.assertBlockingReturn(17, ``)
+	bt.assertBlockingReturn(22, ``)
+	bt.assertBlockingReturn(28, ``)
+	bt.assertBlockingReturn(34, ``)
+	bt.assertBlockingReturn(40, ``)
+	bt.assertBlockingReturn(49, ``)
 }
 
 func TestBlocking_Defers_WithReturnsAndDeferBuiltin(t *testing.T) {
@@ -477,7 +477,7 @@ func TestBlocking_Defers_WithReturnsAndDeferBuiltin(t *testing.T) {
 
 	bt.assertFuncInstCount(1)
 	bt.assertNotBlocking(`deferBuiltinCall`)
-	bt.assertNotBlockingReturn(10)
+	bt.assertNotBlockingReturn(10, ``)
 }
 
 func TestBlocking_Defers_WithReturnsInLoops(t *testing.T) {
@@ -575,14 +575,14 @@ func TestBlocking_Defers_WithReturnsInLoops(t *testing.T) {
 	// When the following 2 returns are defined there are no defers, however,
 	// because of the loop, the blocking defers defined after the return will
 	// block the returns.
-	bt.assertBlockingReturn(12)
-	bt.assertBlockingReturn(22)
-	bt.assertBlockingReturn(31)
-	bt.assertBlockingReturn(44)
-	bt.assertBlockingReturn(52)
-	bt.assertBlockingReturn(66)
-	bt.assertBlockingReturn(73)
-	bt.assertBlockingReturn(77)
+	bt.assertBlockingReturn(12, ``)
+	bt.assertBlockingReturn(22, ``)
+	bt.assertBlockingReturn(31, ``)
+	bt.assertBlockingReturn(44, ``)
+	bt.assertBlockingReturn(52, ``)
+	bt.assertBlockingReturn(66, ``)
+	bt.assertBlockingReturn(73, ``)
+	bt.assertBlockingReturn(77, ``)
 }
 
 func TestBlocking_Defers_WithReturnsInLoopsInLoops(t *testing.T) {
@@ -652,19 +652,19 @@ func TestBlocking_Defers_WithReturnsInLoopsInLoops(t *testing.T) {
 	bt.assertFuncInstCount(4)
 	bt.assertBlocking(`blocking`)
 	bt.assertBlocking(`forLoopTheLoop`)
-	bt.assertNotBlockingReturn(9)
-	bt.assertBlockingReturn(13)
-	bt.assertBlockingReturn(17)
-	bt.assertBlockingReturn(21)
-	bt.assertBlockingReturn(25)
-	bt.assertBlockingReturn(28)
+	bt.assertNotBlockingReturn(9, ``)
+	bt.assertBlockingReturn(13, ``)
+	bt.assertBlockingReturn(17, ``)
+	bt.assertBlockingReturn(21, ``)
+	bt.assertBlockingReturn(25, ``)
+	bt.assertBlockingReturn(28, ``)
 	bt.assertBlocking(`rangeLoopTheLoop`)
-	bt.assertBlockingReturn(36)
-	bt.assertBlockingReturn(41)
+	bt.assertBlockingReturn(36, ``)
+	bt.assertBlockingReturn(41, ``)
 	bt.assertBlocking(`noopThenLoop`)
-	bt.assertNotBlockingReturn(48)
-	bt.assertBlockingReturn(54)
-	bt.assertBlockingReturn(58)
+	bt.assertNotBlockingReturn(48, ``)
+	bt.assertBlockingReturn(54, ``)
+	bt.assertBlockingReturn(58, ``)
 }
 
 func TestBlocking_Returns_WithoutDefers(t *testing.T) {
@@ -693,19 +693,67 @@ func TestBlocking_Returns_WithoutDefers(t *testing.T) {
 			return true // line 22
 		}`)
 	bt.assertBlocking(`blocking`)
-	bt.assertBlockingReturn(4)
+	bt.assertBlockingReturn(4, ``)
 
 	bt.assertBlocking(`blockingBeforeReturn`)
-	bt.assertNotBlockingReturn(9)
+	bt.assertNotBlockingReturn(9, ``)
 
 	bt.assertBlocking(`indirectlyBlocking`)
-	bt.assertBlockingReturn(13)
+	bt.assertBlockingReturn(13, ``)
 
 	bt.assertBlocking(`indirectlyBlockingBeforeReturn`)
-	bt.assertNotBlockingReturn(18)
+	bt.assertNotBlockingReturn(18, ``)
 
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertNotBlockingReturn(22)
+	bt.assertNotBlockingReturn(22, ``)
+}
+
+func TestBlocking_Defers_WithReturnsInInstances(t *testing.T) {
+	// This is an example of a deferred function literal inside of
+	// an instance of a generic function affecting the return
+	// differently based on the type arguments of the instance.
+	bt := newBlockingTest(t,
+		`package test
+
+		type BazBlocker struct {
+			c chan bool
+		}
+		func (bb BazBlocker) Baz() {
+			println(<-bb.c)
+		}
+
+		type BazNotBlocker struct {}
+		func (bnb BazNotBlocker) Baz() {
+			println("hi")
+		}
+
+		type Foo interface { Baz() }
+		func FooBaz[T Foo]() bool {
+			defer func() { // line 17
+				var foo T
+				foo.Baz()
+			}()
+			return true // line 21
+		}
+
+		func main() {
+			FooBaz[BazBlocker]()
+			FooBaz[BazNotBlocker]()
+		}`)
+
+	bt.assertFuncInstCount(5)
+	bt.assertBlocking(`BazBlocker.Baz`)
+	bt.assertNotBlocking(`BazNotBlocker.Baz`)
+	bt.assertBlockingInst(`pkg/test.FooBaz<pkg/test.BazBlocker>`)
+	bt.assertNotBlockingInst(`pkg/test.FooBaz<pkg/test.BazNotBlocker>`)
+	bt.assertBlocking(`main`)
+
+	bt.assertFuncLitCount(2)
+	bt.assertBlockingLit(17, `pkg/test.BazBlocker`)
+	bt.assertNotBlockingLit(17, `pkg/test.BazNotBlocker`)
+
+	bt.assertBlockingReturn(21, `pkg/test.BazBlocker`)
+	bt.assertNotBlockingReturn(21, `pkg/test.BazNotBlocker`)
 }
 
 func TestBlocking_Defers_WithReturnsAndOtherPackages(t *testing.T) {
@@ -737,10 +785,10 @@ func TestBlocking_Defers_WithReturnsAndOtherPackages(t *testing.T) {
 	bt := newBlockingTestWithOtherPackage(t, testSrc, otherSrc)
 
 	bt.assertBlocking(`deferOtherBlocking`)
-	bt.assertBlockingReturn(7)
+	bt.assertBlockingReturn(7, ``)
 
 	bt.assertNotBlocking(`deferOtherNotBlocking`)
-	bt.assertNotBlockingReturn(12)
+	bt.assertNotBlockingReturn(12, ``)
 }
 
 func TestBlocking_FunctionLiteral(t *testing.T) {
@@ -770,13 +818,13 @@ func TestBlocking_FunctionLiteral(t *testing.T) {
 	bt.assertBlocking(`blocking`)
 
 	bt.assertBlocking(`indirectlyBlocking`)
-	bt.assertBlockingLit(9)
+	bt.assertBlockingLit(9, ``)
 
 	bt.assertBlocking(`directlyBlocking`)
-	bt.assertBlockingLit(13)
+	bt.assertBlockingLit(13, ``)
 
 	bt.assertNotBlocking(`notBlocking`)
-	bt.assertNotBlockingLit(20)
+	bt.assertNotBlockingLit(20, ``)
 }
 
 func TestBlocking_LinkedFunction(t *testing.T) {
@@ -818,9 +866,9 @@ func TestBlocking_Instances_WithSingleTypeArg(t *testing.T) {
 	// blocking and notBlocking as generics do not have FuncInfo,
 	// only non-generic and instances have FuncInfo.
 
-	bt.assertBlockingInst(`test.blocking[int]`)
+	bt.assertBlockingInst(`pkg/test.blocking<int>`)
 	bt.assertBlocking(`bInt`)
-	bt.assertNotBlockingInst(`test.notBlocking[uint]`)
+	bt.assertNotBlockingInst(`pkg/test.notBlocking<uint>`)
 	bt.assertNotBlocking(`nbUint`)
 }
 
@@ -849,9 +897,9 @@ func TestBlocking_Instances_WithMultipleTypeArgs(t *testing.T) {
 	// blocking and notBlocking as generics do not have FuncInfo,
 	// only non-generic and instances have FuncInfo.
 
-	bt.assertBlockingInst(`test.blocking[string, int, map[string]int]`)
+	bt.assertBlockingInst(`pkg/test.blocking<string, int, map[string]int>`)
 	bt.assertBlocking(`bInt`)
-	bt.assertNotBlockingInst(`test.notBlocking[string, uint, map[string]uint]`)
+	bt.assertNotBlockingInst(`pkg/test.notBlocking<string, uint, map[string]uint>`)
 	bt.assertNotBlocking(`nbUint`)
 }
 
@@ -1075,7 +1123,7 @@ func TestBlocking_VarFunctionCall(t *testing.T) {
 		func bar() {
 			foo()
 		}`)
-	bt.assertNotBlockingLit(3)
+	bt.assertNotBlockingLit(3, ``)
 	bt.assertBlocking(`bar`)
 }
 
@@ -1233,12 +1281,12 @@ func TestBlocking_InstantiationBlocking(t *testing.T) {
 	bt.assertBlocking(`BazBlocker.Baz`)
 	bt.assertBlocking(`blockingViaExplicit`)
 	bt.assertBlocking(`blockingViaImplicit`)
-	bt.assertBlockingInst(`test.FooBaz[pkg/test.BazBlocker]`)
+	bt.assertBlockingInst(`pkg/test.FooBaz<pkg/test.BazBlocker>`)
 
 	bt.assertNotBlocking(`BazNotBlocker.Baz`)
 	bt.assertNotBlocking(`notBlockingViaExplicit`)
 	bt.assertNotBlocking(`notBlockingViaImplicit`)
-	bt.assertNotBlockingInst(`test.FooBaz[pkg/test.BazNotBlocker]`)
+	bt.assertNotBlockingInst(`pkg/test.FooBaz<pkg/test.BazNotBlocker>`)
 }
 
 func TestBlocking_NestedInstantiations(t *testing.T) {
@@ -1272,12 +1320,129 @@ func TestBlocking_NestedInstantiations(t *testing.T) {
 	bt.assertFuncInstCount(8)
 	bt.assertNotBlocking(`bazInt`)
 	bt.assertNotBlocking(`bazString`)
-	bt.assertNotBlockingInst(`test.Foo[map[int]int]`)
-	bt.assertNotBlockingInst(`test.Foo[map[int]string]`)
-	bt.assertNotBlockingInst(`test.Bar[int, int, map[int]int]`)
-	bt.assertNotBlockingInst(`test.Bar[int, string, map[int]string]`)
-	bt.assertNotBlockingInst(`test.Baz[int, []int]`)
-	bt.assertNotBlockingInst(`test.Baz[string, []string]`)
+	bt.assertNotBlockingInst(`pkg/test.Foo<map[int]int>`)
+	bt.assertNotBlockingInst(`pkg/test.Foo<map[int]string>`)
+	bt.assertNotBlockingInst(`pkg/test.Bar<int, int, map[int]int>`)
+	bt.assertNotBlockingInst(`pkg/test.Bar<int, string, map[int]string>`)
+	bt.assertNotBlockingInst(`pkg/test.Baz<int, []int>`)
+	bt.assertNotBlockingInst(`pkg/test.Baz<string, []string>`)
+}
+
+func TestBlocking_UnusedGenericFunctions(t *testing.T) {
+	// Checking that the type parameters are being propagated down into callee.
+	// This is based off of go1.19.13/test/typeparam/orderedmap.go
+	bt := newBlockingTest(t,
+		`package test
+
+		type node[K, V any] struct {
+			key         K
+			val         V
+			left, right *node[K, V]
+		}
+
+		type Tree[K, V any] struct {
+			root *node[K, V]
+			eq   func(K, K) bool
+		}
+
+		func New[K, V any](eq func(K, K) bool) *Tree[K, V] {
+			return &Tree[K, V]{eq: eq}
+		}
+
+		func NewStrKey[K ~string, V any]() *Tree[K, V] { // unused
+			return New[K, V](func(k1, k2 K) bool {
+				return string(k1) == string(k2)
+			})
+		}
+
+		func NewStrStr[V any]() *Tree[string, V] { // unused
+			return NewStrKey[string, V]()
+		}
+
+		func main() {
+			t := New[int, string](func(k1, k2 int) bool {
+				return k1 == k2
+			})
+			println(t)
+		}`)
+	bt.assertFuncInstCount(2)
+	// Notice that `NewStrKey` and `NewStrStr` are not called so doesn't have
+	// any known instances and therefore they don't have any FuncInfos.
+	bt.assertNotBlockingInst(`pkg/test.New<int, string>`)
+	bt.assertNotBlocking(`main`)
+}
+
+func TestBlocking_LitInstanceCalls(t *testing.T) {
+	// Literals defined inside a generic function must inherit the
+	// type arguments (resolver) of the enclosing instance it is defined in
+	// so that things like calls to other generic functions create the
+	// call to the correct concrete instance.
+	bt := newBlockingTest(t,
+		`package test
+
+		func foo[T any](x T) {
+			println(x)
+		}
+
+		func bar[T any](x T) {
+			f := func(v T) { // line 8
+				foo[T](v)
+			}
+			f(x)
+		}
+
+		func main() {
+			bar[int](42)
+			bar[float64](3.14)
+		}`)
+	bt.assertFuncInstCount(5)
+
+	bt.assertNotBlockingInst(`pkg/test.foo<int>`)
+	bt.assertNotBlockingInst(`pkg/test.foo<float64>`)
+	bt.assertNotBlockingLit(8, `int`)
+	bt.assertNotBlockingLit(8, `float64`)
+	// The following are blocking because the function literal call.
+	bt.assertBlockingInst(`pkg/test.bar<int>`)
+	bt.assertBlockingInst(`pkg/test.bar<float64>`)
+}
+
+func TestBlocking_BlockingLitInstance(t *testing.T) {
+	bt := newBlockingTest(t,
+		`package test
+
+		type BazBlocker struct {
+			c chan bool
+		}
+		func (bb BazBlocker) Baz() {
+			println(<-bb.c)
+		}
+
+		type BazNotBlocker struct {}
+		func (bnb BazNotBlocker) Baz() {
+			println("hi")
+		}
+
+		type Foo interface { Baz() }
+		func FooBaz[T Foo](foo T) func() {
+			return func() { // line 17
+				foo.Baz()
+			}
+		}
+
+		func main() {
+			_ = FooBaz(BazBlocker{})
+			_ = FooBaz(BazNotBlocker{})
+		}`)
+	bt.assertFuncInstCount(5)
+
+	bt.assertBlocking(`BazBlocker.Baz`)
+	// THe following is not blocking because the function literal is not called.
+	bt.assertNotBlockingInst(`pkg/test.FooBaz<pkg/test.BazBlocker>`)
+	bt.assertBlockingLit(17, `pkg/test.BazBlocker`)
+
+	bt.assertNotBlocking(`BazNotBlocker.Baz`)
+	bt.assertNotBlockingInst(`pkg/test.FooBaz<pkg/test.BazNotBlocker>`)
+	bt.assertNotBlockingLit(17, `pkg/test.BazNotBlocker`)
 }
 
 func TestBlocking_MethodSelection(t *testing.T) {
@@ -1333,13 +1498,13 @@ func TestBlocking_MethodSelection(t *testing.T) {
 	bt.assertFuncInstCount(8)
 
 	bt.assertBlocking(`BazBlocker.Baz`)
-	bt.assertBlockingInst(`test.ByMethodExpression[pkg/test.BazBlocker]`)
-	bt.assertBlockingInst(`test.ByInstance[pkg/test.BazBlocker]`)
+	bt.assertBlockingInst(`pkg/test.FooBaz.ByMethodExpression<pkg/test.BazBlocker>`)
+	bt.assertBlockingInst(`pkg/test.FooBaz.ByInstance<pkg/test.BazBlocker>`)
 	bt.assertBlocking(`blocking`)
 
 	bt.assertNotBlocking(`BazNotBlocker.Baz`)
-	bt.assertNotBlockingInst(`test.ByMethodExpression[pkg/test.BazNotBlocker]`)
-	bt.assertNotBlockingInst(`test.ByInstance[pkg/test.BazNotBlocker]`)
+	bt.assertNotBlockingInst(`pkg/test.FooBaz.ByMethodExpression<pkg/test.BazNotBlocker>`)
+	bt.assertNotBlockingInst(`pkg/test.FooBaz.ByInstance<pkg/test.BazNotBlocker>`)
 	bt.assertNotBlocking(`notBlocking`)
 }
 
@@ -1529,21 +1694,29 @@ func (bt *blockingTest) assertFuncInstCount(expCount int) {
 	if got := bt.pkgInfo.funcInstInfos.Len(); got != expCount {
 		bt.f.T.Errorf(`Got %d function instance infos but expected %d.`, got, expCount)
 		for i, inst := range bt.pkgInfo.funcInstInfos.Keys() {
-			bt.f.T.Logf(`  %d. %q`, i+1, inst.TypeString())
+			bt.f.T.Logf(`  %d. %q`, i+1, inst.String())
 		}
 	}
 }
 
 func (bt *blockingTest) assertFuncLitCount(expCount int) {
-	if got := len(bt.pkgInfo.funcLitInfos); got != expCount {
+	got := 0
+	for _, fis := range bt.pkgInfo.funcLitInfos {
+		got += len(fis)
+	}
+	if got != expCount {
 		bt.f.T.Errorf(`Got %d function literal infos but expected %d.`, got, expCount)
-		pos := make([]string, 0, len(bt.pkgInfo.funcLitInfos))
-		for fl := range bt.pkgInfo.funcLitInfos {
-			pos = append(pos, bt.f.FileSet.Position(fl.Pos()).String())
+
+		lits := make([]string, 0, len(bt.pkgInfo.funcLitInfos))
+		for fl, fis := range bt.pkgInfo.funcLitInfos {
+			pos := bt.f.FileSet.Position(fl.Pos()).String()
+			for _, fi := range fis {
+				lits = append(lits, pos+`<`+fi.typeArgs.String()+`>`)
+			}
 		}
-		sort.Strings(pos)
-		for i := range pos {
-			bt.f.T.Logf(`  %d. %q`, i+1, pos)
+		sort.Strings(lits)
+		for i := range lits {
+			bt.f.T.Logf(`  %d. %q`, i+1, lits[i])
 		}
 	}
 }
@@ -1597,24 +1770,41 @@ func (bt *blockingTest) isTypesFuncBlocking(funcName string) bool {
 	return bt.pkgInfo.IsBlocking(inst)
 }
 
-func (bt *blockingTest) assertBlockingLit(lineNo int) {
-	if !bt.isFuncLitBlocking(lineNo) {
-		bt.f.T.Errorf(`Got FuncLit at line %d as not blocking but expected it to be blocking.`, lineNo)
+func (bt *blockingTest) assertBlockingLit(lineNo int, typeArgsStr string) {
+	if !bt.isFuncLitBlocking(lineNo, typeArgsStr) {
+		bt.f.T.Errorf(`Got FuncLit at line %d with type args %q as not blocking but expected it to be blocking.`, lineNo, typeArgsStr)
 	}
 }
 
-func (bt *blockingTest) assertNotBlockingLit(lineNo int) {
-	if bt.isFuncLitBlocking(lineNo) {
-		bt.f.T.Errorf(`Got FuncLit at line %d as blocking but expected it to be not blocking.`, lineNo)
+func (bt *blockingTest) assertNotBlockingLit(lineNo int, typeArgsStr string) {
+	if bt.isFuncLitBlocking(lineNo, typeArgsStr) {
+		bt.f.T.Errorf(`Got FuncLit at line %d with type args %q as blocking but expected it to be not blocking.`, lineNo, typeArgsStr)
 	}
 }
 
-func (bt *blockingTest) isFuncLitBlocking(lineNo int) bool {
+func (bt *blockingTest) isFuncLitBlocking(lineNo int, typeArgsStr string) bool {
 	fnLit := srctesting.GetNodeAtLineNo[*ast.FuncLit](bt.file, bt.f.FileSet, lineNo)
 	if fnLit == nil {
 		bt.f.T.Fatalf(`FuncLit on line %d not found in the AST.`, lineNo)
 	}
-	return bt.pkgInfo.FuncLitInfo(fnLit).IsBlocking()
+
+	fis, ok := bt.pkgInfo.funcLitInfos[fnLit]
+	if !ok {
+		bt.f.T.Fatalf(`No FuncInfo found for FuncLit at line %d.`, lineNo)
+	}
+
+	for _, fi := range fis {
+		if fi.typeArgs.String() == typeArgsStr {
+			return fi.IsBlocking()
+		}
+	}
+
+	bt.f.T.Logf("FuncList instances:")
+	for i, fi := range fis {
+		bt.f.T.Logf("\t%d. %q\n", i+1, fi.typeArgs.String())
+	}
+	bt.f.T.Fatalf(`No FuncInfo found for FuncLit at line %d with type args %q.`, lineNo, typeArgsStr)
+	return false
 }
 
 func (bt *blockingTest) assertBlockingInst(instanceStr string) {
@@ -1632,40 +1822,58 @@ func (bt *blockingTest) assertNotBlockingInst(instanceStr string) {
 func (bt *blockingTest) isFuncInstBlocking(instanceStr string) bool {
 	instances := bt.pkgInfo.funcInstInfos.Keys()
 	for _, inst := range instances {
-		if inst.TypeString() == instanceStr {
+		if inst.String() == instanceStr {
 			return bt.pkgInfo.FuncInfo(inst).IsBlocking()
 		}
 	}
 	bt.f.T.Logf(`Function instances found in package info:`)
 	for i, inst := range instances {
-		bt.f.T.Logf(`  %d. %s`, i+1, inst.TypeString())
+		bt.f.T.Logf(` %d. %s`, i+1, inst.String())
 	}
 	bt.f.T.Fatalf(`No function instance found for %q in package info.`, instanceStr)
 	return false
 }
 
-func (bt *blockingTest) assertBlockingReturn(lineNo int) {
-	if !bt.isReturnBlocking(lineNo) {
-		bt.f.T.Errorf(`Got return at line %d as not blocking but expected it to be blocking.`, lineNo)
+func (bt *blockingTest) assertBlockingReturn(lineNo int, typeArgsStr string) {
+	if !bt.isReturnBlocking(lineNo, typeArgsStr) {
+		bt.f.T.Errorf(`Got return at line %d (%q) as not blocking but expected it to be blocking.`, lineNo, typeArgsStr)
 	}
 }
 
-func (bt *blockingTest) assertNotBlockingReturn(lineNo int) {
-	if bt.isReturnBlocking(lineNo) {
-		bt.f.T.Errorf(`Got return at line %d as blocking but expected it to be not blocking.`, lineNo)
+func (bt *blockingTest) assertNotBlockingReturn(lineNo int, typeArgsStr string) {
+	if bt.isReturnBlocking(lineNo, typeArgsStr) {
+		bt.f.T.Errorf(`Got return at line %d (%q) as blocking but expected it to be not blocking.`, lineNo, typeArgsStr)
 	}
 }
 
-func (bt *blockingTest) isReturnBlocking(lineNo int) bool {
+func (bt *blockingTest) isReturnBlocking(lineNo int, typeArgsStr string) bool {
 	ret := srctesting.GetNodeAtLineNo[*ast.ReturnStmt](bt.file, bt.f.FileSet, lineNo)
 	if ret == nil {
 		bt.f.T.Fatalf(`ReturnStmt on line %d not found in the AST.`, lineNo)
 	}
+
+	foundInfo := []*FuncInfo{}
 	for _, info := range bt.pkgInfo.allInfos {
-		if blocking, found := info.Blocking[ret]; found {
-			return blocking
+		for _, rs := range info.returnStmts {
+			if rs.analyzeStack[len(rs.analyzeStack)-1] == ret {
+				if info.typeArgs.String() == typeArgsStr {
+					// Found info that matches the type args and
+					// has the return statement so return the blocking value.
+					return info.Blocking[ret]
+				}
+
+				// Wrong instance, record for error message in the case
+				// that the correct one instance is not found.
+				foundInfo = append(foundInfo, info)
+				break
+			}
 		}
 	}
-	// If not found in any info.Blocking, then it is not blocking.
+
+	bt.f.T.Logf("FuncInfo instances with ReturnStmt at line %d:", lineNo)
+	for i, info := range foundInfo {
+		bt.f.T.Logf("\t%d. %q\n", i+1, info.typeArgs.String())
+	}
+	bt.f.T.Fatalf(`No FuncInfo found for ReturnStmt at line %d with type args %q.`, lineNo, typeArgsStr)
 	return false
 }

--- a/compiler/internal/typeparams/map.go
+++ b/compiler/internal/typeparams/map.go
@@ -40,7 +40,7 @@ func (im *InstanceMap[V]) findIndex(key Instance) (mapBucket[V], int) {
 	if im != nil && im.data != nil {
 		bucket := im.data[key.Object][typeHash(im.hasher, key.TArgs...)]
 		for i, candidate := range bucket {
-			if candidate != nil && typeArgsEq(candidate.key.TArgs, key.TArgs) {
+			if candidate != nil && candidate.key.TArgs.Equal(key.TArgs) {
 				return bucket, i
 			}
 		}
@@ -90,7 +90,7 @@ func (im *InstanceMap[V]) Set(key Instance, value V) V {
 	for i, candidate := range bucket {
 		if candidate == nil {
 			hole = i
-		} else if typeArgsEq(candidate.key.TArgs, key.TArgs) {
+		} else if candidate.key.TArgs.Equal(key.TArgs) {
 			old := candidate.value
 			candidate.value = value
 			return old
@@ -191,18 +191,4 @@ func typeHash(hasher typeutil.Hasher, types ...types.Type) uint32 {
 		hash ^= hasher.Hash(typ)
 	}
 	return hash
-}
-
-// typeArgsEq returns if both lists of type arguments are identical.
-func typeArgsEq(a, b []types.Type) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !types.Identical(a[i], b[i]) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/compiler/internal/typeparams/map_test.go
+++ b/compiler/internal/typeparams/map_test.go
@@ -317,7 +317,7 @@ func keysMatch(a, b []Instance) bool {
 
 func keyAt(keys []Instance, target Instance) int {
 	for i, v := range keys {
-		if v.Object == target.Object && typeArgsEq(v.TArgs, target.TArgs) {
+		if v.Object == target.Object && v.TArgs.Equal(target.TArgs) {
 			return i
 		}
 	}

--- a/compiler/typesutil/typelist.go
+++ b/compiler/typesutil/typelist.go
@@ -18,3 +18,16 @@ func (tl TypeList) String() string {
 	}
 	return buf.String()
 }
+
+// Equal returns true if both lists of type arguments are identical.
+func (tl TypeList) Equal(other TypeList) bool {
+	if len(tl) != len(other) {
+		return false
+	}
+	for i := range tl {
+		if !types.Identical(tl[i], other[i]) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
While I was doing other work I ran into a few issues and fixed them:

1. **Unused Generic Functions**: Unused generic functions and methods that perform calls were making requests with the type parameters, e.g. `func Foo[T any]() { Bar[T]() }` will make a request for the function information for `Bar[T]` with `T` being the type parameter. This was because if there were no instances, I assumed that meant that it was a non-generic function, but I totally missed the possibility that it is a generic function that just isn't used. I now check for instances and check if the function is generic and if it is unused and generic, skip over the function and don't bother making a FuncInfo for it. Since it is unused, it can't be needed by anything else other than other unused functions.

2. **Function Literal Instances**: Function literals that are inside a generic function were not getting the instance information, e.g. `func Foo[T any]() { func() { Bar[T]() }() }` will make a request for the function information for `Bar[T]` with `T` being the type parameter. This was because when the function literal FuncInfo is created it wasn't getting the type arguments from the instance of the generic function that it is inside of. I changed the function literal to take on the instance it is inside of. To make this work I also made the function literal FuncInfo lookup require the type arguments of the specific instance of the function literal to lookup.

3. **Delay Remote Calls**: I make the `IsBlocking` method able to use the `isImportedBlocking` function if the instance of the function that is being looked up isn't from the current `Info`. With this change I could also delay the lookup of other remote calls and defers until the end of the analysis when function information is propagating. This change will help later for getting generic changes across package boundaries.

These changes will help prepare for some of the changes needed to make function lookup in the ImportContext look for the correct instance of a generic function Decl. This is related to #1013 and #1270