### PR TITLE
Adding selectors to index handling for generics

### DIFF
--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -53,22 +53,11 @@ func IsTypeExpr(expr ast.Expr, info *types.Info) bool {
 		_, ok := info.Uses[e].(*types.TypeName)
 		return ok
 	case *ast.SelectorExpr:
-		_, ok := info.Uses[e.Sel].(*types.TypeName)
-		return ok
+		return IsTypeExpr(e.Sel, info)
 	case *ast.IndexExpr:
-		ident, ok := e.X.(*ast.Ident)
-		if !ok {
-			return false
-		}
-		_, ok = info.Uses[ident].(*types.TypeName)
-		return ok
+		return IsTypeExpr(e.X, info)
 	case *ast.IndexListExpr:
-		ident, ok := e.X.(*ast.Ident)
-		if !ok {
-			return false
-		}
-		_, ok = info.Uses[ident].(*types.TypeName)
-		return ok
+		return IsTypeExpr(e.X, info)
 	case *ast.ParenExpr:
 		return IsTypeExpr(e.X, info)
 	default:

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -723,6 +723,78 @@ func Test_CrossPackageAnalysis(t *testing.T) {
 	)
 }
 
+func Test_IndexedSelectors(t *testing.T) {
+	src1 := `
+		package main
+		import "github.com/gopherjs/gopherjs/compiler/other"
+		func main() {
+			// Instance IndexExpr with a package SelectorExpr for a function call.
+			other.PrintZero[int]()
+			other.PrintZero[string]()
+
+			// Instance IndexListExpr with a package SelectorExpr for a function call.
+			other.PrintZeroZero[int, string]()
+
+			// Index IndexExpr with a struct SelectorExpr for a function call.
+			f := other.Foo{Ops: []func() {
+				other.PrintZero[int],
+				other.PrintZero[string],
+				other.PrintZeroZero[int, string],
+			}}
+			f.Ops[0]()
+			f.Ops[1]()
+
+			// Index IndexExpr with a package/var SelectorExpr for a function call.
+			other.Bar.Ops[0]()
+			other.Baz[0]()
+
+			// IndexExpr with a SelectorExpr for a cast
+			_ = other.ZHandle[int](other.PrintZero[int])
+
+			// IndexListExpr with a SelectorExpr for a cast
+			_ = other.ZZHandle[int, string](other.PrintZeroZero[int, string])
+		}`
+	src2 := `
+		package other
+		func PrintZero[T any]() {
+			var zero T
+			println("Zero is ", zero)
+		}
+
+		func PrintZeroZero[T any, U any]() {
+			PrintZero[T]()
+			PrintZero[U]()
+		}
+
+		type ZHandle[T any] func()
+		type ZZHandle[T any, U any] func()
+
+		type Foo struct { Ops []func() }
+		var Bar = Foo{Ops: []func() {
+			PrintZero[int],
+			PrintZero[string],
+		}}
+		var Baz = Bar.Ops`
+
+	root := srctesting.ParseSources(t,
+		[]srctesting.Source{
+			{Name: `main.go`, Contents: []byte(src1)},
+		},
+		[]srctesting.Source{
+			{Name: `other/other.go`, Contents: []byte(src2)},
+		})
+
+	archives := compileProject(t, root, false)
+	// We mostly are checking that the code was turned into decls correctly,
+	// since the issue was that indexed selectors were not being handled correctly,
+	// so if it didn't panic by this point, it should be fine.
+	checkForDeclFullNames(t, archives,
+		`func:command-line-arguments.main`,
+		`type:github.com/gopherjs/gopherjs/compiler/other.ZHandle<int>`,
+		`type:github.com/gopherjs/gopherjs/compiler/other.ZZHandle<int, string>`,
+	)
+}
+
 func TestArchiveSelectionAfterSerialization(t *testing.T) {
 	src := `
 		package main

--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -282,25 +282,34 @@ func (fc *funcContext) funcDecls(functions []*ast.FuncDecl) ([]*Decl, error) {
 	var mainFunc *types.Func
 	for _, fun := range functions {
 		o := fc.pkgCtx.Defs[fun.Name].(*types.Func)
+		instances := fc.knownInstances(o)
+		if len(instances) == 0 {
+			// No instances of the function, skip it.
+			continue
+		}
 
 		if fun.Recv == nil {
 			// Auxiliary decl shared by all instances of the function that defines
-			// package-level variable by which they all are referenced.
+			// package-level variable by which they all are referenced,
+			// e.g. init functions and instances of generic functions.
 			objName := fc.objectName(o)
 			varDecl := &Decl{
 				FullName: funcVarDeclFullName(o),
 				Vars:     []string{objName},
 			}
 			varDecl.Dce().SetName(o)
-			if o.Type().(*types.Signature).TypeParams().Len() != 0 {
+			if len(instances) > 1 || !instances[0].IsTrivial() {
 				varDecl.DeclCode = fc.CatchOutput(0, func() {
 					fc.Printf("%s = {};", objName)
+					if o.Exported() {
+						fc.Printf("$pkg.%s = %s;", encodeIdent(fun.Name.Name), objName)
+					}
 				})
 			}
 			funcDecls = append(funcDecls, varDecl)
 		}
 
-		for _, inst := range fc.knownInstances(o) {
+		for _, inst := range instances {
 			funcDecls = append(funcDecls, fc.newFuncDecl(fun, inst))
 
 			if o.Name() == "main" {

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -529,14 +529,28 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		case *types.Basic:
 			return fc.formatExpr("%e.charCodeAt(%f)", e.X, e.Index)
 		case *types.Signature:
-			return fc.formatExpr("%s", fc.instName(fc.instanceOf(e.X.(*ast.Ident))))
+			switch u := e.X.(type) {
+			case *ast.Ident:
+				return fc.formatExpr("%s", fc.instName(fc.instanceOf(u)))
+			case *ast.SelectorExpr:
+				return fc.formatExpr("%s", fc.instName(fc.instanceOf(u.Sel)))
+			default:
+				panic(fmt.Errorf("unhandled IndexExpr of a Signature: %T in %T", u, fc.typeOf(e.X)))
+			}
 		default:
 			panic(fmt.Errorf(`unhandled IndexExpr: %T`, t))
 		}
 	case *ast.IndexListExpr:
 		switch t := fc.typeOf(e.X).Underlying().(type) {
 		case *types.Signature:
-			return fc.formatExpr("%s", fc.instName(fc.instanceOf(e.X.(*ast.Ident))))
+			switch u := e.X.(type) {
+			case *ast.Ident:
+				return fc.formatExpr("%s", fc.instName(fc.instanceOf(u)))
+			case *ast.SelectorExpr:
+				return fc.formatExpr("%s", fc.instName(fc.instanceOf(u.Sel)))
+			default:
+				panic(fmt.Errorf("unhandled IndexListExpr of a Signature: %T in %T", u, fc.typeOf(e.X)))
+			}
 		default:
 			panic(fmt.Errorf("unhandled IndexListExpr: %T", t))
 		}

--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -126,7 +126,7 @@ func (fc *funcContext) translateStandaloneFunction(fun *ast.FuncDecl) []byte {
 	body := fc.translateFunctionBody(fun.Type, nil, fun.Body)
 	code := bytes.NewBuffer(nil)
 	fmt.Fprintf(code, "\t%s = %s;\n", lvalue, body)
-	if fun.Name.IsExported() {
+	if fun.Name.IsExported() && fc.instance.IsTrivial() {
 		fmt.Fprintf(code, "\t$pkg.%s = %s;\n", encodeIdent(fun.Name.Name), lvalue)
 	}
 	return code.Bytes()

--- a/compiler/internal/analysis/info.go
+++ b/compiler/internal/analysis/info.go
@@ -574,7 +574,21 @@ func (fi *FuncInfo) visitCallExpr(n *ast.CallExpr, deferredCall bool) ast.Visito
 		if astutil.IsTypeExpr(f.Index, fi.pkgInfo.Info) {
 			// This is a call of an instantiation of a generic function,
 			// e.g. `foo[int]` in `func foo[T any]() { ... }; func main() { foo[int]() }`
-			fi.callToNamedFunc(fi.instanceForIdent(f.X.(*ast.Ident)), deferredCall)
+			var inst typeparams.Instance
+			switch fxt := f.X.(type) {
+			case *ast.Ident:
+				inst = fi.instanceForIdent(fxt)
+			case *ast.SelectorExpr:
+				if sel := fi.pkgInfo.Selections[fxt]; sel != nil {
+					inst = fi.instanceForSelection(sel)
+				} else {
+					// For qualified identifiers like `pkg.Foo`
+					inst = fi.instanceForIdent(fxt.Sel)
+				}
+			default:
+				panic(fmt.Errorf(`unexpected type %T for index expression %s`, f.X, f.X))
+			}
+			fi.callToNamedFunc(inst, deferredCall)
 			return fi
 		}
 		// The called function is gotten with an index or key from a map, array, or slice.
@@ -596,7 +610,21 @@ func (fi *FuncInfo) visitCallExpr(n *ast.CallExpr, deferredCall bool) ast.Visito
 		}
 		// This is a call of an instantiation of a generic function,
 		// e.g. `foo[int, bool]` in `func foo[T1, T2 any]() { ... }; func main() { foo[int, bool]() }`
-		fi.callToNamedFunc(fi.instanceForIdent(f.X.(*ast.Ident)), deferredCall)
+		var inst typeparams.Instance
+		switch fxt := f.X.(type) {
+		case *ast.Ident:
+			inst = fi.instanceForIdent(fxt)
+		case *ast.SelectorExpr:
+			if sel := fi.pkgInfo.Selections[fxt]; sel != nil {
+				inst = fi.instanceForSelection(sel)
+			} else {
+				// For qualified identifiers like `pkg.Foo`
+				inst = fi.instanceForIdent(fxt.Sel)
+			}
+		default:
+			panic(fmt.Errorf(`unexpected type %T for index list expression %s`, f.X, f.X))
+		}
+		fi.callToNamedFunc(inst, deferredCall)
 		return fi
 	default:
 		if astutil.IsTypeExpr(f, fi.pkgInfo.Info) {

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -959,3 +959,28 @@ func TestFileSetSize(t *testing.T) {
 		t.Errorf("Got: unsafe.Sizeof(token.FileSet{}) %v, Want: %v", n2, n1)
 	}
 }
+
+// TestCrossPackageGenericFuncCalls ensures that generic functions from other
+// packages can be called correctly.
+func TestCrossPackageGenericFuncCalls(t *testing.T) {
+	var wantInt int
+	if got := otherpkg.Zero[int](); got != wantInt {
+		t.Errorf(`Got: otherpkg.Zero[int]() = %v, Want: %v`, got, wantInt)
+	}
+
+	var wantStr string
+	if got := otherpkg.Zero[string](); got != wantStr {
+		t.Errorf(`Got: otherpkg.Zero[string]() = %q, Want: %q`, got, wantStr)
+	}
+}
+
+// TestCrossPackageGenericCasting ensures that generic types from other
+// packages can be used in a type cast.
+// The cast looks like a function call but should be treated as a type conversion.
+func TestCrossPackageGenericCasting(t *testing.T) {
+	fn := otherpkg.GetterHandle[int](otherpkg.Zero[int])
+	var wantInt int
+	if got := fn(); got != wantInt {
+		t.Errorf(`Got: otherpkg.GetterHandle[int](otherpkg.Zero[int]) = %v, Want: %v`, got, wantInt)
+	}
+}

--- a/tests/otherpkg/otherpkg.go
+++ b/tests/otherpkg/otherpkg.go
@@ -1,3 +1,10 @@
 package otherpkg
 
 var Test float32
+
+func Zero[T any]() T {
+	var zero T
+	return zero
+}
+
+type GetterHandle[T any] func() T


### PR DESCRIPTION
In several cases we expected the target expression (e.g. `e.X`) of an indexer expression (i.e.`IndexExp` and `IndexListExp`) to be an `*ast.Ident`, which is not true for all cases. I wrote a test containing a bunch of the cases I could think of that would put a `*ast. SelectorExpr` as the target expression of the indexer expression. Most of the unhandled cases were around calling an exported generic function from a different package, e.g. `package.Foo[int]()`. This must have slipped through the cracks when we were doing other generic stuff since it isn't too common in tests (ours and Go's) to have multiple packages.

I also fixed how exported functions are written to the package object. It was overwriting the package variable with the individual instances instead of setting the list of instances once.

This is related to #1013 and #1270