### PR TITLE
Adding nested type support

### DIFF
--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -433,7 +433,7 @@ func (fc *funcContext) newNamedTypeVarDecl(obj *types.TypeName) *Decl {
 		FullName: typeVarDeclFullName(obj),
 		Vars:     []string{name},
 	}
-	if typeparams.HasTypeParams(obj.Type()) {
+	if fc.pkgCtx.instanceSet.Pkg(obj.Pkg()).ObjHasInstances(obj) {
 		varDecl.DeclCode = fc.CatchOutput(0, func() {
 			fc.Printf("%s = {};", name)
 		})
@@ -451,16 +451,28 @@ func (fc *funcContext) newNamedTypeVarDecl(obj *types.TypeName) *Decl {
 func (fc *funcContext) newNamedTypeInstDecl(inst typeparams.Instance) (*Decl, error) {
 	originType := inst.Object.Type().(*types.Named)
 
-	fc.typeResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, typeparams.ToSlice(originType.TypeParams()), inst.TArgs)
+	var nestResolver *typeparams.Resolver
+	if len(inst.TNest) > 0 {
+		fn := typeparams.FindNestingFunc(inst.Object)
+		tp := typeparams.SignatureTypeParams(fn.Type().(*types.Signature))
+		nestResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, tp, inst.TNest, nil)
+	}
+	fc.typeResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, originType.TypeParams(), inst.TArgs, nestResolver)
 	defer func() { fc.typeResolver = nil }()
 
 	instanceType := originType
 	if !inst.IsTrivial() {
-		instantiated, err := types.Instantiate(fc.pkgCtx.typesCtx, originType, inst.TArgs, true)
-		if err != nil {
-			return nil, fmt.Errorf("failed to instantiate type %v with args %v: %w", originType, inst.TArgs, err)
+		if len(inst.TArgs) > 0 {
+			instantiated, err := types.Instantiate(fc.pkgCtx.typesCtx, originType, inst.TArgs, true)
+			if err != nil {
+				return nil, fmt.Errorf("failed to instantiate type %v with args %v: %w", originType, inst.TArgs, err)
+			}
+			instanceType = instantiated.(*types.Named)
 		}
-		instanceType = instantiated.(*types.Named)
+		if len(inst.TNest) > 0 {
+			instantiated := nestResolver.Substitute(instanceType)
+			instanceType = instantiated.(*types.Named)
+		}
 	}
 
 	underlying := instanceType.Underlying()
@@ -541,7 +553,8 @@ func (fc *funcContext) structConstructor(t *types.Struct) string {
 	// If no arguments were passed, zero-initialize all fields.
 	fmt.Fprintf(constructor, "\t\tif (arguments.length === 0) {\n")
 	for i := 0; i < t.NumFields(); i++ {
-		fmt.Fprintf(constructor, "\t\t\tthis.%s = %s;\n", fieldName(t, i), fc.translateExpr(fc.zeroValue(t.Field(i).Type())).String())
+		zeroValue := fc.zeroValue(fc.fieldType(t, i))
+		fmt.Fprintf(constructor, "\t\t\tthis.%s = %s;\n", fieldName(t, i), fc.translateExpr(zeroValue).String())
 	}
 	fmt.Fprintf(constructor, "\t\t\treturn;\n")
 	fmt.Fprintf(constructor, "\t\t}\n")

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -49,9 +49,9 @@ func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, inst typep
 	}
 
 	if sig.TypeParams().Len() > 0 {
-		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, typeparams.ToSlice(sig.TypeParams()), inst.TArgs)
+		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, sig.TypeParams(), inst.TArgs, nil)
 	} else if sig.RecvTypeParams().Len() > 0 {
-		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, typeparams.ToSlice(sig.RecvTypeParams()), inst.TArgs)
+		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, sig.RecvTypeParams(), inst.TArgs, nil)
 	}
 	if c.objectNames == nil {
 		c.objectNames = map[types.Object]string{}

--- a/compiler/internal/analysis/info.go
+++ b/compiler/internal/analysis/info.go
@@ -126,8 +126,8 @@ func (info *Info) newFuncInfoInstances(fd *ast.FuncDecl) []*FuncInfo {
 	for _, inst := range instances {
 		var resolver *typeparams.Resolver
 		if sig, ok := obj.Type().(*types.Signature); ok {
-			tp := typeparams.ToSlice(typeparams.SignatureTypeParams(sig))
-			resolver = typeparams.NewResolver(info.typeCtx, tp, inst.TArgs)
+			tp := typeparams.SignatureTypeParams(sig)
+			resolver = typeparams.NewResolver(info.typeCtx, tp, inst.TArgs, nil)
 		}
 		fi := info.newFuncInfo(fd, inst.Object, inst.TArgs, resolver)
 		funcInfos = append(funcInfos, fi)

--- a/compiler/internal/analysis/info_test.go
+++ b/compiler/internal/analysis/info_test.go
@@ -382,6 +382,7 @@ func TestBlocking_Defers_WithMultipleReturns(t *testing.T) {
 	// of which flow control statements (e.g. if-statements) are terminating
 	// or not. Any defers added in a terminating control flow would not
 	// propagate to returns that are not in that block.
+	// See golang.org/x/tools/go/ssa for flow control analysis.
 	//
 	// For now we simply build up the list of defers as we go making
 	// the return on line 31 also blocking.

--- a/compiler/internal/symbol/symbol.go
+++ b/compiler/internal/symbol/symbol.go
@@ -21,6 +21,11 @@ type Name struct {
 
 // New constructs SymName for a given named symbol.
 func New(o types.Object) Name {
+	pkgPath := `_`
+	if pkg := o.Pkg(); pkg != nil {
+		pkgPath = pkg.Path()
+	}
+
 	if fun, ok := o.(*types.Func); ok {
 		sig := fun.Type().(*types.Signature)
 		if recv := sig.Recv(); recv != nil {
@@ -28,18 +33,18 @@ func New(o types.Object) Name {
 			typ := recv.Type()
 			if ptr, ok := typ.(*types.Pointer); ok {
 				return Name{
-					PkgPath: o.Pkg().Path(),
+					PkgPath: pkgPath,
 					Name:    "(*" + ptr.Elem().(*types.Named).Obj().Name() + ")." + o.Name(),
 				}
 			}
 			return Name{
-				PkgPath: o.Pkg().Path(),
+				PkgPath: pkgPath,
 				Name:    typ.(*types.Named).Obj().Name() + "." + o.Name(),
 			}
 		}
 	}
 	return Name{
-		PkgPath: o.Pkg().Path(),
+		PkgPath: pkgPath,
 		Name:    o.Name(),
 	}
 }

--- a/compiler/internal/typeparams/collect_test.go
+++ b/compiler/internal/typeparams/collect_test.go
@@ -2,7 +2,9 @@ package typeparams
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,7 +37,11 @@ func TestVisitor(t *testing.T) {
 		t := typ[int, A]{}
 		t.method(0)
 		(*typ[int32, A]).method(nil, 0)
+
 		type x struct{ T []typ[int64, A] }
+		type y[X any] struct{ T []typ[A, X] }
+		_ = y[int8]{}
+		_ = y[A]{}
 
 		return
 	}
@@ -49,7 +55,11 @@ func TestVisitor(t *testing.T) {
 		t := typ[int, T]{}
 		t.method(0)
 		(*typ[int32, T]).method(nil, 0)
+
 		type x struct{ T []typ[int64, T] }
+		type y[X any] struct{ T []typ[T, X] }
+		_ = y[int8]{}
+		_ = y[T]{}
 
 		return
 	}
@@ -67,7 +77,11 @@ func TestVisitor(t *testing.T) {
 		t := typ[int, T]{}
 		t.method(0)
 		(*typ[int32, T]).method(nil, 0)
+
 		type x struct{ T []typ[int64, T] }
+		type y[X any] struct{ T []typ[T, X] }
+		_ = y[int8]{}
+		_ = y[T]{}
 
 		return
 	}
@@ -189,22 +203,50 @@ func TestVisitor(t *testing.T) {
 			descr:    "non-generic function",
 			resolver: nil,
 			node:     lookupDecl("entry1"),
-			want:     instancesInFunc(lookupType("A")),
+			want: append(
+				instancesInFunc(lookupType("A")),
+				Instance{
+					Object: lookupObj("entry1.y"),
+					TArgs:  []types.Type{types.Typ[types.Int8]},
+				},
+				Instance{
+					Object: lookupObj("entry1.y"),
+					TArgs:  []types.Type{lookupType("A")},
+				},
+			),
 		}, {
 			descr: "generic function",
 			resolver: NewResolver(
 				types.NewContext(),
-				ToSlice(lookupType("entry2").(*types.Signature).TypeParams()),
+				lookupType("entry2").(*types.Signature).TypeParams(),
 				[]types.Type{lookupType("B")},
+				nil,
 			),
 			node: lookupDecl("entry2"),
-			want: instancesInFunc(lookupType("B")),
+			want: append(
+				instancesInFunc(lookupType("B")),
+				Instance{
+					Object: lookupObj("entry2.x"),
+					TNest:  []types.Type{lookupType("B")},
+				},
+				Instance{
+					Object: lookupObj("entry1.y"),
+					TNest:  []types.Type{lookupType("B")},
+					TArgs:  []types.Type{types.Typ[types.Int8]},
+				},
+				Instance{
+					Object: lookupObj("entry2.y"),
+					TNest:  []types.Type{lookupType("B")},
+					TArgs:  []types.Type{lookupType("B")},
+				},
+			),
 		}, {
 			descr: "generic method",
 			resolver: NewResolver(
 				types.NewContext(),
-				ToSlice(lookupType("entry3.method").(*types.Signature).RecvTypeParams()),
+				lookupType("entry3.method").(*types.Signature).RecvTypeParams(),
 				[]types.Type{lookupType("C")},
+				nil,
 			),
 			node: lookupDecl("entry3.method"),
 			want: append(
@@ -217,13 +259,28 @@ func TestVisitor(t *testing.T) {
 					Object: lookupObj("entry3.method"),
 					TArgs:  []types.Type{lookupType("C")},
 				},
+				Instance{
+					Object: lookupObj("entry3.method.x"),
+					TNest:  []types.Type{lookupType("C")},
+				},
+				Instance{
+					Object: lookupObj("entry3.method.y"),
+					TNest:  []types.Type{lookupType("C")},
+					TArgs:  []types.Type{types.Typ[types.Int8]},
+				},
+				Instance{
+					Object: lookupObj("entry3.method.y"),
+					TNest:  []types.Type{lookupType("C")},
+					TArgs:  []types.Type{lookupType("C")},
+				},
 			),
 		}, {
 			descr: "generic type declaration",
 			resolver: NewResolver(
 				types.NewContext(),
-				ToSlice(lookupType("entry3").(*types.Named).TypeParams()),
+				lookupType("entry3").(*types.Named).TypeParams(),
 				[]types.Type{lookupType("D")},
+				nil,
 			),
 			node: lookupDecl("entry3"),
 			want: instancesInType(lookupType("D")),
@@ -255,6 +312,11 @@ func TestVisitor(t *testing.T) {
 				instances: &PackageInstanceSets{},
 				resolver:  test.resolver,
 				info:      info,
+			}
+			if test.resolver != nil {
+				// Since we know all the tests are for functions and methods,
+				// set the nested type to the type parameter from the resolver.
+				v.tNest = test.resolver.tArgs
 			}
 			ast.Walk(&v, test.node)
 			got := v.instances.Pkg(pkg).Values()
@@ -319,7 +381,7 @@ func TestSeedVisitor(t *testing.T) {
 	}
 	got := sv.instances.Pkg(pkg).Values()
 	if diff := cmp.Diff(want, got, instanceOpts()); diff != "" {
-		t.Errorf("Instances from initialSeeder contain diff (-want,+got):\n%s", diff)
+		t.Errorf("Instances from seedVisitor contain diff (-want,+got):\n%s", diff)
 	}
 }
 
@@ -353,28 +415,333 @@ func TestCollector(t *testing.T) {
 	}
 	c.Scan(pkg, file)
 
-	inst := func(name string, tArg types.Type) Instance {
+	inst := func(name, tNest, tArg string) Instance {
 		return Instance{
 			Object: srctesting.LookupObj(pkg, name),
-			TArgs:  []types.Type{tArg},
+			TNest:  evalTypeArgs(t, f.FileSet, pkg, tNest),
+			TArgs:  evalTypeArgs(t, f.FileSet, pkg, tArg),
 		}
 	}
 	want := []Instance{
-		inst("typ", types.Typ[types.Int]),
-		inst("typ.method", types.Typ[types.Int]),
-		inst("fun", types.Typ[types.Int8]),
-		inst("fun.nested", types.Typ[types.Int8]),
-		inst("typ", types.Typ[types.Int16]),
-		inst("typ.method", types.Typ[types.Int16]),
-		inst("typ", types.Typ[types.Int32]),
-		inst("typ.method", types.Typ[types.Int32]),
-		inst("fun", types.Typ[types.Int64]),
-		inst("fun.nested", types.Typ[types.Int64]),
+		inst(`typ`, ``, `int`),
+		inst(`typ.method`, ``, `int`),
+		inst(`fun`, ``, `int8`),
+		inst(`fun.nested`, `int8`, `int8`),
+		inst(`typ`, ``, `int16`),
+		inst(`typ.method`, ``, `int16`),
+		inst(`typ`, ``, `int32`),
+		inst(`typ.method`, ``, `int32`),
+		inst(`fun`, ``, `int64`),
+		inst(`fun.nested`, `int64`, `int64`),
 	}
 	got := c.Instances.Pkg(pkg).Values()
 	if diff := cmp.Diff(want, got, instanceOpts()); diff != "" {
-		t.Errorf("Instances from initialSeeder contain diff (-want,+got):\n%s", diff)
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
 	}
+}
+
+func TestCollector_MoreNesting(t *testing.T) {
+	src := `package test
+
+	func fun[T any]() {
+		type nestedCon struct{ X T }
+		_ = nestedCon{}
+
+		type nestedGen[U any] struct{ Y T; Z U }
+		_ = nestedGen[T]{}
+		_ = nestedGen[int8]{}
+
+		type nestedCover[T any] struct{ W T }
+		_ = nestedCover[T]{}
+		_ = nestedCover[int16]{}
+	}
+
+	func a() {
+		fun[int32]()
+		fun[int64]()
+	}
+	`
+
+	f := srctesting.New(t)
+	file := f.Parse(`test.go`, src)
+	info, pkg := f.Check(`pkg/test`, file)
+
+	c := Collector{
+		TContext:  types.NewContext(),
+		Info:      info,
+		Instances: &PackageInstanceSets{},
+	}
+	c.Scan(pkg, file)
+
+	inst := func(name, tNest, tArg string) Instance {
+		return Instance{
+			Object: srctesting.LookupObj(pkg, name),
+			TNest:  evalTypeArgs(t, f.FileSet, pkg, tNest),
+			TArgs:  evalTypeArgs(t, f.FileSet, pkg, tArg),
+		}
+	}
+	want := []Instance{
+		inst(`fun`, ``, `int32`),
+		inst(`fun`, ``, `int64`),
+
+		inst(`fun.nestedCon`, `int32`, ``),
+		inst(`fun.nestedCon`, `int64`, ``),
+
+		inst(`fun.nestedGen`, `int32`, `int32`),
+		inst(`fun.nestedGen`, `int32`, `int8`),
+		inst(`fun.nestedGen`, `int64`, `int64`),
+		inst(`fun.nestedGen`, `int64`, `int8`),
+
+		inst(`fun.nestedCover`, `int32`, `int32`),
+		inst(`fun.nestedCover`, `int32`, `int16`),
+		inst(`fun.nestedCover`, `int64`, `int64`),
+		inst(`fun.nestedCover`, `int64`, `int16`),
+	}
+	got := c.Instances.Pkg(pkg).Values()
+	if diff := cmp.Diff(want, got, instanceOpts()); diff != `` {
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCollector_NestingWithVars(t *testing.T) {
+	// This is loosely based off of go1.19.13/test/typeparam/issue47740b.go
+	// I was getting an error where `Q.print[int;]` was showing up when
+	// `Q.print` is not in a nesting context with `int` and this helped debug
+	// it. The problem was that `q` was being treated like a type not a var.
+	src := `package test
+
+	type Q struct{ v any }
+	func (q Q) print() {
+		println(q.v)
+	}
+
+	func newQ(v any) Q {
+		return Q{v}
+	}
+
+	type S[T any] struct{ x T }
+	func (s S[T]) echo() {
+		q := newQ(s.x)
+		q.print()
+	}
+
+	func a() {
+		s := S[int]{x: 0}
+		s.echo()
+	}
+	`
+
+	f := srctesting.New(t)
+	file := f.Parse(`test.go`, src)
+	info, pkg := f.Check(`pkg/test`, file)
+
+	c := Collector{
+		TContext:  types.NewContext(),
+		Info:      info,
+		Instances: &PackageInstanceSets{},
+	}
+	c.Scan(pkg, file)
+
+	inst := func(name, tNest, tArg string) Instance {
+		return Instance{
+			Object: srctesting.LookupObj(pkg, name),
+			TNest:  evalTypeArgs(t, f.FileSet, pkg, tNest),
+			TArgs:  evalTypeArgs(t, f.FileSet, pkg, tArg),
+		}
+	}
+	want := []Instance{
+		inst(`S`, ``, `int`),
+		inst(`S.echo`, ``, `int`),
+	}
+	got := c.Instances.Pkg(pkg).Values()
+	if diff := cmp.Diff(want, got, instanceOpts()); diff != `` {
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCollector_RecursiveTypeParams(t *testing.T) {
+	// This is based off of part of go1.19.13/test/typeparam/nested.go
+	src := `package test
+	func F[A any]() {}
+	func main() {
+		type U[_ any] int
+		type X[A any] U[X[A]]
+		F[X[int]]()
+	}
+	`
+
+	f := srctesting.New(t)
+	file := f.Parse(`test.go`, src)
+	info, pkg := f.Check(`test`, file)
+
+	c := Collector{
+		TContext:  types.NewContext(),
+		Info:      info,
+		Instances: &PackageInstanceSets{},
+	}
+	c.Scan(pkg, file)
+
+	tInt := types.Typ[types.Int]
+	xAny := srctesting.LookupObj(pkg, `main.X`)
+	xInt, err := types.Instantiate(types.NewContext(), xAny.Type(), []types.Type{tInt}, true)
+	if err != nil {
+		t.Fatalf("Failed to instantiate X[int]: %v", err)
+	}
+
+	want := []Instance{
+		{
+			Object: srctesting.LookupObj(pkg, `F`),
+			TArgs:  []types.Type{xInt},
+		}, {
+			Object: srctesting.LookupObj(pkg, `main.U`),
+			TArgs:  []types.Type{xInt},
+		}, {
+			Object: xAny,
+			TArgs:  []types.Type{tInt},
+		},
+	}
+	got := c.Instances.Pkg(pkg).Values()
+	if diff := cmp.Diff(want, got, instanceOpts()); diff != `` {
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCollector_NestedRecursiveTypeParams(t *testing.T) {
+	t.Skip(`Skipping test due to known issue with nested recursive type parameters.`)
+	// TODO(grantnelson-wf): This test is failing because the type parameters
+	// inside of U are not being resolved to concrete types. This is because
+	// when instantiating X in the collector, we are not resolving the
+	// nested type of U that is X's type argument. This leave the A in U
+	// as a type parameter instead of resolving it to string.
+
+	// This is based off of part of go1.19.13/test/typeparam/nested.go
+	src := `package test
+	func F[A any]() any {
+		type U[_ any] struct{ x A }
+		type X[B any] U[X[B]]
+		return X[int]{}
+	}
+	func main() {
+		print(F[string]())
+	}
+	`
+
+	f := srctesting.New(t)
+	file := f.Parse(`test.go`, src)
+	info, pkg := f.Check(`test`, file)
+
+	c := Collector{
+		TContext:  types.NewContext(),
+		Info:      info,
+		Instances: &PackageInstanceSets{},
+	}
+	c.Scan(pkg, file)
+
+	xAny := srctesting.LookupObj(pkg, `F.X`)
+	xInt, err := types.Instantiate(types.NewContext(), xAny.Type(), []types.Type{types.Typ[types.Int]}, true)
+	if err != nil {
+		t.Fatalf("Failed to instantiate X[int]: %v", err)
+	}
+	// TODO(grantnelson-wf): Need to instantiate xInt to replace `A` with `int` in the struct.
+	if isGeneric(xInt) {
+		t.Errorf("Expected uInt to be non-generic, got %v", xInt.Underlying())
+	}
+
+	want := []Instance{
+		{
+			Object: srctesting.LookupObj(pkg, `F`),
+			TArgs:  []types.Type{types.Typ[types.String]},
+		}, {
+			Object: srctesting.LookupObj(pkg, `F.U`),
+			TNest:  []types.Type{types.Typ[types.String]},
+			TArgs:  []types.Type{xInt},
+		}, {
+			Object: xAny,
+			TNest:  []types.Type{types.Typ[types.String]},
+			TArgs:  []types.Type{types.Typ[types.Int]},
+		},
+	}
+	got := c.Instances.Pkg(pkg).Values()
+	if diff := cmp.Diff(want, got, instanceOpts()); diff != `` {
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCollector_NestedTypeParams(t *testing.T) {
+	t.Skip(`Skipping test due to known issue with nested recursive type parameters.`)
+	// TODO(grantnelson-wf): This test is failing because the type parameters
+	// inside of U are not being resolved to concrete types. This is because
+	// when instantiating X in the collector, we are not resolving the
+	// nested type of U that is X's type argument. This leave the A in U
+	// as a type parameter instead of resolving it to string.
+
+	// This is based off of part of go1.19.13/test/typeparam/nested.go
+	src := `package test
+	func F[A any]() any {
+		type T[B any] struct{}
+		type U[_ any] struct{ X A }
+		return T[U[A]]{}
+	}
+	func main() {
+		print(F[int]())
+	}
+	`
+
+	f := srctesting.New(t)
+	file := f.Parse(`test.go`, src)
+	info, pkg := f.Check(`test`, file)
+
+	c := Collector{
+		TContext:  types.NewContext(),
+		Info:      info,
+		Instances: &PackageInstanceSets{},
+	}
+	c.Scan(pkg, file)
+
+	uAny := srctesting.LookupObj(pkg, `F.U`)
+	uInt, err := types.Instantiate(types.NewContext(), uAny.Type(), []types.Type{types.Typ[types.Int]}, true)
+	if err != nil {
+		t.Fatalf("Failed to instantiate U[int]: %v", err)
+	}
+	//TODO(grantnelson-wf): Need to instantiate uInt to replace `A` with `int` in the struct.
+	if isGeneric(uInt) {
+		t.Errorf("Expected uInt to be non-generic, got %v", uInt.Underlying())
+	}
+
+	want := []Instance{
+		{
+			Object: srctesting.LookupObj(pkg, `F`),
+			TArgs:  []types.Type{types.Typ[types.Int]},
+		}, {
+			Object: srctesting.LookupObj(pkg, `F.U`),
+			TNest:  []types.Type{types.Typ[types.Int]},
+			TArgs:  []types.Type{types.Typ[types.Int]},
+		}, {
+			Object: srctesting.LookupObj(pkg, `F.T`),
+			TNest:  []types.Type{types.Typ[types.Int]},
+			TArgs:  []types.Type{uInt},
+		},
+	}
+	got := c.Instances.Pkg(pkg).Values()
+	if diff := cmp.Diff(want, got, instanceOpts()); diff != `` {
+		t.Errorf("Instances from Collector contain diff (-want,+got):\n%s", diff)
+	}
+}
+
+func evalTypeArgs(t *testing.T, fSet *token.FileSet, pkg *types.Package, expr string) []types.Type {
+	if len(expr) == 0 {
+		return nil
+	}
+	args := strings.Split(expr, ",")
+	targs := make([]types.Type, 0, len(args))
+	for _, astr := range args {
+		tv, err := types.Eval(fSet, pkg, 0, astr)
+		if err != nil {
+			t.Fatalf("Eval(%s) failed: %v", astr, err)
+		}
+		targs = append(targs, tv.Type)
+	}
+	return targs
 }
 
 func TestCollector_CrossPackage(t *testing.T) {
@@ -492,7 +859,7 @@ func TestResolver_SubstituteSelection(t *testing.T) {
 			info, pkg := f.Check("pkg/test", file)
 
 			method := srctesting.LookupObj(pkg, "g.Method").(*types.Func).Type().(*types.Signature)
-			resolver := NewResolver(nil, ToSlice(method.RecvTypeParams()), []types.Type{srctesting.LookupObj(pkg, "x").Type()})
+			resolver := NewResolver(nil, method.RecvTypeParams(), []types.Type{srctesting.LookupObj(pkg, "x").Type()}, nil)
 
 			if l := len(info.Selections); l != 1 {
 				t.Fatalf("Got: %d selections. Want: 1", l)

--- a/compiler/internal/typeparams/map.go
+++ b/compiler/internal/typeparams/map.go
@@ -38,9 +38,9 @@ type InstanceMap[V any] struct {
 // If the given key isn't found, an empty bucket and -1 are returned.
 func (im *InstanceMap[V]) findIndex(key Instance) (mapBucket[V], int) {
 	if im != nil && im.data != nil {
-		bucket := im.data[key.Object][typeHash(im.hasher, key.TArgs...)]
+		bucket := im.data[key.Object][typeHash(im.hasher, key.TNest, key.TArgs)]
 		for i, candidate := range bucket {
-			if candidate != nil && candidate.key.TArgs.Equal(key.TArgs) {
+			if candidateArgsMatch(key, candidate) {
 				return bucket, i
 			}
 		}
@@ -82,7 +82,7 @@ func (im *InstanceMap[V]) Set(key Instance, value V) V {
 	if _, ok := im.data[key.Object]; !ok {
 		im.data[key.Object] = mapBuckets[V]{}
 	}
-	bucketID := typeHash(im.hasher, key.TArgs...)
+	bucketID := typeHash(im.hasher, key.TNest, key.TArgs)
 
 	// If there is already an identical key in the map, override the entry value.
 	hole := -1
@@ -90,7 +90,7 @@ func (im *InstanceMap[V]) Set(key Instance, value V) V {
 	for i, candidate := range bucket {
 		if candidate == nil {
 			hole = i
-		} else if candidate.key.TArgs.Equal(key.TArgs) {
+		} else if candidateArgsMatch(key, candidate) {
 			old := candidate.value
 			candidate.value = value
 			return old
@@ -180,13 +180,24 @@ func (im *InstanceMap[V]) String() string {
 	return `{` + strings.Join(entries, `, `) + `}`
 }
 
+// candidateArgsMatch checks if the candidate entry has the same type
+// arguments as the given key.
+func candidateArgsMatch[V any](key Instance, candidate *mapEntry[V]) bool {
+	return candidate != nil &&
+		candidate.key.TNest.Equal(key.TNest) &&
+		candidate.key.TArgs.Equal(key.TArgs)
+}
+
 // typeHash returns a combined hash of several types.
 //
 // Provided hasher is used to compute hashes of individual types, which are
 // xor'ed together. Xor preserves bit distribution property, so the combined
 // hash should be as good for bucketing, as the original.
-func typeHash(hasher typeutil.Hasher, types ...types.Type) uint32 {
+func typeHash(hasher typeutil.Hasher, nestTypes, types []types.Type) uint32 {
 	var hash uint32
+	for _, typ := range nestTypes {
+		hash ^= hasher.Hash(typ)
+	}
 	for _, typ := range types {
 		hash ^= hasher.Hash(typ)
 	}

--- a/compiler/internal/typeparams/map_test.go
+++ b/compiler/internal/typeparams/map_test.go
@@ -7,8 +7,10 @@ import (
 )
 
 func TestInstanceMap(t *testing.T) {
+	pkg := types.NewPackage(`testPkg`, `testPkg`)
+
 	i1 := Instance{
-		Object: types.NewTypeName(token.NoPos, nil, "i1", nil),
+		Object: types.NewTypeName(token.NoPos, pkg, "i1", nil),
 		TArgs: []types.Type{
 			types.Typ[types.Int],
 			types.Typ[types.Int8],
@@ -23,7 +25,7 @@ func TestInstanceMap(t *testing.T) {
 	}
 
 	i2 := Instance{
-		Object: types.NewTypeName(token.NoPos, nil, "i2", nil), // Different pointer.
+		Object: types.NewTypeName(token.NoPos, pkg, "i2", nil), // Different pointer.
 		TArgs: []types.Type{
 			types.Typ[types.Int],
 			types.Typ[types.Int8],
@@ -70,7 +72,7 @@ func TestInstanceMap(t *testing.T) {
 		if got := m.Len(); got != 1 {
 			t.Errorf("Got: map length %d. Want: 1.", got)
 		}
-		if got, want := m.String(), `{{type i1 int, int8}:abc}`; got != want {
+		if got, want := m.String(), `{testPkg.i1<int, int8>:abc}`; got != want {
 			t.Errorf("Got: map string %q. Want: map string %q.", got, want)
 		}
 		if got, want := m.Keys(), []Instance{i1}; !keysMatch(got, want) {
@@ -95,7 +97,7 @@ func TestInstanceMap(t *testing.T) {
 		if got := m.Get(i1clone); got != "def" {
 			t.Errorf(`Got: getting set key returned %q. Want: "def"`, got)
 		}
-		if got, want := m.String(), `{{type i1 int, int8}:def}`; got != want {
+		if got, want := m.String(), `{testPkg.i1<int, int8>:def}`; got != want {
 			t.Errorf("Got: map string %q. Want: map string %q.", got, want)
 		}
 		if got, want := m.Keys(), []Instance{i1}; !keysMatch(got, want) {
@@ -165,7 +167,7 @@ func TestInstanceMap(t *testing.T) {
 		if got := m.Len(); got != 5 {
 			t.Errorf("Got: map length %d. Want: 5.", got)
 		}
-		if got, want := m.String(), `{{type i1 int, int8}:def, {type i1 int, int}:456, {type i1 string, string}:789, {type i1 }:ghi, {type i2 int, int8}:123}`; got != want {
+		if got, want := m.String(), `{testPkg.i1:ghi, testPkg.i1<int, int8>:def, testPkg.i1<int, int>:456, testPkg.i1<string, string>:789, testPkg.i2<int, int8>:123}`; got != want {
 			t.Errorf("Got: map string %q. Want: map string %q.", got, want)
 		}
 		if got, want := m.Keys(), []Instance{i1, i2, i3, i4, i5}; !keysMatch(got, want) {

--- a/compiler/internal/typeparams/utils.go
+++ b/compiler/internal/typeparams/utils.go
@@ -3,6 +3,7 @@ package typeparams
 import (
 	"errors"
 	"fmt"
+	"go/token"
 	"go/types"
 )
 
@@ -17,6 +18,31 @@ func SignatureTypeParams(sig *types.Signature) *types.TypeParamList {
 	} else {
 		return nil
 	}
+}
+
+// FindNestingFunc returns the function or method that the given object
+// is nested in, or nil if the object was defined at the package level.
+func FindNestingFunc(obj types.Object) *types.Func {
+	objPos := obj.Pos()
+	if objPos == token.NoPos {
+		return nil
+	}
+
+	scope := obj.Parent()
+	for scope != nil {
+		// Iterate over all declarations in the scope.
+		for _, name := range scope.Names() {
+			decl := scope.Lookup(name)
+			if fn, ok := decl.(*types.Func); ok {
+				// Check if the object's position is within the function's scope.
+				if objPos >= fn.Pos() && objPos <= fn.Scope().End() {
+					return fn
+				}
+			}
+		}
+		scope = scope.Parent()
+	}
+	return nil
 }
 
 var (
@@ -57,4 +83,59 @@ func RequiresGenericsSupport(info *types.Info) error {
 	}
 
 	return nil
+}
+
+// isGeneric will search all the given types and their subtypes for a
+// *types.TypeParam. This will not check if a type could be generic,
+// but if each instantiation is not completely concrete yet.
+//
+// This is useful to check for generics types like `X[B[T]]`, where
+// `X` appears concrete because it is instantiated with the type argument `B[T]`,
+// however the `T` inside `B[T]` is a type parameter making `X[B[T]]` a generic
+// type since it required instantiation to a concrete type, e.g. `X[B[int]]`.
+func isGeneric(typ ...types.Type) bool {
+	var containsTypeParam func(t types.Type) bool
+
+	foreach := func(count int, getter func(index int) types.Type) bool {
+		for i := 0; i < count; i++ {
+			if containsTypeParam(getter(i)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	seen := make(map[types.Type]struct{})
+	containsTypeParam = func(t types.Type) bool {
+		if _, ok := seen[t]; ok {
+			return false
+		}
+		seen[t] = struct{}{}
+
+		switch t := t.(type) {
+		case *types.TypeParam:
+			return true
+		case *types.Named:
+			return t.TypeParams().Len() != t.TypeArgs().Len() ||
+				foreach(t.TypeArgs().Len(), func(i int) types.Type { return t.TypeArgs().At(i) }) ||
+				containsTypeParam(t.Underlying())
+		case *types.Struct:
+			return foreach(t.NumFields(), func(i int) types.Type { return t.Field(i).Type() })
+		case *types.Interface:
+			return foreach(t.NumMethods(), func(i int) types.Type { return t.Method(i).Type() })
+		case *types.Signature:
+			return foreach(t.Params().Len(), func(i int) types.Type { return t.Params().At(i).Type() }) ||
+				foreach(t.Results().Len(), func(i int) types.Type { return t.Results().At(i).Type() })
+		case *types.Map:
+			return containsTypeParam(t.Key()) || containsTypeParam(t.Elem())
+		case interface{ Elem() types.Type }:
+			// Handles *types.Pointer, *types.Slice, *types.Array, *types.Chan
+			return containsTypeParam(t.Elem())
+		default:
+			// Other types (e.g., basic types) do not contain type parameters.
+			return false
+		}
+	}
+
+	return foreach(len(typ), func(i int) types.Type { return typ[i] })
 }

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -198,7 +198,7 @@ func (fc *funcContext) translateSelection(sel typesutil.Selection, pos token.Pos
 			jsFieldName := s.Field(index).Name()
 			for {
 				fields = append(fields, fieldName(s, 0))
-				ft := s.Field(0).Type()
+				ft := fc.fieldType(s, 0)
 				if typesutil.IsJsObject(ft) {
 					return fields, jsTag
 				}
@@ -215,7 +215,7 @@ func (fc *funcContext) translateSelection(sel typesutil.Selection, pos token.Pos
 			}
 		}
 		fields = append(fields, fieldName(s, index))
-		t = s.Field(index).Type()
+		t = fc.fieldType(s, index)
 	}
 	return fields, ""
 }
@@ -441,13 +441,16 @@ func (fc *funcContext) objectName(o types.Object) string {
 
 // knownInstances returns a list of known instantiations of the object.
 //
-// For objects without type params always returns a single trivial instance.
+// For objects without type params and not nested in a generic function or
+// method, this always returns a single trivial instance.
+// If the object is generic, or in a generic function or method, but there are
+// no instances, then the object is unused and an empty list is returned.
 func (fc *funcContext) knownInstances(o types.Object) []typeparams.Instance {
-	if !typeparams.HasTypeParams(o.Type()) {
+	instances := fc.pkgCtx.instanceSet.Pkg(o.Pkg()).ForObj(o)
+	if len(instances) == 0 && !typeparams.HasTypeParams(o.Type()) {
 		return []typeparams.Instance{{Object: o}}
 	}
-
-	return fc.pkgCtx.instanceSet.Pkg(o.Pkg()).ForObj(o)
+	return instances
 }
 
 // instName returns a JS expression that refers to the provided instance of a
@@ -459,7 +462,8 @@ func (fc *funcContext) instName(inst typeparams.Instance) string {
 		return objName
 	}
 	fc.pkgCtx.DeclareDCEDep(inst.Object, inst.TArgs...)
-	return fmt.Sprintf("%s[%d /* %v */]", objName, fc.pkgCtx.instanceSet.ID(inst), inst.TArgs)
+	label := inst.TypeParamsString(` /* `, ` */`)
+	return fmt.Sprintf("%s[%d%s]", objName, fc.pkgCtx.instanceSet.ID(inst), label)
 }
 
 // methodName returns a JS identifier (specifically, object property name)
@@ -504,14 +508,31 @@ func (fc *funcContext) typeName(ty types.Type) string {
 			return "$error"
 		}
 		inst := typeparams.Instance{Object: t.Obj()}
+
+		// Get type arguments for the type if there are any.
 		for i := 0; i < t.TypeArgs().Len(); i++ {
 			inst.TArgs = append(inst.TArgs, t.TypeArgs().At(i))
 		}
+
+		// Get the nesting type arguments if there are any.
+		if fn := typeparams.FindNestingFunc(t.Obj()); fn != nil {
+			if fn.Scope().Contains(t.Obj().Pos()) {
+				tp := typeparams.SignatureTypeParams(fn.Type().(*types.Signature))
+				tNest := make([]types.Type, tp.Len())
+				for i := 0; i < tp.Len(); i++ {
+					tNest[i] = fc.typeResolver.Substitute(tp.At(i))
+				}
+				inst.TNest = typesutil.TypeList(tNest)
+			}
+		}
+
 		return fc.instName(inst)
 	case *types.Interface:
 		if t.Empty() {
 			return "$emptyInterface"
 		}
+	case *types.TypeParam:
+		panic(fmt.Errorf("unexpected type parameter: %v", t))
 	}
 
 	// For anonymous composite types, generate a synthetic package-level type
@@ -573,6 +594,12 @@ func (fc *funcContext) typeOf(expr ast.Expr) types.Type {
 		}
 	}
 	return fc.typeResolver.Substitute(typ)
+}
+
+// fieldType returns the type of the i-th field of the given struct
+// after substituting type parameters with concrete types for nested context.
+func (fc *funcContext) fieldType(t *types.Struct, i int) types.Type {
+	return fc.typeResolver.Substitute(t.Field(i).Type())
 }
 
 func (fc *funcContext) selectionOf(e *ast.SelectorExpr) (typesutil.Selection, bool) {

--- a/internal/govendor/subst/subst.go
+++ b/internal/govendor/subst/subst.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Copy of https://cs.opensource.google/go/x/tools/+/refs/tags/v0.17.0:go/ssa/subst.go
+// Any changes to this copy are labelled with GOPHERJS.
 package subst
 
 import (
@@ -81,9 +83,12 @@ func (subst *subster) typ(t types.Type) (res types.Type) {
 	// fall through if result r will be identical to t, types.Identical(r, t).
 	switch t := t.(type) {
 	case *types.TypeParam:
-		r := subst.replacements[t]
-		assert(r != nil, "type param without replacement encountered")
-		return r
+		// GOPHERJS: Replaced an assert that was causing a panic for nested types with code from
+		// https://cs.opensource.google/go/x/tools/+/refs/tags/v0.33.0:go/ssa/subst.go;l=92
+		if r := subst.replacements[t]; r != nil {
+			return r
+		}
+		return t
 
 	case *types.Basic:
 		return t

--- a/internal/govendor/subst/subst_test.go
+++ b/internal/govendor/subst/subst_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Copy of https://cs.opensource.google/go/x/tools/+/refs/tags/v0.17.0:go/ssa/subst_test.go
 package subst
 
 import (

--- a/internal/govendor/subst/util.go
+++ b/internal/govendor/subst/util.go
@@ -6,18 +6,16 @@ package subst
 
 import "go/types"
 
-// This file defines a number of miscellaneous utility functions.
-
-//// Sanity checking utilities
-
 // assert panics with the mesage msg if p is false.
 // Avoid combining with expensive string formatting.
+// From https://cs.opensource.google/go/x/tools/+/refs/tags/v0.17.0:go/ssa/util.go;l=27
 func assert(p bool, msg string) {
 	if !p {
 		panic(msg)
 	}
 }
 
+// From https://cs.opensource.google/go/x/tools/+/refs/tags/v0.33.0:go/ssa/wrappers.go;l=262
 func changeRecv(s *types.Signature, recv *types.Var) *types.Signature {
 	return types.NewSignatureType(recv, nil, nil, s.Params(), s.Results(), s.Variadic())
 }

--- a/internal/srctesting/srctesting.go
+++ b/internal/srctesting/srctesting.go
@@ -158,6 +158,9 @@ func LookupObj(pkg *types.Package, name string) types.Object {
 
 	for len(path) > 0 {
 		obj = scope.Lookup(path[0])
+		if obj == nil {
+			panic(fmt.Sprintf("failed to find %q in %q", path[0], name))
+		}
 		path = path[1:]
 
 		if fun, ok := obj.(*types.Func); ok {
@@ -170,6 +173,9 @@ func LookupObj(pkg *types.Package, name string) types.Object {
 		if len(path) > 0 {
 			obj, _, _ = types.LookupFieldOrMethod(obj.Type(), true, obj.Pkg(), path[0])
 			path = path[1:]
+			if fun, ok := obj.(*types.Func); ok {
+				scope = fun.Scope()
+			}
 		}
 	}
 	return obj


### PR DESCRIPTION
## Summary

Adding type parameters from a function into the nested types inside of that function. For example:

```Go
func Foo[T any]() {
	type Bar struct { x T }
	type Baz[U any] struct { x T; y U }
	...
}
```

The type `Bar` is concrete (i.e. not generic) however it acts like it is generic because it is nested in a generic function. If the function is called like `Foo[string]()` then `Bar` innately is different from if the function is called like `Foo[int]()`. The nesting type parameters is shown like `Bar[T;]` and instantiated like `Bar[string;]` and `Bar[int;]`.

In Go the `;` in the type parameters isn't present if the nested type is concrete. `Baz` is generic meaning the `;` indicates the separation between the nested type parameters and the objects own type parameters. For example if `Baz[string]{}` is expressed inside of `Foo[int]`, then a `Baz[int; string]` is instantiated. If `Baz[T]{}` is expressed inside of `Foo[X]`, then a `Baz[X; X]` is instantiated.

When creating instances for a nested type, all combinations of nest function instances and nesting type instances need to be determined. For example if `Foo` has the instances `Foo[string]` and `Foo[int]`, and `Baz` has the instances `Baz[bool]` and `Baz[string]`, then the resolved instances for `Baz` are `Baz[string; bool]`, `Baz[string; string]`, `Baz[int; bool]`, and `Baz[int; string]`. While reading the instances from `types.Info`, an instance may have a type parameter in it, e.g. `Baz[T]`. We replace the type parameter with the nest function's instance type arguments, meaning `Baz[T]` resolves to `Baz[int; int]` and `Baz[string; string]`, but not `Baz[int; string]` nor `Baz[string; int]`.

Note: I used `TNest` or similar to store the type arguments from the nest function or method as a separate set from `TArgs`. This is different from what Go does which is using an index for the "implicit" type arguments to differentiate between the two parts, [seen here](https://cs.opensource.google/go/go/+/release-branch.go1.19:src/cmd/compile/internal/noder/reader.go;l=693-713;bpv=1;bpt=0). I felt it was easier to maintain and to fit into the existing code better than using an index.

This is related to #1013 and #1270

----

## Future Work / Known Issues

### Fixing Nested Type Arguments

This change does not include a fix for when a type argument itself is nested. For example:

```Go
func Foo[T any]() {
	type Bar struct { X T }
	type Baz[U any] struct { }
	_ = Baz[Bar]{}
	...
}
```

The `Baz` is instantiated correctly using the nesting type argument for `Foo` and the argument given to it `Bar`. However, `Bar` has not been instantiated correctly with the nesting type argument for `Foo`, meaning `Bar` is still generic with the underlying type of `struct { X T }`. If `Foo[int]()` is called, the `Bar` used for the type argument for `Baz` needs to be `Bar[int;]` with `struct { X int }`.

I didn't fix this issue yet because it feels very unlikely, although possible, to happen, and I found it while finishing up this PR. So, instead of delaying this initial work on nested types, I left some tests that demonstrate the issue and skipped them with a `TODO(grantnelson-wf)` comment.

### Fixing DCE

This change does not include an update to the DCE to remove unused instances caused by nested types. For example:

```Go
func Foo[T any]() {
	type Bar struct { }
	...
}

func aliveCode() {
	Foo[string]()
}

func deadCode() {
	Foo[int]()
}
```

In the above code the instances `Foo[string]` and `Foo[int]` are created, then `Foo[int]` is found to be dead and eliminated. However, the instance `Bar[string;]` and `Bar[int;]` are created by their respective nest function instances. Right now our DCE doesn't take into account the nesting type parameters so will see all instances of `Bar` as alive because `"Bar"` is used in the alive `Foo[string]`. This leaves the dead code `Bar[int]`, also seen as `"Bar"`, alive when it should be eliminated.

A following ticket will fix the DCE to take into acount the nesting type parameters so that dead nested types will be properly removed.

### Numbering Nested Types Issue

This change does not include any of the numbering of types like Go does. For example:

```Go
type Biz[U any] struct{}

func Foo() any {
	type Baz struct{}
	return Biz[Baz]{}
}

func Bar() any {
	type Baz struct{}
	return Biz[Baz]{}
}
```

When the types returned from `Foo` and `Bar` are printed, they are `main.Biz[main.Baz·1]` and `main.Biz[main.Baz·2]` respectively. The `·1` and `·2` are indications of which declaration of `Baz` is being used. They are not shown in all cases and never show for package level declarations. The numbering is applied in the order the files are parsed and nested types are declared in those files.

The number increases monotonically with each new type declaration regardless of their name and type, meaning if the `Baz` in `Bar` is changed to `type Cat interface{}` and `Biz` is instantiated with `Cat` in `Bar`, the types are `main.Biz[main.Baz·1]` and `main.Biz[main.Cat·2]`. The type from `Foo` didn't change and `Cat` is still denoted with a `·2` since it is the second nested type.

Since these numbers aren't being collected nor printed, we can not remove `typeparam/nested.go` from the known failures of the Gorepo Tests yet. The test will not pass because the outputs will not match without the nested type numbering. So, not only are does that test hit some "Nested Type Arguments" (the `main.U`'s aren't being instantiated correctly), but the difference in the outputs looks like:

```Diff
+ 0,3: main.T[int;int]
+ 4,7: main.T[int;main.U[int]]
+ 22,23: main.T[main.Int;main.Int]
+ 26,27: main.T[main.Int;main.U[main.Int]]
- 0,3: main.T·2[int;int]
- 4,7: main.T·2[int;main.U·3[int;int]]
- 22,23: main.T·2[main.Int;main.Int]
- 26,27: main.T·2[main.Int;main.U·3[main.Int;main.Int]]
```