### PR TITLE
Reduce number of import path strings

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1290,7 +1290,7 @@ func renderPackage(t *testing.T, archive *Archive, minify bool) string {
 
 	buf := &bytes.Buffer{}
 
-	if err := WritePkgCode(archive, selection, linkname.GoLinknameSet{}, minify, &SourceMapFilter{Writer: buf}); err != nil {
+	if err := WritePkgCode(archive, selection, linkname.GoLinknameSet{}, minify, &SourceMapFilter{Writer: buf}, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/compiler/internal/analysis/info.go
+++ b/compiler/internal/analysis/info.go
@@ -146,7 +146,7 @@ func (info *Info) IsBlocking(inst typeparams.Instance) bool {
 	if funInfo := info.FuncInfo(inst); funInfo != nil {
 		return funInfo.IsBlocking()
 	}
-	panic(fmt.Errorf(`info did not have function declaration instance for %q`, inst.TypeString()))
+	panic(fmt.Errorf(`info did not have function declaration instance for %q`, inst.TypeString(nil)))
 }
 
 // FuncInfo returns information about the given function declaration instance, or nil if not found.

--- a/compiler/internal/typeparams/instance.go
+++ b/compiler/internal/typeparams/instance.go
@@ -28,12 +28,12 @@ type Instance struct {
 // Two semantically different instances may have the same string representation
 // if the instantiated object or its type arguments shadow other types.
 func (i Instance) String() string {
-	return i.symbolicName() + i.TypeParamsString(`<`, `>`)
+	return i.symbolicName() + i.TypeParamsString(`<`, `>`, nil)
 }
 
 // TypeString returns a Go type string representing the instance (suitable for %T verb).
-func (i Instance) TypeString() string {
-	return i.qualifiedName() + i.TypeParamsString(`[`, `]`)
+func (i Instance) TypeString(qt types.Qualifier) string {
+	return i.qualifiedName() + i.TypeParamsString(`[`, `]`, qt)
 }
 
 // symbolicName returns a string representation of the instance's name
@@ -61,21 +61,21 @@ func (i Instance) qualifiedName() string {
 
 // TypeParamsString returns part of a Go type string that represents the type
 // parameters of the instance including the nesting type parameters, e.g. [X;Y,Z].
-func (i Instance) TypeParamsString(open, close string) string {
+func (i Instance) TypeParamsString(open, close string, qt types.Qualifier) string {
 	hasNest := len(i.TNest) > 0
 	hasArgs := len(i.TArgs) > 0
 	buf := strings.Builder{}
 	if hasNest || hasArgs {
 		buf.WriteString(open)
 		if hasNest {
-			buf.WriteString(i.TNest.String())
+			buf.WriteString(i.TNest.TypesString(qt))
 			buf.WriteRune(';')
 			if hasArgs {
 				buf.WriteRune(' ')
 			}
 		}
 		if hasArgs {
-			buf.WriteString(i.TArgs.String())
+			buf.WriteString(i.TArgs.TypesString(qt))
 		}
 		buf.WriteString(close)
 	}

--- a/compiler/internal/typeparams/instance_test.go
+++ b/compiler/internal/typeparams/instance_test.go
@@ -119,7 +119,7 @@ func TestInstanceString(t *testing.T) {
 				t.Errorf("Got: instance string %q. Want: %q.", got, test.wantStr)
 			}
 			if test.wantTypeString != "" {
-				got = test.instance.TypeString()
+				got = test.instance.TypeString(nil)
 				if got != test.wantTypeString {
 					t.Errorf("Got: instance type string %q. Want: %q.", got, test.wantTypeString)
 				}

--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -392,16 +392,16 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
             }
             var n = new t.ptr();
             for (var i = 0; i < t.fields.length; i++) {
-              var f = t.fields[i];
-      
-              if (!f.exported) {
-                continue;
-              }
-              var jsProp = v[f.name];
-      
-              n[f.prop] = $internalize(jsProp, f.typ, recv, seen, makeWrapper);
+                var f = t.fields[i];
+
+                if (!f.exported) {
+                    continue;
+                }
+                var jsProp = v[f.name];
+
+                n[f.prop] = $internalize(jsProp, f.typ, recv, seen, makeWrapper);
             }
-      
+
             return n;
     }
     $throwRuntimeError("cannot internalize " + t.string);

--- a/compiler/typesutil/typelist.go
+++ b/compiler/typesutil/typelist.go
@@ -9,12 +9,16 @@ import (
 type TypeList []types.Type
 
 func (tl TypeList) String() string {
+	return tl.TypesString(nil)
+}
+
+func (tl TypeList) TypesString(qt types.Qualifier) string {
 	buf := strings.Builder{}
 	for i, typ := range tl {
 		if i != 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(types.TypeString(typ, nil))
+		buf.WriteString(types.TypeString(typ, qt))
 	}
 	return buf.String()
 }

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -375,7 +375,7 @@ func (fc *funcContext) pkgVar(pkg *types.Package) string {
 
 	pkgVar, found := fc.pkgCtx.pkgVars[pkg.Path()]
 	if !found {
-		pkgVar = fmt.Sprintf(`$packages["%s"]`, pkg.Path())
+		pkgVar = fmt.Sprintf(`$packages[%s]`, fc.getPkgPathVar(pkg))
 	}
 	return pkgVar
 }
@@ -467,7 +467,10 @@ func (fc *funcContext) instName(inst typeparams.Instance) string {
 		return objName
 	}
 	fc.pkgCtx.DeclareDCEDep(inst.Object, inst.TNest, inst.TArgs)
-	label := inst.TypeParamsString(` /* `, ` */`)
+
+	// Reduce the size of the comment by only using the package names instead of paths.
+	// This should make it easier to read but risks confusion when multiple packages have the same name.
+	label := inst.TypeParamsString(` /* `, ` */`, (*types.Package).Name)
 	return fmt.Sprintf("%s[%d%s]", objName, fc.pkgCtx.instanceSet.ID(inst), label)
 }
 


### PR DESCRIPTION
The number of times a package import path is written to the JS output has grown since adding support for generics. This can cause the JS output to become much larger even when minified since most minifies won't dedupe string literals. Most don't have to since zipping JS also reduces the JS output. However, for readability and so we don't always have to zip the files, this change will reduce the string literals for import paths.

This PR adds `$progPath#` constants before the packages are added that store all the package import paths.
Paths that are shorter than a "short length" are not changed, since replacing a short path like `"fmt"` with a constant would add bytes to the output. The "short length" is arbitrarily set to 20 characters to account for the constant definition and the identifier usage.

To keep the Archives still (mostly) isolated, they add `$pkgPath#` constants for their package specific import path needs. That allows the Decls to be written using `$pkgPath#` and right at the beginning of package closure we assign the `$pkgPath#` to the `$progPath#` with the same import path value. We probably could remove this extra code if we shared some kind of import path cache while creating all the Archives, but for now this works to still reduce the JS output size.

The Go `%v` print name contains paths in it for type arguments, e.g. `"foo.Foo[git/long/path/to/bar.Bar]"`. The `types.Qualifier` is used to replace those paths with variables so we get `"foo.Foo["+$pkgPath2+".Bar]"`.

Even though it doesn't matter for the minified JS output, I also changed how the type arguments are shown for different implementations in the comment, e.g. `Bar[3 /* foo.Entity */]`. Now those comments use the package name, not the path. This might be confusing if there are many packages with the same package name, but it should be easier to read (at least it is for me).

It could be possible to reduce the output more by using a Trie to remove prefix paths from paths in the same directories, but I figured that was overkill for this and just keep it simpler.

### Above the packages

#### Before

<img width="721" height="47" alt="image" src="https://github.com/user-attachments/assets/ca263067-f8f9-4d95-a4e2-4db14de16613" />

#### After

<img width="582" height="111" alt="image" src="https://github.com/user-attachments/assets/e7656b9f-3cd8-4c46-a9ff-a21aa180dd26" />

### Top of a package

#### Before

<img width="1835" height="47" alt="image" src="https://github.com/user-attachments/assets/4a3b674a-808d-4319-a8db-c4aa230da750" />

#### After

<img width="774" height="65" alt="image" src="https://github.com/user-attachments/assets/c4a68af7-bc08-4575-aec6-3077ed0a0866" />
