### PR TITLE
Handling nested type arguments

### DIFF
--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -451,13 +451,7 @@ func (fc *funcContext) newNamedTypeVarDecl(obj *types.TypeName) *Decl {
 func (fc *funcContext) newNamedTypeInstDecl(inst typeparams.Instance) (*Decl, error) {
 	originType := inst.Object.Type().(*types.Named)
 
-	var nestResolver *typeparams.Resolver
-	if len(inst.TNest) > 0 {
-		fn := typeparams.FindNestingFunc(inst.Object)
-		tp := typeparams.SignatureTypeParams(fn.Type().(*types.Signature))
-		nestResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, tp, inst.TNest, nil)
-	}
-	fc.typeResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, originType.TypeParams(), inst.TArgs, nestResolver)
+	fc.typeResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, inst)
 	defer func() { fc.typeResolver = nil }()
 
 	instanceType := originType
@@ -469,10 +463,7 @@ func (fc *funcContext) newNamedTypeInstDecl(inst typeparams.Instance) (*Decl, er
 			}
 			instanceType = instantiated.(*types.Named)
 		}
-		if len(inst.TNest) > 0 {
-			instantiated := nestResolver.Substitute(instanceType)
-			instanceType = instantiated.(*types.Named)
-		}
+		instanceType = fc.typeResolver.Substitute(instanceType).(*types.Named)
 	}
 
 	underlying := instanceType.Underlying()

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -531,7 +531,7 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		case *types.Signature:
 			return fc.formatExpr("%s", fc.instName(fc.instanceOf(e.X.(*ast.Ident))))
 		default:
-			panic(fmt.Errorf(`unhandled IndexExpr: %T`, t))
+			panic(fmt.Errorf(`unhandled IndexExpr: %T in %T`, t, fc.typeOf(e.X)))
 		}
 	case *ast.IndexListExpr:
 		switch t := fc.typeOf(e.X).Underlying().(type) {

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -48,13 +48,9 @@ func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, inst typep
 		c.allVars[k] = v
 	}
 
