### PR TITLE
Perform cross package type analysis

### DIFF
--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -82,7 +82,7 @@ func (d *Decl) Dce() *dce.Info {
 
 // topLevelObjects extracts package-level variables, functions and named types
 // from the package AST.
-func (fc *funcContext) topLevelObjects(srcs sources.Sources) (vars []*types.Var, functions []*ast.FuncDecl, typeNames typesutil.TypeNames) {
+func (fc *funcContext) topLevelObjects(srcs *sources.Sources) (vars []*types.Var, functions []*ast.FuncDecl, typeNames typesutil.TypeNames) {
 	if !fc.isRoot() {
 		panic(bailout(fmt.Errorf("functionContext.discoverObjects() must be only called on the package-level context")))
 	}

--- a/compiler/internal/analysis/info.go
+++ b/compiler/internal/analysis/info.go
@@ -52,15 +52,19 @@ type Info struct {
 	*types.Info
 	Pkg           *types.Package
 	typeCtx       *types.Context
-	instanceSets  *typeparams.PackageInstanceSets
+	InstanceSets  *typeparams.PackageInstanceSets
 	HasPointer    map[*types.Var]bool
 	funcInstInfos *typeparams.InstanceMap[*FuncInfo]
 	funcLitInfos  map[*ast.FuncLit][]*FuncInfo
 	InitFuncInfo  *FuncInfo // Context for package variable initialization.
 
-	isImportedBlocking func(typeparams.Instance) bool // For functions from other packages.
-	allInfos           []*FuncInfo
+	infoImporter InfoImporter // To get `Info` for other packages.
+	allInfos     []*FuncInfo
 }
+
+// InfoImporter is used to get the `Info` for another package.
+// The path is the resolved import path of the package to get the `Info` for.
+type InfoImporter func(path string) (*Info, error)
 
 func (info *Info) newFuncInfo(n ast.Node, obj types.Object, typeArgs typesutil.TypeList, resolver *typeparams.Resolver) *FuncInfo {
 	funcInfo := &FuncInfo{
@@ -106,7 +110,7 @@ func (info *Info) newFuncInfo(n ast.Node, obj types.Object, typeArgs typesutil.T
 
 func (info *Info) newFuncInfoInstances(fd *ast.FuncDecl) []*FuncInfo {
 	obj := info.Defs[fd.Name]
-	instances := info.instanceSets.Pkg(info.Pkg).ForObj(obj)
+	instances := info.InstanceSets.Pkg(info.Pkg).ForObj(obj)
 	if len(instances) == 0 {
 		if typeparams.HasTypeParams(obj.Type()) {
 			// This is a generic function, but no instances were found,
@@ -132,11 +136,16 @@ func (info *Info) newFuncInfoInstances(fd *ast.FuncDecl) []*FuncInfo {
 }
 
 // IsBlocking returns true if the function may contain blocking calls or operations.
-// If inst is from a different package, this will use the isImportedBlocking
+// If inst is from a different package, this will use the getImportInfo function
 // to lookup the information from the other package.
 func (info *Info) IsBlocking(inst typeparams.Instance) bool {
 	if inst.Object.Pkg() != info.Pkg {
-		return info.isImportedBlocking(inst)
+		path := inst.Object.Pkg().Path()
+		otherInfo, err := info.infoImporter(path)
+		if err != nil {
+			panic(fmt.Errorf(`failed to get info for package %q: %v`, path, err))
+		}
+		return otherInfo.IsBlocking(inst)
 	}
 	if funInfo := info.FuncInfo(inst); funInfo != nil {
 		return funInfo.IsBlocking()
@@ -174,16 +183,21 @@ func (info *Info) VarsWithInitializers() map[*types.Var]bool {
 	return result
 }
 
-func AnalyzePkg(files []*ast.File, fileSet *token.FileSet, typesInfo *types.Info, typeCtx *types.Context, typesPkg *types.Package, instanceSets *typeparams.PackageInstanceSets, isBlocking func(typeparams.Instance) bool) *Info {
+// AnalyzePkg analyzes the given package for blocking calls, defers, etc.
+//
+// Note that at the end of this call the analysis information
+// has NOT been propagated across packages yet. Once all the packages
+// have been analyzed, call PropagateAnalysis to propagate the information.
+func AnalyzePkg(files []*ast.File, fileSet *token.FileSet, typesInfo *types.Info, typeCtx *types.Context, typesPkg *types.Package, instanceSets *typeparams.PackageInstanceSets, infoImporter InfoImporter) *Info {
 	info := &Info{
-		Info:               typesInfo,
-		Pkg:                typesPkg,
-		typeCtx:            typeCtx,
-		instanceSets:       instanceSets,
-		HasPointer:         make(map[*types.Var]bool),
-		isImportedBlocking: isBlocking,
-		funcInstInfos:      new(typeparams.InstanceMap[*FuncInfo]),
-		funcLitInfos:       make(map[*ast.FuncLit][]*FuncInfo),
+		Info:          typesInfo,
+		Pkg:           typesPkg,
+		typeCtx:       typeCtx,
+		InstanceSets:  instanceSets,
+		HasPointer:    make(map[*types.Var]bool),
+		infoImporter:  infoImporter,
+		funcInstInfos: new(typeparams.InstanceMap[*FuncInfo]),
+		funcLitInfos:  make(map[*ast.FuncLit][]*FuncInfo),
 	}
 	info.InitFuncInfo = info.newFuncInfo(nil, nil, nil, nil)
 
@@ -193,13 +207,25 @@ func AnalyzePkg(files []*ast.File, fileSet *token.FileSet, typesInfo *types.Info
 		ast.Walk(info.InitFuncInfo, file)
 	}
 
+	return info
+}
+
+// PropagateAnalysis will propagate analysis information across package
+// boundaries to finish the analysis of a whole project.
+func PropagateAnalysis(allInfo []*Info) {
 	done := false
 	for !done {
-		done = info.propagateFunctionBlocking()
+		done = true
+		for _, info := range allInfo {
+			if !info.propagateFunctionBlocking() {
+				done = false
+			}
+		}
 	}
 
-	info.propagateControlStatementBlocking()
-	return info
+	for _, info := range allInfo {
+		info.propagateControlStatementBlocking()
+	}
 }
 
 // propagateFunctionBlocking propagates information about blocking calls

--- a/internal/srctesting/srctesting.go
+++ b/internal/srctesting/srctesting.go
@@ -187,9 +187,9 @@ type Source struct {
 // root package. At least one source file must be given.
 // The root package's path will be `command-line-arguments`.
 //
-// The auxillary files can be for different packages but should have paths
+// The auxiliary files can be for different packages but should have paths
 // added to the source name so that they can be grouped together by package.
-// To import an auxillary package, the path should be prepended by
+// To import an auxiliary package, the path should be prepended by
 // `github.com/gopherjs/gopherjs/compiler`.
 func ParseSources(t *testing.T, sourceFiles []Source, auxFiles []Source) *packages.Package {
 	t.Helper()


### PR DESCRIPTION
#### These changes are for the 3rd task towards generics

> 3. build system needs to be changed to collect generic instance information and propagate it across package boundaries. This would require reorganizing build package into loading all packages first, analyzing them, and then passing to the compiler, which is different from today's behavior where imported packages are loaded and compiled on-demand when compiler needs them. The tricky part here would be making sure build cache accounts for the fact that dependent packages may influence the set of generic instances of the dependency packages. - [from this slack comment by nevkontakte](https://gophers.slack.com/archives/C039C0R2T/p1721859938577319)

#### What these changes do

- This leverages the prior work to making Sources a more important part of the Build process.
  - This add the type information and linkname information into the Sources.
- This pulls the preparation of the Sources out of the compile phase. During preparation:
  - All the source files are sorted within each package by name
  - The Sources type information and type package are determined and stored in Sources
  - All the Go linknames are gotten
  - All the source files are simplified
  - All the instance information is collected
  - Analysis is run and propagated across package boundaries
- Once all the sources have been prepared, they can be compiled
