### PR TITLE
Separate Parsing and Compiling

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1175,7 +1175,7 @@ func (s *Session) getImportPath(path, srcDir string) (string, error) {
 		return importPath, nil
 	}
 
-	// Fall back to the slop import of the build package.
+	// Fall back to the slow import of the build package.
 	pkg, err := s.xctx.Import(path, srcDir, 0)
 	if err != nil {
 		return ``, err

--- a/build/build.go
+++ b/build/build.go
@@ -788,9 +788,13 @@ type Session struct {
 	options *Options
 	xctx    XContext
 
-	// importPaths is a map of the resolved import paths given the srcDir
-	// and path. This is used to avoid redetermining build packages during
-	// compilation when we're looking up parsed packages.
+	// importPaths is a map of the resolved import paths given the
+	// source directory (first key) and the unresolved import path (second key).
+	// This is used to cache the resolved import returned from XContext.Import.
+	// XContent.Import can be slow, so we cache the resolved path that is used
+	// as the map key by parsedPackages and UpToDateArchives.
+	// This makes subsequent lookups faster during compilation when all we have
+	// is the unresolved import path and source directory.
 	importPaths map[string]map[string]string
 
 	// parsePackage is a map of parsed packages that have been built and augmented.
@@ -958,9 +962,9 @@ func (s *Session) BuildProject(pkg *PackageData) (*compiler.Archive, error) {
 	var parsed *ParsedPackage
 	var err error
 	if pkg.IsTest {
-		parsed, err = s.buildTestPackage(pkg)
+		parsed, err = s.loadTestPackage(pkg)
 	} else {
-		parsed, err = s.buildPackages(pkg)
+		parsed, err = s.loadPackages(pkg)
 	}
 	if err != nil {
 		return nil, err
@@ -975,12 +979,12 @@ func (s *Session) BuildProject(pkg *PackageData) (*compiler.Archive, error) {
 	return s.compilePackages(parsed)
 }
 
-func (s *Session) buildTestPackage(pkg *PackageData) (*ParsedPackage, error) {
-	_, err := s.buildPackages(pkg.TestPackage())
+func (s *Session) loadTestPackage(pkg *PackageData) (*ParsedPackage, error) {
+	_, err := s.loadPackages(pkg.TestPackage())
 	if err != nil {
 		return nil, err
 	}
-	_, err = s.buildPackages(pkg.XTestPackage())
+	_, err = s.loadPackages(pkg.XTestPackage())
 	if err != nil {
 		return nil, err
 	}
@@ -1004,7 +1008,7 @@ func (s *Session) buildTestPackage(pkg *PackageData) (*ParsedPackage, error) {
 
 	// Import dependencies for the testmain package.
 	for _, importedPkgPath := range parsed.Imports() {
-		_, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
+		_, _, err := s.loadImportPathWithSrcDir(importedPkgPath, pkg.Dir)
 		if err != nil {
 			return nil, err
 		}
@@ -1013,11 +1017,11 @@ func (s *Session) buildTestPackage(pkg *PackageData) (*ParsedPackage, error) {
 	return parsed, nil
 }
 
-// buildImportPathWithSrcDir builds the parsed package specified by the import path.
+// loadImportPathWithSrcDir gets the parsed package specified by the import path.
 //
-// Relative import paths are interpreted relative to the passed srcDir. If
-// srcDir is empty, current working directory is assumed.
-func (s *Session) buildImportPathWithSrcDir(path, srcDir string) (*PackageData, *ParsedPackage, error) {
+// Relative import paths are interpreted relative to the passed srcDir.
+// If srcDir is empty, current working directory is assumed.
+func (s *Session) loadImportPathWithSrcDir(path, srcDir string) (*PackageData, *ParsedPackage, error) {
 	pkg, err := s.xctx.Import(path, srcDir, 0)
 	if s.Watcher != nil && pkg != nil { // add watch even on error
 		s.Watcher.Add(pkg.Dir)
@@ -1026,7 +1030,7 @@ func (s *Session) buildImportPathWithSrcDir(path, srcDir string) (*PackageData, 
 		return nil, nil, err
 	}
 
-	parsed, err := s.buildPackages(pkg)
+	parsed, err := s.loadPackages(pkg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1035,8 +1039,8 @@ func (s *Session) buildImportPathWithSrcDir(path, srcDir string) (*PackageData, 
 	return pkg, parsed, nil
 }
 
-// cacheImportPath stores the import path for the build package so we can look
-// it up later without getting the whole build package.
+// cacheImportPath stores the resolved import path for the build package
+// so we can look it up later without getting the whole build package.
 // The given path and source directly are the ones passed into
 // XContext.Import to the get the build package originally.
 func (s *Session) cacheImportPath(path, srcDir, importPath string) {
@@ -1073,7 +1077,7 @@ var getExeModTime = func() func() time.Time {
 	}
 }()
 
-func (s *Session) buildPackages(pkg *PackageData) (*ParsedPackage, error) {
+func (s *Session) loadPackages(pkg *PackageData) (*ParsedPackage, error) {
 	if parsed, ok := s.parsedPackages[pkg.ImportPath]; ok {
 		return parsed, nil
 	}
@@ -1086,7 +1090,7 @@ func (s *Session) buildPackages(pkg *PackageData) (*ParsedPackage, error) {
 		if importedPkgPath == "unsafe" {
 			continue
 		}
-		importedPkg, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
+		importedPkg, _, err := s.loadImportPathWithSrcDir(importedPkgPath, pkg.Dir)
 		if err != nil {
 			return nil, err
 		}
@@ -1126,7 +1130,7 @@ func (s *Session) buildPackages(pkg *PackageData) (*ParsedPackage, error) {
 	// Import dependencies from the augmented files,
 	// whilst skipping any that have been already imported.
 	for _, importedPkgPath := range parsed.Imports(pkg.Imports...) {
-		_, _, err := s.buildImportPathWithSrcDir(importedPkgPath, pkg.Dir)
+		_, _, err := s.loadImportPathWithSrcDir(importedPkgPath, pkg.Dir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/testmain/testmain_test.go
+++ b/internal/testmain/testmain_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/gopherjs/gopherjs/build"
 	"github.com/gopherjs/gopherjs/internal/srctesting"
 	. "github.com/gopherjs/gopherjs/internal/testmain"
@@ -21,7 +22,10 @@ func TestScan(t *testing.T) {
 
 	fset := token.NewFileSet()
 
-	got := TestMain{Package: pkg}
+	got := TestMain{
+		Package: pkg.Package,
+		Context: pkg.InternalBuildContext(),
+	}
 	if err := got.Scan(fset); err != nil {
 		t.Fatalf("Got: tm.Scan() returned error: %s. Want: no error.", err)
 	}
@@ -47,6 +51,7 @@ func TestScan(t *testing.T) {
 	}
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(TestMain{}, "Package"), // Inputs.
+		cmpopts.IgnoreFields(TestMain{}, "Context"),
 	}
 	if diff := cmp.Diff(want, got, opts...); diff != "" {
 		t.Errorf("List of test function is different from expected (-want,+got):\n%s", diff)
@@ -54,9 +59,7 @@ func TestScan(t *testing.T) {
 }
 
 func TestSynthesize(t *testing.T) {
-	pkg := &build.PackageData{
-		Package: &gobuild.Package{ImportPath: "foo/bar"},
-	}
+	pkg := &gobuild.Package{ImportPath: "foo/bar"}
 
 	tests := []struct {
 		descr   string


### PR DESCRIPTION
This is the start of several changes to get generic information propagated across package lines.

This changes how packages are loaded so that they are not converted into `Archive`s right away. This does mean that `Archive` caching has been disabled. With the `Archive`s creation delayed, we have two phases:

1. **Parse**: The parse phase uses `BuildPackage`s to determine the files that are needed to be parsed for a package and determine the imports that are required for a package. The result of the parse phase will be `ParsedPackage`s. All the `ParsedPackage`s needed for a project will be gotten prior to moving onto the compile phase.
2. **Compile**: The compile phase will take the root `ParsedPackage` and start compiling it, compiling any imported `ParsedPackage` as it goes. Each compile of a `ParsedPackage` results in an `Archive`. Once the `Archive`s have all been created, GopherJS continues as usual.

The point of this change is to prepare for following PR's. In the following PR's we can break up phase 2 into smaller steps. Right now the compile phase does Type Checking, code simplifying, link finding, anaylizing, then converting into JS. The analyzing includes determining flattening, blocking, etc information for the methods. At the point I left the `TODO` between phase 1 and 2. We can move several of those parts out of compile and do them to the whole project at once. We can run type checking and analyzing all at once to help propagate information across package lines. Once all the preliminary information has been gathered, then we output the `Archive`s.

This is related to #1013 and #1270
