### PR TITLE
Skipping crypto tests with expired certificate

### DIFF
--- a/compiler/natives/src/crypto/tls/handshake_test.go
+++ b/compiler/natives/src/crypto/tls/handshake_test.go
@@ -10,7 +10,7 @@ import (
 
 // Same as upstream, except we check for GOARCH=ecmascript instead of wasm.
 // This override can be removed after https://github.com/golang/go/pull/51827
-// is available in the upstream (likely in Go 1.19).
+// is available in the upstream (likely after Go 1.19).
 func TestServerHandshakeContextCancellation(t *testing.T) {
 	c, s := localPipe(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -42,7 +42,7 @@ func TestServerHandshakeContextCancellation(t *testing.T) {
 
 // Same as upstream, except we check for GOARCH=ecmascript instead of wasm.
 // This override can be removed after https://github.com/golang/go/pull/51827
-// is available in the upstream (likely in Go 1.19).
+// is available in the upstream (likely after Go 1.19).
 func TestClientHandshakeContextCancellation(t *testing.T) {
 	c, s := localPipe(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -70,4 +70,16 @@ func TestClientHandshakeContextCancellation(t *testing.T) {
 	if err == nil {
 		t.Error("Client connection was not closed when the context was canceled")
 	}
+}
+
+func TestVerifyConnection(t *testing.T) {
+	// This should be rechecked after upgrading to Go 1.20 or later.
+	// go1.19.13/src/crypto/tls/handshake_test.go:testRSACertificateIssuer has expired.
+	t.Skip("Skipping test that uses predefined certificate that expired in Jan 1st 2025")
+}
+
+func TestResumptionKeepsOCSPAndSCT(t *testing.T) {
+	// This should be rechecked after upgrading to Go 1.20 or later.
+	// go1.19.13/src/crypto/tls/handshake_test.go:testRSACertificateIssuer has expired.
+	t.Skip("Skipping test that uses predefined certificate that expired in Jan 1st 2025")
 }


### PR DESCRIPTION
## Problem

Master started failing CI because `TestVerifyConnection` and  `TestResumptionKeepsOCSPAndSCT` failed with "bad certificate". Digging into the problem revealed that [`testRSACertificateIssuer`](https://cs.opensource.google/go/go/+/refs/tags/go1.19.13:src/crypto/tls/handshake_test.go;l=434), a hardcoded byte array of a certificate, expired in 2025-01-01. The last update to those that certificate for go1.19.13 is in [2019-06-20](https://cs.opensource.google/go/go/+/0884bca05a278e7f8783be3545a88a26b14dd4e4), so they gave it 6 years before expiring.

## Solution

Added overrides to skip those tests with a comment to check in future versions.

It appears that the same string in [go1.23.1](https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/crypto/tls/handshake_test.go;l=524) but have added code to those tests to update the time stamp on the certificates, so as we hit go1.20 and beyond we should check if we can stop skipping these tests or not.