### PR TITLE
[WIP] Separate Parsing and Compiling

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1044,6 +1044,10 @@ func (s *Session) BuildPackage(pkg *PackageData) (*ParsedPackage, error) {
 
 // CompilePackage compiles a previously prepared parsed package.
 func (s *Session) CompilePackage(pkg *ParsedPackage) (*compiler.Archive, error) {
+	if archive, ok := s.UpToDateArchives[pkg.ImportPath]; ok {
+		return archive, nil
+	}
+
 	importContext := &compiler.ImportContext{
 		Packages: s.Types,
 		Import:   s.ImportResolverFor(pkg.Dir),


### PR DESCRIPTION
# WIP

Working on aligning the compile step so that at some point in the build we have all the ASTs for all packages at the same time. This means delay the creation of Archives until all the parsed packages have been gathered. The goal is to allow analysis to be run prior to Archives being created. This will also allow all the instances of a generic to be determined prior ot any Archive being created.

This will cause the Archive to no longer be read or written to the cache.