-	if sig.TypeParams().Len() > 0 {
-		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, sig.TypeParams(), inst.TArgs, nil)
-	} else if sig.RecvTypeParams().Len() > 0 {
-		c.typeResolver = typeparams.NewResolver(c.pkgCtx.typesCtx, sig.RecvTypeParams(), inst.TArgs, nil)
-	}
-	if c.objectNames == nil {
-		c.objectNames = map[types.Object]string{}
+	// Use the parent function's resolver unless the function has it's own type arguments.
+	if !inst.IsTrivial() {
+		c.typeResolver = typeparams.NewResolver(fc.pkgCtx.typesCtx, inst)
 	}
 
 	// Synthesize an identifier by which the function may reference itself. Since

--- a/compiler/internal/analysis/info.go
+++ b/compiler/internal/analysis/info.go
@@ -124,11 +124,7 @@ func (info *Info) newFuncInfoInstances(fd *ast.FuncDecl) []*FuncInfo {
 
 	funcInfos := make([]*FuncInfo, 0, len(instances))
 	for _, inst := range instances {
-		var resolver *typeparams.Resolver
-		if sig, ok := obj.Type().(*types.Signature); ok {
-			tp := typeparams.SignatureTypeParams(sig)
-			resolver = typeparams.NewResolver(info.typeCtx, tp, inst.TArgs, nil)
-		}
+		resolver := typeparams.NewResolver(info.typeCtx, inst)
 		fi := info.newFuncInfo(fd, inst.Object, inst.TArgs, resolver)
 		funcInfos = append(funcInfos, fi)
 	}

--- a/compiler/internal/typeparams/resolver.go
+++ b/compiler/internal/typeparams/resolver.go
@@ -1,0 +1,215 @@
+package typeparams
+
+import (
+	"fmt"
+	"go/types"
+	"sort"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/typesutil"
+	"github.com/gopherjs/gopherjs/internal/govendor/subst"
+)
+
+// Resolver translates types defined in terms of type parameters into concrete
+// types, given a root instance. The root instance provides context for mapping
+// from type parameters to type arguments so that the resolver can substitute
+// any type parameters used in types to the corresponding type arguments.
+//
+// In some cases, a generic type may not be able to be fully instantiated.
+// Generic named types that have no type arguments applied will have the
+// type parameters substituted, however the type arguments will not be
+// applied to instantiate the named type.
+//
+// For example, given `func Foo[T any]() { type Bar[U *T] struct { x T; y U } }`,
+// and if `Foo[int]` is used as the root for the resolver, then `Bar[U *T]` will
+// be substituted to create the generic `Bar[U *int] struct { x int; y U }`.
+// Alternatively, the instantiated but still generic because of the `T`,
+// `Bar[bool] struct { x T; y bool}` will be substituted for `Foo[int]` to
+// create the concrete `Bar[bool] struct { x int; y bool }`.
+//
+// Typically the instantiated type from `info.Instances` should be substituted
+// to resolve the implicit nesting types and create a concrete type.
+// See internal/govendor/subst/subst.go for more details.
+type Resolver struct {
+	tParams      *types.TypeParamList
+	tArgs        []types.Type
+	nest         *types.Func
+	nestTParams  *types.TypeParamList
+	nestTArgs    []types.Type
+	replacements map[*types.TypeParam]types.Type
+	root         Instance
+
+	// subster is the substitution helper that will perform the actual
+	// substitutions. This maybe nil when there are no substitutions but
+	// will still be usable when nil.
+	subster *subst.Subster
+	selMemo map[typesutil.Selection]typesutil.Selection
+}
+
+// NewResolver creates a new Resolver that will substitute type parameters
+// with the type arguments as defined in the provided Instance.
+func NewResolver(tc *types.Context, root Instance) *Resolver {
+	var (
+		nest         *types.Func
+		nestTParams  *types.TypeParamList
+		tParams      *types.TypeParamList
+		replacements = map[*types.TypeParam]types.Type{}
+	)
+
+	switch typ := root.Object.Type().(type) {
+	case *types.Signature:
+		nest = root.Object.(*types.Func)
+		tParams = SignatureTypeParams(typ)
+	case *types.Named:
+		tParams = typ.TypeParams()
+		nest = FindNestingFunc(root.Object)
+		if nest != nil {
+			nestTParams = SignatureTypeParams(nest.Type().(*types.Signature))
+		}
+	default:
+		panic(fmt.Errorf("unexpected type %T for object %s", typ, root.Object))
+	}
+
+	// Check the root's implicit nesting type parameters and arguments match,
+	// then add them to the replacements.
+	if nestTParams.Len() != len(root.TNest) {
+		panic(fmt.Errorf(`number of nesting type parameters and arguments must match: %d => %d`, nestTParams.Len(), len(root.TNest)))
+	}
+	for i := 0; i < nestTParams.Len(); i++ {
+		replacements[nestTParams.At(i)] = root.TNest[i]
+	}
+
+	// Check the root's type parameters and arguments match,
+	// then add them to the replacements.
+	if tParams.Len() != len(root.TArgs) {
+		panic(fmt.Errorf(`number of type parameters and arguments must match: %d => %d`, tParams.Len(), len(root.TArgs)))
+	}
+	for i := 0; i < tParams.Len(); i++ {
+		replacements[tParams.At(i)] = root.TArgs[i]
+	}
+
+	return &Resolver{
+		tParams:      tParams,
+		tArgs:        root.TArgs,
+		nest:         nest,
+		nestTParams:  nestTParams,
+		nestTArgs:    root.TNest,
+		replacements: replacements,
+		root:         root,
+		subster:      subst.New(tc, replacements),
+		selMemo:      map[typesutil.Selection]typesutil.Selection{},
+	}
+}
+
+// TypeParams is the list of type parameters that this resolver will substitute.
+func (r *Resolver) TypeParams() *types.TypeParamList {
+	if r == nil {
+		return nil
+	}
+	return r.tParams
+}
+
+// TypeArgs is the list of type arguments that this resolver will resolve to.
+func (r *Resolver) TypeArgs() []types.Type {
+	if r == nil {
+		return nil
+	}
+	return r.tArgs
+}
+
+// Nest is the nesting function that this resolver will resolve types with.
+// This will be null if the resolver is not for a nested context,
+func (r *Resolver) Nest() *types.Func {
+	if r == nil {
+		return nil
+	}
+	return r.nest
+}
+
+// NestTypeParams is the list of type parameters from the nesting function
+// that this resolver will substitute.
+func (r *Resolver) NestTypeParams() *types.TypeParamList {
+	if r == nil {
+		return nil
+	}
+	return r.nestTParams
+}
+
+// NestTypeArgs is the list of type arguments from the nesting function
+// that this resolver will resolve to.
+func (r *Resolver) NestTypeArgs() []types.Type {
+	if r == nil {
+		return nil
+	}
+	return r.nestTArgs
+}
+
+// Substitute replaces references to type params in the provided type definition
+// with the corresponding concrete types.
+func (r *Resolver) Substitute(typ types.Type) types.Type {
+	if r == nil || typ == nil {
+		return typ // No substitutions to be made.
+	}
+	return r.subster.Type(typ)
+}
+
+// SubstituteAll same as Substitute, but accepts a TypeList are returns
+// substitution results as a slice in the same order.
+func (r *Resolver) SubstituteAll(list *types.TypeList) []types.Type {
+	result := make([]types.Type, list.Len())
+	for i := range result {
+		result[i] = r.Substitute(list.At(i))
+	}
+	return result
+}
+
+// SubstituteSelection replaces a method of field selection on a generic type
+// defined in terms of type parameters with a method selection on a concrete
+// instantiation of the type.
+func (r *Resolver) SubstituteSelection(sel typesutil.Selection) typesutil.Selection {
+	if r == nil || sel == nil {
+		return sel // No substitutions to be made.
+	}
+	if concrete, ok := r.selMemo[sel]; ok {
+		return concrete
+	}
+
+	switch sel.Kind() {
+	case types.MethodExpr, types.MethodVal, types.FieldVal:
+		recv := r.Substitute(sel.Recv())
+		if types.Identical(recv, sel.Recv()) {
+			return sel // Non-generic receiver, no substitution necessary.
+		}
+
+		// Look up the method on the instantiated receiver.
+		pkg := sel.Obj().Pkg()
+		obj, index, _ := types.LookupFieldOrMethod(recv, true, pkg, sel.Obj().Name())
+		if obj == nil {
+			panic(fmt.Errorf("failed to lookup field %q in type %v", sel.Obj().Name(), recv))
+		}
+		typ := obj.Type()
+
+		if sel.Kind() == types.MethodExpr {
+			typ = typesutil.RecvAsFirstArg(typ.(*types.Signature))
+		}
+		concrete := typesutil.NewSelection(sel.Kind(), recv, index, obj, typ)
+		r.selMemo[sel] = concrete
+		return concrete
+	default:
+		panic(fmt.Errorf("unexpected selection kind %v: %v", sel.Kind(), sel))
+	}
+}
+
+// String gets a strings representation of the resolver for debugging.
+func (r *Resolver) String() string {
+	if r == nil {
+		return `{}`
+	}
+
+	parts := make([]string, 0, len(r.replacements))
+	for tp, ta := range r.replacements {
+		parts = append(parts, fmt.Sprintf("%s->%s", tp, ta))
+	}
+	sort.Strings(parts)
+	return `{` + strings.Join(parts, `, `) + `}`
+}

--- a/compiler/internal/typeparams/utils.go
+++ b/compiler/internal/typeparams/utils.go
@@ -28,16 +28,16 @@ func FindNestingFunc(obj types.Object) *types.Func {
 		return nil
 	}
 
-	scope := obj.Parent()
+	// We can't use `obj.Parent()` here since some types don't have a set
+	// parent, such as types created with `types.NewTypeName`. Instead find
+	// the innermost scope from the package to use as the object's parent scope.
+	scope := obj.Pkg().Scope().Innermost(objPos)
 	for scope != nil {
 		// Iterate over all declarations in the scope.
 		for _, name := range scope.Names() {
 			decl := scope.Lookup(name)
-			if fn, ok := decl.(*types.Func); ok {
-				// Check if the object's position is within the function's scope.
-				if objPos >= fn.Pos() && objPos <= fn.Scope().End() {
-					return fn
-				}
+			if fn, ok := decl.(*types.Func); ok && fn.Scope().Contains(objPos) {
+				return fn
 			}
 		}
 		scope = scope.Parent()
@@ -85,15 +85,22 @@ func RequiresGenericsSupport(info *types.Info) error {
 	return nil
 }
 
-// isGeneric will search all the given types and their subtypes for a
+// isGeneric will search all the given types in `typ` and their subtypes for a
 // *types.TypeParam. This will not check if a type could be generic,
 // but if each instantiation is not completely concrete yet.
+// The given `ignore` slice is used to ignore type params that are known not
+// to be substituted yet, typically the nest type parameters.
+//
+// This does allow for named types to have lazily substituted underlying types,
+// as returned by methods like `types.Instantiate`,
+// meaning that the type `B[T]` may be instantiated to `B[int]` but still have
+// the underlying type of `struct { t T }` instead of `struct { t int }`.
 //
 // This is useful to check for generics types like `X[B[T]]`, where
 // `X` appears concrete because it is instantiated with the type argument `B[T]`,
 // however the `T` inside `B[T]` is a type parameter making `X[B[T]]` a generic
 // type since it required instantiation to a concrete type, e.g. `X[B[int]]`.
-func isGeneric(typ ...types.Type) bool {
+func isGeneric(ignore *types.TypeParamList, typ []types.Type) bool {
 	var containsTypeParam func(t types.Type) bool
 
 	foreach := func(count int, getter func(index int) types.Type) bool {
@@ -106,19 +113,34 @@ func isGeneric(typ ...types.Type) bool {
 	}
 
 	seen := make(map[types.Type]struct{})
+	managed := make(map[types.Type]struct{})
+	for i := ignore.Len() - 1; i >= 0; i-- {
+		managed[ignore.At(i)] = struct{}{}
+	}
 	containsTypeParam = func(t types.Type) bool {
 		if _, ok := seen[t]; ok {
 			return false
 		}
 		seen[t] = struct{}{}
 
+		if _, ok := managed[t]; ok {
+			return false
+		}
+
 		switch t := t.(type) {
 		case *types.TypeParam:
 			return true
 		case *types.Named:
-			return t.TypeParams().Len() != t.TypeArgs().Len() ||
-				foreach(t.TypeArgs().Len(), func(i int) types.Type { return t.TypeArgs().At(i) }) ||
-				containsTypeParam(t.Underlying())
+			if t.TypeParams().Len() != t.TypeArgs().Len() ||
+				foreach(t.TypeArgs().Len(), func(i int) types.Type { return t.TypeArgs().At(i) }) {
+				return true
+			}
+			// Add type parameters to managed so that if they are encountered
+			// we know that they are just lazy substitutions for the checked type arguments.
+			for i := t.TypeParams().Len() - 1; i >= 0; i-- {
+				managed[t.TypeParams().At(i)] = struct{}{}
+			}
+			return containsTypeParam(t.Underlying())
 		case *types.Struct:
 			return foreach(t.NumFields(), func(i int) types.Type { return t.Field(i).Type() })
 		case *types.Interface:

--- a/internal/govendor/subst/export.go
+++ b/internal/govendor/subst/export.go
@@ -3,10 +3,7 @@
 // type arguments.
 package subst
 
-import (
-	"fmt"
-	"go/types"
-)
+import "go/types"
 
 // To simplify future updates of the borrowed code, we minimize modifications
 // to it as much as possible. This file implements an exported interface to the
@@ -17,17 +14,15 @@ type Subster struct {
 	impl *subster
 }
 
-// New creates a new Subster with a given list of type parameters and matching args.
-func New(tc *types.Context, tParams *types.TypeParamList, tArgs []types.Type) *Subster {
-	if tParams.Len() != len(tArgs) {
-		panic(fmt.Errorf("number of type parameters and arguments must match: %d => %d", tParams.Len(), len(tArgs)))
-	}
-
-	if tParams.Len() == 0 && len(tArgs) == 0 {
+// New creates a new Subster with a given a map from type parameters and the arguments
+// that should be used to replace them. If the map is empty, nil is returned.
+func New(tc *types.Context, replacements map[*types.TypeParam]types.Type) *Subster {
+	if len(replacements) == 0 {
 		return nil
 	}
 
-	subst := makeSubster(tc, nil, tParams, tArgs, false)
+	subst := makeSubster(tc, nil, nil, nil, false)
+	subst.replacements = replacements
 	return &Subster{impl: subst}
 }
 

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -153,10 +153,12 @@ var knownFails = map[string]failReason{
 	"typeparam/issue51733.go":  {category: usesUnsupportedPackage, desc: "unsafe: uintptr to struct pointer conversion is unsupported"},
 	"typeparam/typeswitch5.go": {category: lowLevelRuntimeDifference, desc: "GopherJS println format is different from Go's"},
 
-	// Failures related to the lack of generics support. Ideally, this section
-	// should be emptied once https://github.com/gopherjs/gopherjs/issues/1013 is
-	// fixed.
-	"typeparam/nested.go": {category: usesUnsupportedGenerics, desc: "incomplete support for generic types inside generic functions"},
+	// Failures related to the lack of nested type number indicators and deep nested types not printing correctly.
+	// For example, the following line from the test's outputs (see "typeparam/nested.out")
+	// `4,7: main.T·2[int;main.U·3[int;int]]` will currently output as `4,7: main.T[int;main.U[int]]`
+	// in GopherJS because we doesn't currently add the `·2` and `·3` indicators to the type names
+	// and the nested type arguments to deep nested type, e.g. `U[int;int]` is printed as `U[int]`.
+	"typeparam/nested.go": {category: usesUnsupportedGenerics, desc: "incomplete support for nested type numbering"},
 
 	// These are new tests in Go 1.19
 	"typeparam/issue51521.go": {category: lowLevelRuntimeDifference, desc: "different panic message when calling a method on nil interface"},


### PR DESCRIPTION
This fixes some issues (see "Fixing Nested Type Arguments" in summary of #1370).
This also cleans up some of the resolver code to make it easier to prepare for resolution of types.

This change fixes when a type argument itself is nested. For example:

```Go
func Foo[T any]() {
	type Bar struct { X T }
	type Baz[U any] struct { }
	_ = Baz[Bar]{}
	...
}
```

The `Baz` is instantiated correctly using the nesting type argument for `Foo` and the argument given to it `Bar`. However, `Bar` has not been instantiated correctly with the nesting type argument for `Foo`, meaning `Bar` is still generic with the underlying type of `struct { X T }`. If `Foo[int]()` is called, the `Bar` used for the type argument for `Baz` needs to be understood to be `Bar[int;]` with `struct { X int }`.

Initially I intended to change the substitution to always modify the underlying struct in a named type. However, that causes problems in the instance map since the instance map uses the object pointer as a key and the fully substituted object has a different pointer. Instead, following how `types.Instantiate` works, I made the instances allow for lazy substitution, i.e. unsubstituted type parameters are allowed in the context of a named type with those type parameters and properly substituted type arguments.

In the above example this would mean `Bar` would be seen as `struct { X T }` but that is now acceptable to the code since it is in context where `T` is defined. This is acceptable since the transformation code later on continues to substitute as needed, so the `T` will be substituted to `int` before it is used.

The only draw back to not fully substituting the underlying types is that when printing `Baz[Bar]` in `Foo[int]`; Go will output `Baz[Bar[int;]]` (ignoring the dot numbering and the extra `;`), whilst now, GopherJS will output `Baz[Bar]` without properly indicating the nesting context. We can swing back around to this later, I didn't want get stuck on this too long when it is rare that nested type arguments or deep nesting is used in normal code.
