### PR TITLE
[WIP] Separate Parsing and Compiling

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1048,8 +1048,6 @@ func (s *Session) ImportResolverFor(pkg *PackageData) func(string) (*compiler.Ar
 		if archive, ok := s.UpToDateArchives[path]; ok {
 			return archive, nil
 		}
-		// TODO(gn): REMOVE: Grant waz here, this should not cause crypto to fail yet again, no changes, just a comment!!!
-
 		_, archive, err := s.buildImportPathWithSrcDir(path, pkg.Dir)
 		return archive, err
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -1018,7 +1018,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 
 	importContext := &compiler.ImportContext{
 		Packages: s.Types,
-		Import:   s.ImportResolverFor(pkg),
+		Import:   s.ImportResolverFor(pkg.Dir),
 	}
 	archive, err := compiler.Compile(pkg.ImportPath, files, fileSet, importContext, s.options.Minify)
 	if err != nil {
@@ -1043,12 +1043,12 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 
 // ImportResolverFor returns a function which returns a compiled package archive
 // given an import path.
-func (s *Session) ImportResolverFor(pkg *PackageData) func(string) (*compiler.Archive, error) {
+func (s *Session) ImportResolverFor(srcDir string) func(string) (*compiler.Archive, error) {
 	return func(path string) (*compiler.Archive, error) {
 		if archive, ok := s.UpToDateArchives[path]; ok {
 			return archive, nil
 		}
-		_, archive, err := s.buildImportPathWithSrcDir(path, pkg.Dir)
+		_, archive, err := s.buildImportPathWithSrcDir(path, srcDir)
 		return archive, err
 	}
 }
@@ -1087,13 +1087,7 @@ func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) 
 		sourceMapFilter.MappingCallback = s.SourceMappingCallback(m)
 	}
 
-	deps, err := compiler.ImportDependencies(archive, func(path string) (*compiler.Archive, error) {
-		if archive, ok := s.UpToDateArchives[path]; ok {
-			return archive, nil
-		}
-		_, archive, err := s.buildImportPathWithSrcDir(path, "")
-		return archive, err
-	})
+	deps, err := compiler.ImportDependencies(archive, s.ImportResolverFor(""))
 	if err != nil {
 		return err
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -1018,7 +1018,7 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 
 	importContext := &compiler.ImportContext{
 		Packages: s.Types,
-		Import:   s.ImportResolverFor(pkg, pkg.Dir),
+		Import:   s.ImportResolverFor(pkg),
 	}
 	archive, err := compiler.Compile(pkg.ImportPath, files, fileSet, importContext, s.options.Minify)
 	if err != nil {
@@ -1043,14 +1043,12 @@ func (s *Session) BuildPackage(pkg *PackageData) (*compiler.Archive, error) {
 
 // ImportResolverFor returns a function which returns a compiled package archive
 // given an import path.
-func (s *Session) ImportResolverFor(pkg *PackageData, srcDir string) func(string) (*compiler.Archive, error) {
+func (s *Session) ImportResolverFor(pkg *PackageData) func(string) (*compiler.Archive, error) {
 	return func(path string) (*compiler.Archive, error) {
 		if archive, ok := s.UpToDateArchives[path]; ok {
 			return archive, nil
 		}
-		if pkg.Dir != srcDir { // TODO(gn): REMOVE
-			panic("import resolver called with different srcDir: " + srcDir + " != " + pkg.Dir)
-		}
+		// TODO(gn): REMOVE: Grant waz here, this should not cause crypto to fail yet again, no changes, just a comment!!!
 
 		_, archive, err := s.buildImportPathWithSrcDir(path, pkg.Dir)
 		return archive, err

--- a/tool.go
+++ b/tool.go
@@ -389,7 +389,7 @@ func main() {
 			}
 			importContext := &compiler.ImportContext{
 				Packages: s.Types,
-				Import:   s.ImportResolverFor(mainPkg.Dir),
+				Import:   s.ImportResolverFor(mainPkg, mainPkg.Dir),
 			}
 			mainPkgArchive, err := compiler.Compile(mainPkg.ImportPath, []*ast.File{mainFile}, fset, importContext, options.Minify)
 			if err != nil {

--- a/tool.go
+++ b/tool.go
@@ -389,7 +389,7 @@ func main() {
 			}
 			importContext := &compiler.ImportContext{
 				Packages: s.Types,
-				Import:   s.ImportResolverFor(mainPkg),
+				Import:   s.ImportResolverFor(mainPkg.Dir),
 			}
 			mainPkgArchive, err := compiler.Compile(mainPkg.ImportPath, []*ast.File{mainFile}, fset, importContext, options.Minify)
 			if err != nil {

--- a/tool.go
+++ b/tool.go
@@ -389,7 +389,7 @@ func main() {
 			}
 			importContext := &compiler.ImportContext{
 				Packages: s.Types,
-				Import:   s.ImportResolverFor(mainPkg, mainPkg.Dir),
+				Import:   s.ImportResolverFor(mainPkg),
 			}
 			mainPkgArchive, err := compiler.Compile(mainPkg.ImportPath, []*ast.File{mainFile}, fset, importContext, options.Minify)
 			if err != nil {


### PR DESCRIPTION
# WIP

Working on aligning the compile step so that at some point in the build we have all the ASTs for all packages at the same time. This means delay the creation of Archives until all the parsed packages have been gathered. The goal is to allow analysis to be run prior to Archives being created. This will also allow all the instances of a generic to be determined prior ot any Archive being created.

This will cause the Archive to no longer be read or written to the cache.