### PR TITLE
Adding Type Initialization Grouping and Ordering

### DIFF
--- a/compiler/internal/grouper/grouper.go
+++ b/compiler/internal/grouper/grouper.go
@@ -1,0 +1,242 @@
+package grouper
+
+import (
+	"go/types"
+	"sort"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/internal/sequencer"
+)
+
+type Decl interface {
+	Grouper() *Info
+	comparable
+}
+
+// Group groups the declarations by their dependencies and set the group number
+// (i.e. the dependency depth) for each Info.
+//
+// This returns the group count, where each decl with the same
+// group number is at the same depth and can be initialized together.
+// All group numbers will be in the range [0, count).
+//
+// This assumes that the `Grouper() *Info` methods on the declarations will
+// consistently return the same unique *Info for each declaration.
+//
+// This may panic with ErrCycleDetected if a cycle is detected in the dependency
+// graph created by the declarations' types. (see [Sequencer] for more details)
+//
+// [Sequencer]: ../sequencer/sequencer.go
+func Group[D Decl](decl map[D]struct{}) int {
+	g := prepareGrouper(decl)
+	for d := range decl {
+		g.assignGroup(d)
+	}
+	return g.count()
+}
+
+// ToGraph generates a Dot diagram string for the given declarations.
+// This is useful for visualizing the dependency graph of the declarations
+// any any possible cycles while debugging the type initialization order.
+//
+// This will not panic if a cycle is detected in the dependency graph,
+// instead it will indicate the declarations involved in the cycle with red
+// but the depth groups may be incorrect.
+func ToGraph[D Decl](decl map[D]struct{}, options sequencer.GraphOptions[D]) string {
+	g := prepareGrouper(decl)
+	return g.toGraph(decl, options)
+}
+
+// CyclesToString returns a string representation of the cycles detected in the
+// dependency graph of the given declarations.
+// This returns an empty string if no cycles are detected.
+//
+// If `toString` is not nil it is used to convert the declaration to a string
+// representation for additional context in the output.
+func CyclesToString[D Decl](decl map[D]struct{}, toString func(d D) string) string {
+	g := prepareGrouper(decl)
+	return g.toCycleString(decl, toString)
+}
+
+func prepareGrouper[D Decl](decl map[D]struct{}) *grouper[D] {
+	g := &grouper[D]{
+		typeMap: map[types.Type]*Info{},
+		alias:   map[*Info]*Info{},
+		seq:     sequencer.New[*Info](),
+	}
+	for d := range decl {
+		g.addDecl(d)
+	}
+	for d := range decl {
+		g.addDeps(d)
+	}
+	return g
+}
+
+type grouper[D Decl] struct {
+	typeMap map[types.Type]*Info
+	alias   map[*Info]*Info
+	seq     sequencer.Sequencer[*Info]
+}
+
+func (g *grouper[D]) addDecl(d D) {
+	info := d.Grouper()
+	if info == nil {
+		return
+	}
+	if info.name == nil && len(info.dep) == 0 {
+		// If the decl has no name and no deps, then it was a type
+		// that doesn't needed to be ordered, so we can skip it.
+		info.Group = 0
+		return
+	}
+	if info.name != nil {
+		if rep, has := g.typeMap[info.name]; has {
+			// A representative for the named type already exists
+			// so this info will alias to it.
+			g.alias[info] = rep
+		} else {
+			// If the name doesn't exist then this info will become
+			// the representative for the named type.
+			g.typeMap[info.name] = info
+			g.seq.Add(info)
+		}
+	} else {
+		// Add any unnamed info to the sequencer.
+		g.seq.Add(info)
+	}
+}
+
+func (g *grouper[D]) addDeps(d D) {
+	info := d.Grouper()
+	rep := g.unalias(info)
+	if !g.seq.Has(rep) {
+		// If the sequencer doesn't have this decl, then it was a type
+		// that doesn't needed to be ordered, so we can skip it.
+		return
+	}
+
+	// Add the dependencies from this info to the representative item.
+	for dep := range info.dep {
+		// If a type can not be found it doesn't exist so isn't initialized.
+		// So we can skip adding any dependencies for it.
+		if depInfo, ok := g.typeMap[dep]; ok {
+			g.seq.Add(rep, depInfo)
+		}
+	}
+}
+
+// unalias returns the representative info for the given info,
+// otherwise it returns the given info.
+func (g *grouper[D]) unalias(info *Info) *Info {
+	if rep, has := g.alias[info]; has {
+		return rep
+	}
+	return info
+}
+
+func (g *grouper[D]) getUnaliasMap(decl map[D]struct{}) map[*Info][]D {
+	infoMap := make(map[*Info][]D, len(decl))
+	for d := range decl {
+		if rep := g.unalias(d.Grouper()); g.seq.Has(rep) {
+			infoMap[rep] = append(infoMap[rep], d)
+		}
+	}
+	return infoMap
+}
+
+func (g *grouper[D]) count() int {
+	return g.seq.DepthCount()
+}
+
+func (g *grouper[D]) assignGroup(d D) {
+	info := d.Grouper()
+	// Calling `Depth` may perform sequencing if it hasn't been run before.
+	// It may cause a panic if a cycle is detected,
+	// but the cycle might not involve the current declaration and the panic
+	// would have occurred with any other declaration too.
+	depth := g.seq.Depth(g.unalias(info))
+	// If the depth is negative, then decl was not in the sequencer
+	// and was already assigned to group 0.
+	if depth >= 0 {
+		info.Group = depth
+	}
+}
+
+func (g *grouper[D]) toGraph(decl map[D]struct{}, declOpts sequencer.GraphOptions[D]) string {
+	seqOpts := sequencer.GraphOptions[*Info]{
+		FilterCycles:              declOpts.FilterCycles,
+		StrictFilter:              declOpts.StrictFilter,
+		Mermaid:                   declOpts.Mermaid,
+		HideGroups:                declOpts.HideGroups,
+		LabelItemsWithGroupNumber: declOpts.LabelItemsWithGroupNumber,
+	}
+
+	infoMap := g.getUnaliasMap(decl)
+
+	if declOpts.ItemToString != nil {
+		seqOpts.ItemToString = func(info *Info) string {
+			if decls, ok := infoMap[info]; ok {
+				parts := make([]string, len(decls))
+				for i, d := range decls {
+					parts[i] = declOpts.ItemToString(d)
+				}
+				return strings.Join(parts, "\n")
+			}
+			// This shouldn't happen, but handle it gracefully anyway.
+			return `unknown decl`
+		}
+	}
+
+	if declOpts.ItemFilter != nil {
+		seqOpts.ItemFilter = func(info *Info) bool {
+			if decls, ok := infoMap[info]; ok {
+				for _, d := range decls {
+					if declOpts.ItemFilter(d) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+	}
+
+	return g.seq.ToGraph(seqOpts)
+}
+
+func (g *grouper[D]) toCycleString(decl map[D]struct{}, toString func(d D) string) string {
+	cycles := g.seq.GetCycles()
+	if len(cycles) == 0 {
+		return `` // No cycles detected.
+	}
+
+	fullToString := func(d D) string {
+		if toString != nil {
+			return toString(d) + ` ` + d.Grouper().String()
+		}
+		return d.Grouper().String()
+	}
+
+	infoMap := g.getUnaliasMap(decl)
+	parts := make([]string, 0, len(cycles))
+	for _, cycle := range cycles {
+		decl := infoMap[cycle]
+		if len(decl) == 1 {
+			parts = append(parts, "-- "+fullToString(decl[0]))
+			continue
+		}
+
+		subParts := make([]string, len(decl))
+		for j, d := range decl {
+			subParts[j] = fullToString(d)
+		}
+		sort.Strings(subParts)
+		maxIndex := len(subParts) - 1
+		part := ",- " + subParts[0] + "\n|  " +
+			strings.Join(subParts[1:maxIndex], "\n|  ") +
+			"\n`- " + subParts[maxIndex]
+		parts = append(parts, part)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
+}

--- a/compiler/internal/grouper/info.go
+++ b/compiler/internal/grouper/info.go
@@ -1,0 +1,264 @@
+package grouper
+
+import (
+	"fmt"
+	"go/types"
+	"sort"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/compiler/internal/typeparams"
+	"github.com/gopherjs/gopherjs/compiler/typesutil"
+)
+
+type Info struct {
+	// Group is the group number for initializing this declaration.
+	// The declarations in the same group should still be initialized in the
+	// same order as they were declared based on imports first.
+	Group int
+
+	// name is the concrete named type that this declaration is associated with.
+	// This may be nil for declarations that do not have an associated concrete
+	// named type, such as functions, or have a skipped type, like `error`.
+	// Methods will use their receiver as the named type.
+	name *types.Named
+
+	// dep is a set of named types from other packages that this declaration
+	// depends on. This may be empty if there are no dependencies.
+	dep map[*types.Named]struct{}
+}
+
+// SetInstance sets the types and dependencies used by the grouper to represent
+// the declaration this grouper info is attached to.
+func (i *Info) SetInstance(tc *types.Context, inst typeparams.Instance) {
+	var pkg *types.Package
+	if inst.Object != nil {
+		pkg = inst.Object.Pkg()
+	}
+	i.setType(tc, inst, pkg)
+	i.addAllDeps(tc, inst, pkg)
+}
+
+func (i *Info) String() string {
+	name := `<unnamed>`
+	if i.name != nil {
+		name = i.name.String()
+	}
+	deps := make([]string, 0, len(i.dep))
+	for dep := range i.dep {
+		deps = append(deps, dep.String())
+	}
+	sort.Strings(deps)
+	return fmt.Sprintf(`Info(%d, %s, [%s])`, i.Group, name, strings.Join(deps, `, `))
+}
+
+func skipType(t *types.Named) bool {
+	if t.Obj() == nil || t.Obj().Pkg() == nil {
+		return true // skip objects in universal scope, e.g. `error`
+	}
+	if typesutil.IsJsPackage(t.Obj().Pkg()) && t.Obj().Name() == "Object" {
+		return true // skip *js.Object
+	}
+	return false
+}
+
+func (i *Info) setType(tc *types.Context, inst typeparams.Instance, pkg *types.Package) {
+	if inst.Object == nil {
+		return
+	}
+
+	var name *types.Named
+	switch t := inst.Object.Type().(type) {
+	case *types.Named:
+		if typeparams.CanResolve(inst) {
+			name = inst.Resolve(tc).(*types.Named)
+		}
+	case *types.Signature:
+		if recv := typesutil.RecvType(t); recv != nil {
+			inst2 := typeparams.Instance{
+				Object: recv.Obj(),
+				TNest:  inst.TNest,
+				TArgs:  inst.TArgs,
+			}
+			if typeparams.CanResolve(inst2) {
+				name = inst2.Resolve(tc).(*types.Named)
+			}
+		}
+	}
+
+	if name != nil && !skipType(name) {
+		if pkg == nil || pkg == name.Obj().Pkg() {
+			// Found the named type to use to represent this declaration.
+			i.name = name
+		}
+	}
+}
+
+type dedupStack struct {
+	stack []types.Type
+	seen  map[types.Type]struct{}
+}
+
+func (s *dedupStack) push(t ...types.Type) {
+	for _, t := range t {
+		if t == nil {
+			continue
+		}
+		if _, ok := s.seen[t]; !ok {
+			if s.seen == nil {
+				s.seen = make(map[types.Type]struct{})
+			}
+			s.seen[t] = struct{}{}
+			s.stack = append(s.stack, t)
+		}
+	}
+}
+
+func (s *dedupStack) pop() types.Type {
+	maxIndex := len(s.stack) - 1
+	if maxIndex < 0 {
+		return nil
+	}
+	t := s.stack[maxIndex]
+	s.stack = s.stack[:maxIndex]
+	return t
+}
+
+func (s *dedupStack) hasMore() bool {
+	return len(s.stack) > 0
+}
+
+func (i *Info) initPendingDeps(tc *types.Context, inst typeparams.Instance) *dedupStack {
+	pending := &dedupStack{}
+	pending.push(inst.TNest...)
+	pending.push(inst.TArgs...)
+
+	if inst.Object == nil {
+		// shouldn't happen, but if it does, just check the type args.
+		return pending
+	}
+
+	switch t := inst.Object.Type().(type) {
+	case *types.Named:
+		if typeparams.CanResolve(inst) {
+			r := typeparams.NewResolver(tc, inst)
+			tArgs := r.Substitute(t).(*types.Named).TypeArgs()
+			for j := tArgs.Len() - 1; j >= 0; j-- {
+				pending.push(tArgs.At(j))
+			}
+			pending.push(r.Substitute(t.Underlying()))
+			for j := t.NumMethods() - 1; j >= 0; j-- {
+				pending.push(r.Substitute(t.Method(j).Type()))
+			}
+		}
+		return pending
+
+	case *types.Signature:
+		if recv := typesutil.RecvType(t); recv != nil {
+			// The instance is a method, resolve the receiver type
+			// and the signature of the method to find its dependencies.
+			recvInst := typeparams.Instance{
+				Object: recv.Obj(),
+				TNest:  inst.TNest,
+				TArgs:  inst.TArgs,
+			}
+			if typeparams.CanResolve(recvInst) {
+				r := typeparams.NewResolver(tc, recvInst)
+				pending.push(r.Substitute(t))
+			}
+			return pending
+		}
+
+		// The instance is a function, resolve the signature.
+		if typeparams.CanResolve(inst) {
+			pending.push(inst.Resolve(tc))
+		}
+		return pending
+
+	default:
+		// If not a named type or method, we can add the type
+		// as a dependency directly without needing to resolve it further.
+		// This will take a type like `[]Cat` and add `Cat` as a dependency.
+		pending.push(inst.Object.Type())
+		return pending
+	}
+}
+
+func (i *Info) addAllDeps(tc *types.Context, inst typeparams.Instance, pkg *types.Package) {
+	pending := i.initPendingDeps(tc, inst)
+	for pending.hasMore() {
+		t := pending.pop()
+
+		switch t := t.(type) {
+		case *types.Basic:
+			// ignore basic types like int, string, unsafe.Pointer, etc.
+
+		case *types.Named:
+			if skipType(t) {
+				continue
+			}
+
+			// Add the basics for this object including methods.
+			inst2 := typeparams.Instance{Object: t.Obj()}
+			tArgs := t.TypeArgs()
+			inst2.TArgs = make(typesutil.TypeList, tArgs.Len())
+			for j := tArgs.Len() - 1; j >= 0; j-- {
+				inst2.TArgs[j] = tArgs.At(j)
+			}
+			var r *typeparams.Resolver
+			if typeparams.CanResolve(inst2) {
+				r = typeparams.NewResolver(tc, inst2)
+				for j := t.NumMethods() - 1; j >= 0; j-- {
+					pending.push(r.Substitute(t.Method(j).Type()))
+				}
+			}
+
+			if pkg != nil && pkg == t.Obj().Pkg() {
+				// Skip over named types from the same package,
+				// continue into them to depend on the same dependencies as they do.
+				// This prevents circular dependencies from being added.
+				for j := tArgs.Len() - 1; j >= 0; j-- {
+					pending.push(tArgs.At(j))
+				}
+				if r != nil {
+					pending.push(r.Substitute(t.Underlying()))
+				}
+				continue
+			}
+
+			// add the dependency to the set
+			if i.dep == nil {
+				i.dep = make(map[*types.Named]struct{})
+			}
+			i.dep[t] = struct{}{}
+
+		case *types.Interface:
+			for j := t.NumExplicitMethods() - 1; j >= 0; j-- {
+				pending.push(t.ExplicitMethod(j).Type())
+			}
+			for j := t.NumEmbeddeds() - 1; j >= 0; j-- {
+				pending.push(t.EmbeddedType(j))
+			}
+
+		case *types.Struct:
+			for j := t.NumFields() - 1; j >= 0; j-- {
+				pending.push(t.Field(j).Type())
+			}
+
+		case *types.Signature:
+			for j := t.Params().Len() - 1; j >= 0; j-- {
+				pending.push(t.Params().At(j).Type())
+			}
+			for j := t.Results().Len() - 1; j >= 0; j-- {
+				pending.push(t.Results().At(j).Type())
+			}
+
+		case *types.Map:
+			pending.push(t.Key())
+			pending.push(t.Elem())
+
+		case interface{ Elem() types.Type }:
+			// Handles *types.Pointer, *types.Slice, *types.Array, and *types.Chan
+			pending.push(t.Elem())
+		}
+	}
+}

--- a/compiler/internal/grouper/info_test.go
+++ b/compiler/internal/grouper/info_test.go
@@ -1,0 +1,332 @@
+package grouper
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gopherjs/gopherjs/compiler/internal/typeparams"
+	"github.com/gopherjs/gopherjs/compiler/typesutil"
+	"github.com/gopherjs/gopherjs/internal/srctesting"
+)
+
+func TestInstanceDecomposition(t *testing.T) {
+	type testData struct {
+		name     string
+		context  *types.Context
+		instance typeparams.Instance
+		expName  *types.Named
+		expDeps  map[*types.Named]struct{}
+	}
+
+	tests := []testData{
+		func() testData {
+			tg := readTypes(t, `type Foo[T, U, V any] struct {}`)
+			return testData{
+				name:    `do not depend on basic types`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo`),
+					TArgs:  tg.TypeList(`int`, `string`, `bool`),
+				},
+				expName: tg.Named(`Foo[int, string, bool]`),
+				expDeps: nil,
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `type Foo[T, U any] struct {}`)
+			return testData{
+				name:    `do not depend on empty any or error`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo`),
+					TArgs:  tg.TypeList(`any`, `error`),
+				},
+				expName: tg.Named(`Foo[any, error]`),
+				expDeps: nil,
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo[T, U any] struct {}
+				type Baz[V any] struct {}`)
+			return testData{
+				name:    `depend on type parameters`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo`),
+					TArgs:  tg.TypeList(`Baz[any]`, `Foo[int, bool]`),
+				},
+				expName: tg.Named(`Foo[Baz[any], Foo[int, bool]]`),
+				expDeps: tg.NamedSet(`Baz[any]`, `Foo[int, bool]`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct {}
+				var f *Foo`)
+			return testData{
+				name:    `depend on pointer element`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`f`),
+				},
+				expName: nil, // `*Foo` is not named so it can't be depended on by name
+				expDeps: tg.NamedSet(`Foo`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct {}
+				var s []Foo`)
+			return testData{
+				name:    `depend on slice element`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`s`),
+				},
+				expName: nil, // `[]Foo` is not named
+				expDeps: tg.NamedSet(`Foo`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct {}
+				var c chan Foo`)
+			return testData{
+				name:    `depend on chan element`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`c`),
+				},
+				expName: nil, // `chan Foo` is not named
+				expDeps: tg.NamedSet(`Foo`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct {}
+				type Bar struct {}
+				var m map[Bar]Foo`)
+			return testData{
+				name:    `depend on map key and element`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`m`),
+				},
+				expName: nil, // `map[Bar]Foo` is not named
+				expDeps: tg.NamedSet(`Bar`, `Foo`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct { X Bar[Baz] }
+				type Bar[T any] struct {}
+				type Baz struct {}`)
+			return testData{
+				name:    `depend on fields`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo`),
+				},
+				expName: tg.Named(`Foo`),
+				expDeps: tg.NamedSet(`Bar[Baz]`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo struct {}
+				func (f Foo) Bar(p *Baz) []*Taz { return nil}
+				type Baz struct {}
+				type Taz struct {}`)
+			return testData{
+				name:    `depend on receiver, parameter, and result types`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo.Bar`),
+				},
+				// methods are named with their receiver
+				expName: tg.Named(`Foo`),
+				expDeps: tg.NamedSet(`Baz`, `Taz`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo[T any] struct {}
+				func (f *Foo[T]) Bar(x int, y int) {}`)
+			return testData{
+				name:    `depend on complex receiver types`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo.Bar`),
+					TArgs:  tg.TypeList(`int`),
+				},
+				// methods are named with their receiver
+				expName: tg.Named(`Foo[int]`),
+				expDeps: nil,
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo[T any] struct {}
+				func Bar[T any](x []*Foo[T]) map[string]*Foo[T] { return nil }
+				type Baz struct {}`)
+			return testData{
+				name:    `depend on resolved parameters and results`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Bar`),
+					TArgs:  tg.TypeList(`Baz`),
+				},
+				expName: nil,
+				expDeps: tg.NamedSet(`Baz`, `Foo[Baz]`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo[T any] struct {}
+				type Bar struct {}
+				var Baz = Foo[Bar]{}`)
+			return testData{
+				name:    `variables depend on the named in their type`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Baz`),
+				},
+				expName: tg.Named(`Foo[Bar]`),
+				expDeps: tg.NamedSet(`Bar`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+				type Foo []struct{ b Bar }
+				type Bar struct {}
+				type Baz Foo`)
+			return testData{
+				name:    `dependency on underlying types for aliased types`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Baz`),
+				},
+				expName: tg.Named(`Baz`),
+				expDeps: tg.NamedSet(`Bar`),
+			}
+		}(),
+		func() testData {
+			tg := readTypes(t, `
+					func Foo[T any]() any {
+						type Bar struct{ x T}
+						return Bar{}
+					}
+					type Baz struct{}`)
+			return testData{
+				name:    `depend on implicit nesting type arguments`,
+				context: tg.tf.Context,
+				instance: typeparams.Instance{
+					Object: tg.Object(`Foo.Bar`),
+					TNest:  tg.TypeList(`Baz`),
+				},
+				expName: tg.Object(`Foo.Bar`).Type().(*types.Named),
+				expDeps: tg.NamedSet(`Baz`),
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info := &Info{}
+			// Instead of calling SetInstance, we manually set the type and
+			// dependencies so that we can tell it to not skip the same package
+			// dependencies (via passing in a nil package to addAllDeps).
+			// This will make testing Info a lot easier.
+			info.setType(test.context, test.instance, nil)
+			info.addAllDeps(test.context, test.instance, nil)
+
+			if info.name != test.expName {
+				t.Errorf("expected type %v, got %v", test.expName, info.name)
+			}
+			if diff := cmp.Diff(test.expDeps, info.dep); diff != "" {
+				t.Errorf("unexpected dependencies (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type typeGetter struct {
+	tf    *srctesting.Fixture
+	cache map[string]types.Type
+}
+
+func readTypes(t *testing.T, src string) typeGetter {
+	t.Helper()
+	tf := srctesting.New(t)
+	tf.Check(`pkg/test`, tf.Parse(`test.go`, "package testcase\n"+src))
+	return typeGetter{
+		tf:    tf,
+		cache: make(map[string]types.Type),
+	}
+}
+
+func (tg typeGetter) Object(name string) types.Object {
+	tg.tf.T.Helper()
+	importPath := `pkg/test`
+	if path, remainder, found := strings.Cut(name, `.`); found {
+		if _, has := tg.tf.Packages[path]; has {
+			importPath, name = path, remainder
+		}
+	}
+	pkg := tg.tf.Packages[importPath]
+	if pkg == nil {
+		tg.tf.T.Fatalf(`missing package %q in fixture`, importPath)
+	}
+	return srctesting.LookupObj(pkg, name)
+}
+
+func (tg typeGetter) Type(expr string) types.Type {
+	tg.tf.T.Helper()
+	if typ, ok := tg.cache[expr]; ok {
+		return typ
+	}
+
+	f := tg.tf.Parse(`eval`, "package testcase\nvar _ "+expr)
+	config := &types.Config{
+		Context:  tg.tf.Context,
+		Sizes:    &types.StdSizes{WordSize: 4, MaxAlign: 8},
+		Importer: tg.tf,
+	}
+	pkg := tg.tf.Packages[`pkg/test`]
+	ck := types.NewChecker(config, tg.tf.FileSet, pkg, tg.tf.Info)
+	if err := ck.Files([]*ast.File{f}); err != nil {
+		tg.tf.T.Fatalf("failed to type check expression %q: %v", expr, err)
+	}
+
+	node := f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Type
+	typ := tg.tf.Info.Types[node].Type
+	tg.cache[expr] = typ
+	return typ
+}
+
+func (tg typeGetter) TypeList(expr ...string) typesutil.TypeList {
+	tg.tf.T.Helper()
+	result := make([]types.Type, len(expr))
+	for i, expr := range expr {
+		result[i] = tg.Type(expr)
+	}
+	return result
+}
+
+func (tg typeGetter) Named(expr string) *types.Named {
+	tg.tf.T.Helper()
+	return tg.Type(expr).(*types.Named)
+}
+
+func (tg typeGetter) NamedSet(exprs ...string) map[*types.Named]struct{} {
+	tg.tf.T.Helper()
+	result := make(map[*types.Named]struct{}, len(exprs))
+	for _, expr := range exprs {
+		result[tg.Named(expr)] = struct{}{}
+	}
+	return result
+}

--- a/compiler/internal/sequencer/README.md
+++ b/compiler/internal/sequencer/README.md
@@ -1,0 +1,161 @@
+# Sequencer
+
+- [Overview](#overview)
+- [Limitations](#limitations)
+- [Design](#design)
+- [Ordering and Grouping](#ordering-and-grouping)
+
+## Overview
+
+The sequencer is a tool used to determine the order of steps to process
+a set of items based on each items' dependencies.
+This can group items together if they can all be processed in the same step.
+This assumes there are no circular dependencies and will error if any
+cycle is detected.
+
+The sequencer _could_ be used to solve several problems[^1], such as:
+
+- Ordering type initialization
+- Ordering constant resolution
+- Ordering packages for parallel parsing
+- Explicit super-type determination to solidify implicit duck-typing
+- Checking for cycles in dependencies
+
+[^1]: We don't use the sequencer for all of those problems. Some are solved
+with other tools and some are solutions we don't currently support. Several
+of them would need an additional value tagging system added.
+
+## Limitations
+
+> [!IMPORTANT]
+> The sequencer can only sequence a collection of items that do _not_ have
+> dependency cycles.
+
+<!---->
+> [!WARNING]
+> The sequencer can only sequence items that are
+> [comparable](https://go.dev/ref/spec#Comparison_operators)
+>
+> Since the items are used a keys in the graph, the comparable parts
+> of an item must not be modified after being added,
+> since that could cause keying issues.
+
+The sequencer does not:
+
+- sort items in the groups, each group is randomly ordered
+- provide any weighted or prioritized dependencies
+- provide a tagging system for data propagation needed for problems like DCE
+- allow removing items from the graph nor removing dependencies
+
+## Design
+
+The sequencer uses a type of
+[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
+called a [polyforest](https://en.wikipedia.org/wiki/Polytree).
+A polyforest is an acyclic forest were branches may have more than one parent
+branch and those parents may be from the same or different trees.
+
+The polyforest, like any graph, is made up of vertices and edges.
+The vertices are the items being ordered and the directed edge starts from a
+vertex, the parent, and ends on a vertex, child, dependent of that parent.
+Each vertex may have zero or more parents and zero or more children.
+Any vertex that has no children (other vertices depending on it) is a root.
+Any vertex that has no parents (dependencies) is a leaf.
+A vertex may be a leaf and root at the same time.
+The graph flows from the root towards the leaves via child to parent.
+There may be zero or more paths from any root to any leaf.
+
+```mermaid
+flowchart TB
+  v1["1"] --> v7 & v4 & v5
+  v2["2"] --> v5
+  v3["3"]
+  v4["4"] --> v7
+  v5["5"] --> v7 & v8
+  v6["6"] --> v8
+  v7["7"]
+  v8["8"]
+```
+
+In the above example:
+
+- The vertices are $1$, $2$, $3$, $4$, $5$, $6$, $7$, and $8$
+- The edged ($child$ → {$parents$} ) are $1$ → {$4, 5, 7$},
+  $2$ → {$5$}, $4$ → {$7$}, $5$ → {$7, 8$}, and $6$ → {$8$}
+- The leafs are $3$, $7$, and $8$
+- The roots are $1$, $2$, $3$, and $8$
+
+## Ordering and Grouping
+
+All the leaf vertices will receive a depth of zero value.
+All other vertices will receive the maximum value of its parents' depths plus one.
+All the vertices with the same depth value are in a group and may be processed
+together. The depth values provide the ordering of those groups.
+
+For example if there are three depth groups.
+Depth 0 will contain all the leaf vertices with no children.
+Depth 1 will contain all the vertices that only depend on vertices in depth 0.
+Depth 2 will contain all vertices that depend on vertices in depth 0 and 1.
+At each depth, the vertices must depend on at least one vertex in the prior
+depth, otherwise that vertex would have been put into that prior depth itself.
+
+```mermaid
+flowchart TB
+  v1["1"] --> v7 & v4 & v5
+  v2["2"] --> v5
+  v3["3"]
+  v4["4"] --> v7
+  v5["5"] --> v7 & v8
+  v6["6"] --> v8
+  v7["7"]
+  v8["8"]
+  subgraph Depth 2
+    v1 & v2
+  end
+  subgraph Depth 1
+    v4 & v5 & v6
+  end
+  subgraph Depth 0
+    v7 & v8 & v3
+  end
+```
+
+In the above example:
+
+- the group for depth 0 is $\{3, 7, 8\}$
+- the group for depth 1 is $\{4, 5, 6\}$
+- the group for depth 2 is $\{1, 2\}$
+
+There are several ways to perform the grouping and depth determination.
+One way is to set all the vertices to zero (not just the leaves) then update
+each vertex with the maximum of their parents plus one until no more changes
+are made. That would take $n \cdot d$ amount of time, where $n$ is the number
+of vertices and $d$ is the maximum depth. This can be improved by propagating
+starting from each leaf heading towards the roots. Anytime a vertex depth
+changes recalculate all the children vertices.
+However, this is still slow because the same children depths will be
+recalculated each time a parent is changed and it could still get stuck
+in an infinite loop if there is a cycle.
+
+To keep from having to recalculate a child's depth, each vertex will
+keep a count of parents it is waiting on. When a vertex has its depth
+assigned, that vertex's children will have that parent count decremented.
+When that parent count is zero, the vertex will be put into the set of
+vertices that need to be calculated.
+The set of vertices to be calculated is initially populated with
+the leaves since they aren't waiting on any parents.
+If all the set of vertices pending calculation is empty and there are no
+more vertices waiting on parents, then the depth determination is done.
+
+However, if the set of vertices pending calculation is empty but there
+are still vertices waiting on parents, then a cycle exists within those
+vertices still waiting. Some of the vertices waiting may not participate
+in the cycle but instead simply depend on vertices in the cycle.
+There might also be multiple cycles. Cycles indicate the dependency
+information given to the sequencer was bad so the sequencer will return
+an error and provide information about any cycle.
+
+> [!NOTE]
+> This assumes that the sequencing will be performed only once
+> after all dependencies have been added. It doesn't have the partial
+> sequencing capabilities, so it will always recalculate everything.

--- a/compiler/internal/sequencer/sequencer.go
+++ b/compiler/internal/sequencer/sequencer.go
@@ -1,0 +1,131 @@
+package sequencer
+
+import "errors"
+
+// ErrCycleDetected is panicked from a method performing sequencing
+// (e.g. `Depth`, `DepthCount`, and `Group`) to indicate that a cycle
+// was detected in the dependency graph.
+var ErrCycleDetected = errors.New(`cycle detected in the dependency graph`)
+
+// Sequencer is a tool for determining the groups and ordering of the groups
+// of items based on their dependencies.
+type Sequencer[T comparable] interface {
+
+	// Add adds a `child` item with a dependency on the given `parents`.
+	Add(child T, parents ...T)
+
+	// Has checks if an item exists in the sequencer.
+	Has(item T) bool
+
+	// Children returns the items that are dependent on the given item.
+	// If the given item doesn't exist then nil is returned.
+	// Each time this is called it creates a new slice.
+	// The items in the slice are in random order.
+	Children(item T) []T
+
+	// Parents returns the items that the given item depends on.
+	// If the given item doesn't exist then nil is returned.
+	// Each time this is called it creates a new slice.
+	// The items in the slice are in random order.
+	Parents(item T) []T
+
+	// Depth returns the depth of the item in the dependency graph.
+	// Zero indicates the item is a leaf item with no dependencies.
+	// If the given item doesn't exist then -1 is returned.
+	//
+	// This may have to perform sequencing of the items, so
+	// this may panic with `ErrCycleDetected` if a cycle is detected.
+	Depth(item T) int
+
+	// DepthCount returns the number of unique depths in the dependency graph.
+	//
+	// This may have to perform sequencing of the items, so
+	// this may panic with `ErrCycleDetected` if a cycle is detected.
+	DepthCount() int
+
+	// Group returns all the items at the given depth.
+	// If the depth is out-of-bounds, it returns an empty slice.
+	// The depth is zero-based, so the depth 0 group is the leaf items.
+	// Each time this is called it creates a new slice.
+	// The items in the slice are in random order.
+	//
+	// This may have to perform sequencing of the items, so
+	// this may panic with `ErrCycleDetected` if a cycle is detected.
+	Group(depth int) []T
+
+	// AllGroups returns all the items grouped by their depth.
+	// Each group is a slice of items at the same depth.
+	// The depth is zero-based, so the first group is the leaf items.
+	// Each time this is called it creates a new slices.
+	// The items in the slices are in random order.
+	//
+	// This may have to perform sequencing of the items, so
+	// this may panic with `ErrCycleDetected` if a cycle is detected.
+	AllGroups() [][]T
+
+	// GetCycles returns the items that were unable to be sequenced
+	// due to a cycle in the dependency graph.
+	// The returned items may participate in one or more cycles or
+	// depends on an item in a cycle.
+	// Otherwise nil is returned if there are no cycles.
+	//
+	// There is no need to call this method before calling other methods.
+	// If this returns a non-empty slice, other methods that perform sequencing
+	// (e.g. `Depth`, `DepthCount`, and `Group`) will panic with `ErrCycleDetected`.
+	// Obviously, this will not panic if a cycle is detected.
+	//
+	// This may have to perform sequencing of the items.
+	GetCycles() []T
+
+	// ToGraph returns a string representation of the dependency graph.
+	// This is useful for visualizing the dependencies and
+	// debugging dependency issues. When a cycle is detected, the items
+	// participating in the cycle or depending on an item in a cycle
+	// will be marked with red and the groups may be incorrect.
+	ToGraph(options GraphOptions[T]) string
+}
+
+// GraphOptions contains options for the graph generation.
+type GraphOptions[T comparable] struct {
+
+	// ItemToString is used to convert the item to a string
+	// representation for the graph nodes. It should return a unique string.
+	// If nil, then `%v` will be used to convert the item to a string.
+	ItemToString func(item T) string
+
+	// FilterCycles indicates that the graph should only include
+	// items that are part of a cycle or (if StrictFilter is false)
+	// depend on an item in a cycle.
+	// This will still run any item filter on the items in the cycle.
+	FilterCycles bool
+
+	// ItemFilter is used to reduce the items in the graph to only
+	// those that match the filter and any of their children or parents.
+	// If nil, then all items will be included in the graph.
+	ItemFilter func(item T) bool
+
+	// StrictFilter indicates that the graph should only include items
+	// that match the filter and not their children or parents.
+	StrictFilter bool
+
+	// Mermaid indicates the graph should be output as a Mermaid graph
+	// which can be used in Markdown files on Github but is limited in size.
+	// Otherwise, the graph will be output as a DOT graph which can be used
+	// with Graphviz and can handle larger graphs.
+	Mermaid bool
+
+	// HideGroups indicates that the groups should not be shown in the graph.
+	// This is useful for large graphs where the groups are causing clutter.
+	HideGroups bool
+
+	// LabelItemsWithGroupNumber indicates that the items should be labeled
+	// with their group number in the graph.
+	LabelItemsWithGroupNumber bool
+}
+
+// New creates a new sequencer for the given item type T.
+func New[T comparable]() Sequencer[T] {
+	return &sequencerImp[T]{
+		vertices: vertexSet[T]{},
+	}
+}

--- a/compiler/internal/sequencer/sequencer_test.go
+++ b/compiler/internal/sequencer/sequencer_test.go
@@ -1,0 +1,194 @@
+package sequencer
+
+import (
+	"errors"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBasicSequencing(t *testing.T) {
+	s := New[string]()
+	s.Add(`Rad`, `Bob`, `Chris`)
+	s.Add(`Stripe`, `Bob`, `Chris`)
+	s.Add(`Bandit`, `Bob`, `Chris`)
+	s.Add(`Brandy`, `Mort`)
+	s.Add(`Chili`, `Mort`)
+	s.Add(`Muffin`, `Stripe`, `Trixie`)
+	s.Add(`Socks`, `Stripe`, `Trixie`)
+	s.Add(`Bluey`, `Bandit`, `Chili`)
+	s.Add(`Bingo`, `Bandit`, `Chili`)
+	s.Add(`Frisky`)
+
+	if !s.Has(`Bob`) {
+		t.Errorf(`expected to find Bob in sequencer, but did not`)
+	}
+	if s.Has(`Ted`) {
+		t.Errorf(`expected to not find Ted in sequencer, but did not`)
+	}
+
+	gotC := s.Children(`Bandit`)
+	sort.Strings(gotC)
+	expC := []string{`Bingo`, `Bluey`}
+	if diff := cmp.Diff(gotC, expC); len(diff) > 0 {
+		t.Errorf("unexpected children (-got +exp):\n%s", diff)
+	}
+	if gotC := s.Children(`Ted`); len(gotC) != 0 {
+		t.Errorf("expected no children for an item not in the sequencer, got: %v", gotC)
+	}
+
+	gotP := s.Parents(`Bandit`)
+	sort.Strings(gotP)
+	expP := []string{`Bob`, `Chris`}
+	if diff := cmp.Diff(gotP, expP); len(diff) > 0 {
+		t.Errorf("unexpected parents (-got +exp):\n%s", diff)
+	}
+	if gotP := s.Parents(`Ted`); len(gotP) != 0 {
+		t.Errorf("expected no parents for an item not in the sequencer, got: %v", gotP)
+	}
+
+	if depth := s.Depth(`Bandit`); depth != 1 {
+		t.Errorf("expected depth of Bandit to be 1, got: %d", depth)
+	}
+	if depth := s.Depth(`Ted`); depth != -1 {
+		t.Errorf("expected depth of an item not in the sequencer to be -1, got: %d", depth)
+	}
+
+	if mmd := s.ToGraph(GraphOptions[string]{}); len(mmd) == 0 {
+		t.Errorf(`expected non-empty graph output, but got empty`)
+	}
+
+	// Check getting the groups individually.
+	count := s.DepthCount()
+	got := make([][]string, count)
+	for i := 0; i < s.DepthCount(); i++ {
+		group := s.Group(i)
+		sort.Strings(group)
+		got[i] = group
+	}
+	exp := [][]string{
+		{`Bob`, `Chris`, `Frisky`, `Mort`, `Trixie`},
+		{`Bandit`, `Brandy`, `Chili`, `Rad`, `Stripe`},
+		{`Bingo`, `Bluey`, `Muffin`, `Socks`},
+	}
+	if diff := cmp.Diff(got, exp); len(diff) > 0 {
+		t.Errorf("unexpected sequencing (-got +exp):\n%s", diff)
+	}
+
+	// Using AllGroups should return the same result as reading the groups individually.
+	got = s.AllGroups()
+	for _, group := range got {
+		sort.Strings(group)
+	}
+	if diff := cmp.Diff(got, exp); len(diff) > 0 {
+		t.Errorf("unexpected sequencing (-got +exp):\n%s", diff)
+	}
+}
+
+func TestDiamonds(t *testing.T) {
+	s := New[string]()
+	// This makes several diamonds in the graph to check that vertices
+	// are only processed once all the parents are processed.
+	s.Add(`A`, `B`, `C`, `D`, `G`)
+	s.Add(`B`, `D`, `E`)
+	s.Add(`C`, `D`, `F`)
+	s.Add(`D`, `G`)
+	s.Add(`E`, `G`)
+	s.Add(`F`, `G`)
+
+	if mmd := s.ToGraph(GraphOptions[string]{}); len(mmd) == 0 {
+		t.Errorf(`expected non-empty graph output, but got empty`)
+	}
+
+	got := s.AllGroups()
+	for _, group := range got {
+		sort.Strings(group)
+	}
+	exp := [][]string{
+		{`G`},
+		{`D`, `E`, `F`},
+		{`B`, `C`},
+		{`A`},
+	}
+	if diff := cmp.Diff(got, exp); len(diff) > 0 {
+		t.Errorf("unexpected sequencing (-got +exp):\n%s", diff)
+	}
+}
+
+func TestCycleDetection(t *testing.T) {
+	s := New[string]()
+	s.Add(`A`, `B`, `D`) // D is a leaf not part of the cycle
+	s.Add(`B`, `C`, `D`)
+	s.Add(`C`, `A`) // This creates a cycle A-> B->C->A
+	s.Add(`E`, `A`) // E is a branch not part of the cycle
+
+	_ = s.ToGraph(GraphOptions[string]{}) // Should not panic
+
+	// Add more to reset the sequencer state
+	s.Add(`F`, `E`) // F is a root via E not part of the cycle
+
+	expectPanic := func(h func()) {
+		defer func() {
+			r := recover().(error)
+			if !errors.Is(r, ErrCycleDetected) {
+				t.Errorf(`expected panic due to cycle, but got: %v`, r)
+			}
+		}()
+		h()
+		s.DepthCount()
+		t.Errorf(`expected panic due to cycle, but did not panic`)
+	}
+
+	expectPanic(func() { s.DepthCount() })
+	expectPanic(func() { s.Depth(`A`) })
+	expectPanic(func() { s.Group(2) })
+
+	if mmd := s.ToGraph(GraphOptions[string]{}); len(mmd) == 0 { // Should not panic
+		t.Errorf(`expected non-empty graph output, but got empty`)
+	}
+
+	cycles := s.GetCycles()
+	sort.Strings(cycles)
+	exp := []string{`A`, `B`, `C`}
+	if diff := cmp.Diff(cycles, exp); len(diff) > 0 {
+		t.Errorf("unexpected cycles (-got +exp):\n%s", diff)
+	}
+}
+
+func TestLargeGraph(t *testing.T) {
+	const itemCount = 1000
+	const maxDeps = 10
+
+	items := make([]int, itemCount)
+	for i := 0; i < itemCount; i++ {
+		items[i] = i
+	}
+
+	r := rand.New(rand.NewSource(0))
+	r.Shuffle(itemCount, func(i, j int) {
+		items[i], items[j] = items[j], items[i]
+	})
+
+	s := New[int]()
+	for i := 0; i < maxDeps; i++ {
+		s.Add(items[i]) // Add leaf items with no dependencies
+	}
+	for i := maxDeps; i < itemCount; i++ {
+		s.Add(items[i])
+
+		// "Randomly" add dependencies to previous items, since only previous
+		// items are chosen from no cycles should occur.
+		// If the same item is chosen multiple times it should have no effect.
+		depCount := r.Intn(maxDeps)
+		for j := 0; j < depCount; j++ {
+			s.Add(items[i], items[r.Intn(i)])
+		}
+	}
+
+	s.DepthCount() // This should not panic and internal validation should pass.
+	if len(s.GetCycles()) > 0 {
+		t.Errorf(`expected no cycles in the large graph, but found some`)
+	}
+}

--- a/compiler/internal/sequencer/squencerImp.go
+++ b/compiler/internal/sequencer/squencerImp.go
@@ -1,0 +1,412 @@
+package sequencer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// errSequencerLogic is panicked if an error internal to the sequencer logic
+// or error in the parent/child pointers is detected.
+// This error should never be panicked if the sequencer is working correctly.
+var errSequencerLogic = errors.New(`error in sequencer logic or parent/child pointers`)
+
+type sequencerImp[T comparable] struct {
+	// vertices is a set of all vertices indexed by the item they represent.
+	vertices vertexSet[T]
+
+	// needSequencing indicates that the sequencer needs to perform sequencing.
+	needSequencing bool
+
+	// depthCount is the number of unique depths in the dependency graph.
+	// This may be invalid if sequencing needs to be performed.
+	depthCount int
+
+	// groups is the map of groups indexed by their depth.
+	// This may contain invalid groups if sequencing needs to be performed.
+	groups map[int]vertexSet[T]
+
+	// dependencyCycles is the list of items that are part of any cycle
+	// or depend on an item in a cycle.
+	dependencyCycles vertexSet[T]
+}
+
+func (s *sequencerImp[T]) Add(child T, parents ...T) {
+	c := s.getOrAdd(child)
+	for _, parent := range parents {
+		if !c.parents.has(parent) {
+			p := s.getOrAdd(parent)
+			c.addDependency(p)
+		}
+	}
+}
+
+func (s *sequencerImp[T]) Has(item T) bool {
+	return s.vertices.has(item)
+}
+
+func (s *sequencerImp[T]) Children(item T) []T {
+	if v, exists := s.vertices[item]; exists {
+		return v.children.toSlice()
+	}
+	return nil
+}
+
+func (s *sequencerImp[T]) Parents(item T) []T {
+	if v, exists := s.vertices[item]; exists {
+		return v.parents.toSlice()
+	}
+	return nil
+}
+
+func (s *sequencerImp[T]) Depth(item T) int {
+	s.performSequencing(true)
+	if v, exists := s.vertices[item]; exists {
+		return v.depth
+	}
+	return -1
+}
+
+func (s *sequencerImp[T]) DepthCount() int {
+	s.performSequencing(true)
+	return s.depthCount
+}
+
+func (s *sequencerImp[T]) Group(depth int) []T {
+	s.performSequencing(true)
+	return s.groups[depth].toSlice()
+}
+
+func (s *sequencerImp[T]) AllGroups() [][]T {
+	s.performSequencing(true)
+	groups := make([][]T, s.depthCount)
+	for depth := 0; depth < s.depthCount; depth++ {
+		groups[depth] = s.groups[depth].toSlice()
+	}
+	return groups
+}
+
+func (s *sequencerImp[T]) GetCycles() []T {
+	s.performSequencing(false)
+	return s.dependencyCycles.toSlice()
+}
+
+type sortByName[T comparable] struct {
+	vertices []*vertex[T]
+	names    []string
+}
+
+func (s *sortByName[T]) Len() int {
+	return len(s.vertices)
+}
+
+func (s *sortByName[T]) Less(i, j int) bool {
+	return s.names[i] < s.names[j]
+}
+
+func (s *sortByName[T]) Swap(i, j int) {
+	s.vertices[i], s.vertices[j] = s.vertices[j], s.vertices[i]
+	s.names[i], s.names[j] = s.names[j], s.names[i]
+}
+
+func (opt GraphOptions[T]) getName(v *vertex[T]) string {
+	var name string
+	if opt.ItemToString == nil {
+		name = fmt.Sprintf("%v", v.item)
+	} else {
+		name = opt.ItemToString(v.item)
+	}
+	if opt.LabelItemsWithGroupNumber {
+		name = fmt.Sprintf("%s @ %d", name, v.depth)
+	}
+	return name
+}
+
+func (opt GraphOptions[T]) filterVertices(vs, depCycles vertexSet[T]) vertexSet[T] {
+	filtered := make(vertexSet[T], len(vs))
+	for _, v := range vs {
+		if opt.FilterCycles && !depCycles.has(v.item) {
+			continue
+		}
+		if opt.ItemFilter != nil && !opt.ItemFilter(v.item) {
+			continue
+		}
+		filtered[v.item] = v
+		if !opt.StrictFilter {
+			for _, c := range v.children {
+				filtered[c.item] = c
+			}
+			for _, p := range v.parents {
+				filtered[p.item] = p
+			}
+		}
+	}
+	return filtered
+}
+
+func (s *sequencerImp[T]) ToGraph(options GraphOptions[T]) string {
+	s.performSequencing(false)
+
+	buf := &bytes.Buffer{}
+	write := func(format string, args ...any) {
+		// Ignore the error since we are writing to a buffer.
+		_, _ = fmt.Fprintf(buf, format, args...)
+	}
+
+	// Sort the output to make it easier to read and compare consecutive runs.
+	vertMap := options.filterVertices(s.vertices, s.dependencyCycles)
+	vertices := make([]*vertex[T], 0, len(vertMap))
+	names := make([]string, 0, len(vertices))
+	for _, v := range vertMap {
+		vertices = append(vertices, v)
+		names = append(names, options.getName(v))
+	}
+	sort.Sort(&sortByName[T]{vertices: vertices, names: names})
+
+	ids := make(map[*vertex[T]]string, len(vertices))
+	for i, v := range vertices {
+		ids[v] = fmt.Sprintf(`v%d`, i)
+	}
+
+	toIds := func(vs vertexSet[T]) []string {
+		rs := make([]string, 0, len(vs))
+		for _, v := range vs {
+			if _, has := vertMap[v.item]; has {
+				rs = append(rs, ids[v])
+			}
+		}
+		sort.Strings(rs)
+		return rs
+	}
+
+	if options.Mermaid {
+		write("flowchart TB\n")
+		if len(s.dependencyCycles) > 0 {
+			write("  classDef partOfCycle stroke:#f00\n")
+		}
+		for i, v := range vertices {
+			write(`  %s["%v"]`, ids[v], names[i])
+			if s.dependencyCycles.has(v.item) {
+				write(`:::partOfCycle`)
+			}
+			if parents := toIds(v.parents); len(parents) > 0 {
+				write(` --> %s`, parents)
+			}
+			write("\n")
+		}
+		if !options.HideGroups {
+			for depth := s.depthCount - 1; depth >= 0; depth-- {
+				if group := toIds(s.groups[depth]); len(group) > 0 {
+					write("  subgraph Depth %d\n", depth)
+					write("    %s\n", group)
+					write("  end\n")
+				}
+			}
+		}
+	} else {
+		write("digraph G {\n")
+		write("\trankdir=LR;\n")
+		write("\tranksep=20.0;\n") // adds extra space between depths
+		for i, v := range vertices {
+			write("\t%s[label=%q", ids[v], names[i])
+			if s.dependencyCycles.has(v.item) {
+				write(`,style=filled,color=red`)
+			}
+			write("]\n")
+		}
+		for _, v := range vertices {
+			if parents := toIds(v.parents); len(parents) > 0 {
+				write("\t%s -> {%s}\n", ids[v], strings.Join(parents, ` `))
+			}
+		}
+		if !options.HideGroups {
+			for depth := s.depthCount - 1; depth >= 0; depth-- {
+				if group := toIds(s.groups[depth]); len(group) > 0 {
+					write("\tsubgraph cluster_%d {\n", depth)
+					write("\t\tstyle=filled;\n")
+					write("\t\tcolor=lightblue;\n")
+					write("\t\trank=same;\n")
+					write("\t\tlabel=\"Depth %d\"\n", depth)
+					write("\t\t%s;\n", strings.Join(group, `; `))
+					write("\t}\n")
+				}
+			}
+		}
+		write("}\n")
+	}
+	return buf.String()
+}
+
+func (s *sequencerImp[T]) getOrAdd(item T) *vertex[T] {
+	v, added := s.vertices.getOrAdd(item)
+	s.needSequencing = s.needSequencing || added
+	return v
+}
+
+// performSequencing performs a full sequencing of the items in the
+// dependency graph. It calculates the depth of each item and groups
+// them by their depth.
+//
+// `panicOnCycle“ indicates whether to panic if a cycle is detected,
+// or to exit gracefully.
+//
+// This assumes that the sequencing is not called often and is typically
+// only called after all the items have been added. Because of this,
+// it always performs a full sequencing of the items without using any
+// previous solved information. Although this is slower for the few cases
+// where sequencing happens often with only a few new items added at a time,
+// it is much simpler to implement and maintain full sequencing than
+// implementing both incremental and full sequencing.
+func (s *sequencerImp[T]) performSequencing(panicOnCycle bool) {
+	if !s.needSequencing {
+		// If a sequencing was already performed and determined that there
+		// was a cycle, panic if `panicOnCycle` is true.
+		if len(s.dependencyCycles) > 0 && panicOnCycle {
+			panic(ErrCycleDetected)
+		}
+		return
+	}
+	s.needSequencing = false
+
+	// Perform a full sequencing of the items.
+	s.clearGroups()
+	ready := newVertexStack[T](len(s.vertices))
+	waitingCount := s.prepareWaitingAndReady(true, s.vertices, ready)
+	waitingCount = s.propagateDepth(true, waitingCount, ready)
+	if waitingCount <= 0 {
+		s.validateGroups()
+		return
+	}
+
+	// If there are still waiting vertices, it means there is a cycle.
+	// Prune off any branches to roots that are not part of the cycles
+	// using the same logic that starts from the leaves except starting
+	// from the roots and working backwards.
+	// This will not be able to remove branches that go between two cycles
+	// even if vertices in that branch can not reach themselves via a cycle.
+	wv := s.vertices.getWaiting(waitingCount)
+	waitingCount = s.prepareWaitingAndReady(false, wv, ready)
+	waitingCount = s.propagateDepth(false, waitingCount, ready)
+
+	// Sanity check that we have waiting vertices left and we didn't
+	// somehow prune away the vertices participating in the cycles.
+	if waitingCount <= 0 {
+		panic(fmt.Errorf(`%w: pruning cycles resulting in no items in the cycles`, errSequencerLogic))
+	}
+
+	// Anything still waiting is part of a cycle or depends on an item in a
+	// cycle that wasn't able to be pruned.
+	s.dependencyCycles = s.vertices.getWaiting(waitingCount)
+	if panicOnCycle {
+		panic(ErrCycleDetected)
+	}
+}
+
+// clearGroups resets the sequencer state, clearing the groups and depth count.
+func (s *sequencerImp[T]) clearGroups() {
+	s.depthCount = 0
+	s.groups = map[int]vertexSet[T]{}
+	s.dependencyCycles = nil
+}
+
+// writeDepth updates the sequencer state with the depth of the given vertex.
+func (s *sequencerImp[T]) writeDepth(v *vertex[T]) {
+	depth := v.parents.maxDepth() + 1
+	v.depth = depth
+	if _, exists := s.groups[depth]; !exists {
+		s.groups[depth] = vertexSet[T]{}
+		if depth >= s.depthCount {
+			s.depthCount = depth + 1
+		}
+	}
+	s.groups[depth].add(v)
+}
+
+// prepareWaitingAndReady prepare the ready sets so that any leaf (or root) vertex
+// is ready to be processed and any waiting vertex has its parent count.
+// This returns the number of waiting vertices.
+//
+// If `forward` is true, it prepares the vertices for sequencing by starting with the leaves.
+// If `forward` is false, it prepares the vertices for reducing to cycles by starting with the roots.
+func (s *sequencerImp[T]) prepareWaitingAndReady(forward bool, vs vertexSet[T], ready *vertexStack[T]) int {
+	waitingCount := 0
+	for _, v := range vs {
+		if forward {
+			v.waiting = len(v.parents)
+		} else {
+			// For reducing to cycles, count the number of children that are still waiting.
+			count := 0
+			for _, c := range v.children {
+				if vs.has(c.item) {
+					count++
+				}
+			}
+			v.waiting = count
+		}
+
+		if v.isReady() {
+			s.writeDepth(v)
+			ready.push(v)
+		} else {
+			waitingCount++
+		}
+	}
+	return waitingCount
+}
+
+// propagateDepth processes the ready vertices, assigning them a depth and
+// updating the waiting vertices. If a waiting vertex has all of its
+// parents (or children) processed, then move it to the ready list.
+// This continues until all ready vertices are processed.
+func (s *sequencerImp[T]) propagateDepth(forward bool, waitingCount int, ready *vertexStack[T]) int {
+	for ready.hasMore() {
+		v := ready.pop()
+		s.writeDepth(v)
+		for _, c := range v.edges(forward) {
+			if !c.isReady() {
+				c.decWaiting()
+				if c.isReady() {
+					ready.push(c)
+					waitingCount--
+				}
+			}
+		}
+	}
+	return waitingCount
+}
+
+// validateGroups validates that the groups and depths are correctly formed.
+// This is a sanity check to ensure that the sequencer logic appears correct.
+func (s *sequencerImp[T]) validateGroups() {
+	if s.depthCount <= 0 {
+		panic(fmt.Errorf(`%w: depth count is invalid`, errSequencerLogic))
+	}
+	count := 0
+	for depth := 0; depth < s.depthCount; depth++ {
+		group := s.groups[depth]
+		if len(group) == 0 {
+			panic(fmt.Errorf(`%w: group %d is empty`, errSequencerLogic, depth))
+		}
+		for _, v := range group {
+			if v.depth != depth {
+				panic(fmt.Errorf(`%w: vertex %v in group %d has depth %d`, errSequencerLogic, v.item, depth, v.depth))
+			}
+			hasPrior := false
+			for _, p := range v.parents {
+				if p.depth >= v.depth {
+					panic(fmt.Errorf(`%w: vertex %v has parent %v with depth %d that is not less than its depth %d`, errSequencerLogic, v.item, p.item, p.depth, v.depth))
+				}
+				hasPrior = hasPrior || p.depth == v.depth-1
+			}
+			if depth > 0 && !hasPrior {
+				panic(fmt.Errorf(`%w: vertex %v in group %d has no parent with depth %d`, errSequencerLogic, v.item, depth, v.depth-1))
+			}
+		}
+		count += len(group)
+	}
+	if count != len(s.vertices) {
+		panic(fmt.Errorf(`%w: vertices in groups, %d, does not match vertex count %d`, errSequencerLogic, count, len(s.vertices)))
+	}
+}

--- a/compiler/internal/sequencer/vertex.go
+++ b/compiler/internal/sequencer/vertex.go
@@ -1,0 +1,63 @@
+package sequencer
+
+// vertex represents a single item in the dependency graph.
+type vertex[T comparable] struct {
+	item     T
+	depth    int
+	parents  vertexSet[T]
+	children vertexSet[T]
+
+	// waiting is used during sequencing. Typically it contains the number of
+	// parents that are not yet processed for this vertex.
+	// When it reaches 0, the vertex can be processed.
+	// It is used to avoid processing the same vertex multiple times.
+	//
+	// If a cycle is detected in the graph, this value can be used to
+	// reduce the number of vertices that are dependent on the cycle.
+	// In that case this value will be set to the number of children
+	// that are not yet processed for this vertex.
+	//
+	// When reducing to cycles this can be negative for any vertex that was
+	// ready during sequencing. We don't want those to be processed again,
+	// so we only say a vertex is ready when waiting is zero.
+	//
+	// Since this number is only used during sequencing it could have been
+	// stored in a map, however, it is faster to store it directly in the
+	// vertex and avoid the map lookup.
+	waiting int
+}
+
+func newVertex[T comparable](item T) *vertex[T] {
+	return &vertex[T]{
+		item:    item,
+		depth:   -1,
+		waiting: -1,
+	}
+}
+
+func (v *vertex[T]) addDependency(p *vertex[T]) {
+	if p.children == nil {
+		p.children = vertexSet[T]{}
+	}
+	p.children.add(v)
+
+	if v.parents == nil {
+		v.parents = vertexSet[T]{}
+	}
+	v.parents.add(p)
+}
+
+func (v *vertex[T]) edges(forward bool) vertexSet[T] {
+	if forward {
+		return v.children
+	}
+	return v.parents
+}
+
+func (v *vertex[T]) decWaiting() {
+	v.waiting--
+}
+
+func (v *vertex[T]) isReady() bool {
+	return v.waiting == 0
+}

--- a/compiler/internal/sequencer/vertexSet.go
+++ b/compiler/internal/sequencer/vertexSet.go
@@ -1,0 +1,55 @@
+package sequencer
+
+// vertexSet is a set of vertices indexed by the item the represent.
+//
+// The values will be unique since vertices contain the item themselves,
+// and no two vertices can represent the same item in the graph,
+// meaning this map is bijective.
+type vertexSet[T comparable] map[T]*vertex[T]
+
+func (vs vertexSet[T]) add(v *vertex[T]) {
+	vs[v.item] = v
+}
+
+func (vs vertexSet[T]) getOrAdd(item T) (*vertex[T], bool) {
+	if v, exists := vs[item]; exists {
+		return v, false
+	}
+
+	v := newVertex(item)
+	vs.add(v)
+	return v, true
+}
+
+func (vs vertexSet[T]) has(item T) bool {
+	_, exists := vs[item]
+	return exists
+}
+
+func (vs vertexSet[T]) maxDepth() int {
+	maxDepth := -1
+	for _, v := range vs {
+		if v.depth > maxDepth {
+			maxDepth = v.depth
+		}
+	}
+	return maxDepth
+}
+
+func (vs vertexSet[T]) getWaiting(capacity int) vertexSet[T] {
+	wvs := make(vertexSet[T], capacity)
+	for _, v := range vs {
+		if !v.isReady() {
+			wvs.add(v)
+		}
+	}
+	return wvs
+}
+
+func (vs vertexSet[T]) toSlice() []T {
+	items := make([]T, 0, len(vs))
+	for item := range vs {
+		items = append(items, item)
+	}
+	return items
+}

--- a/compiler/internal/sequencer/vertexStack.go
+++ b/compiler/internal/sequencer/vertexStack.go
@@ -1,0 +1,26 @@
+package sequencer
+
+type vertexStack[T comparable] struct {
+	stack []*vertex[T]
+}
+
+func newVertexStack[T comparable](capacity int) *vertexStack[T] {
+	return &vertexStack[T]{
+		stack: make([]*vertex[T], 0, capacity),
+	}
+}
+
+func (vs *vertexStack[T]) hasMore() bool {
+	return len(vs.stack) > 0
+}
+
+func (vs *vertexStack[T]) push(v *vertex[T]) {
+	vs.stack = append(vs.stack, v)
+}
+
+func (vs *vertexStack[T]) pop() *vertex[T] {
+	maxIndex := len(vs.stack) - 1
+	v := vs.stack[maxIndex]
+	vs.stack = vs.stack[:maxIndex]
+	return v
+}

--- a/compiler/internal/typeparams/resolver.go
+++ b/compiler/internal/typeparams/resolver.go
@@ -58,7 +58,7 @@ func NewResolver(tc *types.Context, root Instance) *Resolver {
 
 	switch typ := root.Object.Type().(type) {
 	case *types.Signature:
-		nest = root.Object.(*types.Func)
+		nest, _ = root.Object.(*types.Func)
 		tParams = SignatureTypeParams(typ)
 	case *types.Named:
 		tParams = typ.TypeParams()
@@ -77,6 +77,17 @@ func NewResolver(tc *types.Context, root Instance) *Resolver {
 	}
 	for i := 0; i < nestTParams.Len(); i++ {
 		replacements[nestTParams.At(i)] = root.TNest[i]
+	}
+
+	// If no type arguments are provided, check if the type already has
+	// type arguments. This is the case for instantiated objects in the instance.
+	if tParams.Len() > 0 && len(root.TArgs) == 0 {
+		if typ, ok := root.Object.Type().(interface{ TypeArgs() *types.TypeList }); ok {
+			root.TArgs = make(typesutil.TypeList, typ.TypeArgs().Len())
+			for i := 0; i < typ.TypeArgs().Len(); i++ {
+				root.TArgs[i] = typ.TypeArgs().At(i)
+			}
+		}
 	}
 
 	// Check the root's type parameters and arguments match,
@@ -99,6 +110,43 @@ func NewResolver(tc *types.Context, root Instance) *Resolver {
 		subster:      subst.New(tc, replacements),
 		selMemo:      map[typesutil.Selection]typesutil.Selection{},
 	}
+}
+
+// CanResolve checks if the given instance can be used in a NewResolver call.
+func CanResolve(root Instance) bool {
+	nestTParamsCount := 0
+	tParamsCount := 0
+	switch typ := root.Object.Type().(type) {
+	case *types.Signature:
+		tParamsCount = SignatureTypeParams(typ).Len()
+	case *types.Named:
+		tParamsCount = typ.TypeParams().Len()
+		if nest := FindNestingFunc(root.Object); nest != nil {
+			nestTParamsCount = SignatureTypeParams(nest.Type().(*types.Signature)).Len()
+		}
+	default:
+		return false // not a named type or method, cannot resolve
+	}
+
+	// Check the root's implicit nesting type parameters and arguments match.
+	if nestTParamsCount != len(root.TNest) {
+		return false // number of nesting type parameters and arguments must match
+	}
+
+	// If no type arguments are provided, check if the type already has
+	// type arguments. This is the case for instantiated objects in the instance.
+	tArgCount := len(root.TArgs)
+	if tParamsCount > 0 && tArgCount == 0 {
+		if typ, ok := root.Object.Type().(interface{ TypeArgs() *types.TypeList }); ok {
+			tArgCount = typ.TypeArgs().Len()
+		}
+	}
+
+	// Check the root's type parameters and arguments match.
+	if tParamsCount != tArgCount {
+		return false // number of type parameters and arguments must match
+	}
+	return true
 }
 
 // TypeParams is the list of type parameters that this resolver will substitute.

--- a/internal/srctesting/srctesting.go
+++ b/internal/srctesting/srctesting.go
@@ -20,6 +20,7 @@ import (
 // Fixture provides utilities for parsing and type checking Go code in tests.
 type Fixture struct {
 	T        *testing.T
+	Context  *types.Context
 	FileSet  *token.FileSet
 	Info     *types.Info
 	Packages map[string]*types.Package
@@ -41,6 +42,7 @@ func newInfo() *types.Info {
 func New(t *testing.T) *Fixture {
 	return &Fixture{
 		T:        t,
+		Context:  types.NewContext(),
 		FileSet:  token.NewFileSet(),
 		Info:     newInfo(),
 		Packages: map[string]*types.Package{},
@@ -65,6 +67,7 @@ func (f *Fixture) Parse(name, src string) *ast.File {
 func (f *Fixture) Check(importPath string, files ...*ast.File) (*types.Info, *types.Package) {
 	f.T.Helper()
 	config := &types.Config{
+		Context:  f.Context,
 		Sizes:    &types.StdSizes{WordSize: 4, MaxAlign: 8},
 		Importer: f,
 	}
@@ -148,7 +151,7 @@ func Format(t *testing.T, fset *token.FileSet, node any) string {
 	return buf.String()
 }
 
-// LookupObj returns a top-level object with the given name.
+// LookupObj returns a top-level or nested object with the given name.
 //
 // Methods can be referred to as RecvTypeName.MethodName.
 func LookupObj(pkg *types.Package, name string) types.Object {


### PR DESCRIPTION
When the JS packages are being setup, type instances could require type information from packages which have not been setup yet. For example, `list.List[Cat]` could be defined inside the `cat` package and import the `list` package. The type instance `List[cat.Cat]` is initialized inside the `list` package. This will cause a failure because `cat.Cat` hasn't been setup yet since it requires `list` to be setup first as an import. We can't move `List[Cat]` to the cat package because `List[T]` may access unexposed data inside the `list` package.

This is the first part of two (or more) tickets. To solve the type initialization, each declaration will be given a group number. There will be $n$ groups and each group number is $g_i$ where $`0 \le i < n`$. For any group, $g_i$, the prior groups, $`\{g_0 ... g_{i-1}\}`$, will have to be initialized first. All the declarations with the same group number are part of the same group. However within that group, the declarations will still need to be initialized in the current ordering where imports are done before importers and types are initialized before they are used in pointers, slices, etc.

This PR determines the grouping and order of the groups, then sets the group number for each `Decl`. This PR mainly consists of two new packages: `sequencer` and `grouper`. The `sequencer` is a generalized tool for determining ordering and grouping of items depending on the items' dependencies. The `grouper` stores information about the declarations' types so that it can use the `sequencer` to group and order the declarations based on type.

Following ticket will use that group number to populate a "startup map" where the key is the group number and the value is a set of functions that need to be run. Each function will initialize all the `Decl`s for a particular group for a single package. Then once all the packages have been added, the runtime will call each group of functions in order.