### PR TITLE
[generics] Fixed collecting instances from inverted dependencies

### DIFF
--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -51,23 +51,23 @@ type Decl struct {
 	TypeDeclCode []byte
 	// JavaScript code that assigns exposed named types to the package.
 	ExportTypeCode []byte
-	// JavaScript code that declares basic information about an anonymous types.
+	// JavaScript code that declares basic information about an anonymous type.
 	// It configures basic information about the type.
-	// This is added to the finish setup phase to has access to all packages.
+	// This is added to the finish setup phase to have access to all packages.
 	AnonTypeDeclCode []byte
 	// JavaScript code that declares basic information about a function or
 	// method symbol. This contains the function's or method's compiled body.
-	// This is added to the finish setup phase to has access to all packages.
+	// This is added to the finish setup phase to have access to all packages.
 	FuncDeclCode []byte
 	// JavaScript code that assigns exposed functions to the package.
-	// This is added to the finish setup phase to has access to all packages.
+	// This is added to the finish setup phase to have access to all packages.
 	ExportFuncCode []byte
-	// JavaScript code that initializes reflection metadata about type's method list.
-	// This is added to the finish setup phase to has access to all packages.
+	// JavaScript code that initializes reflection metadata about a type's method list.
+	// This is added to the finish setup phase to have access to all packages.
 	MethodListCode []byte
 	// JavaScript code that initializes the rest of reflection metadata about a type
 	// (e.g. struct fields, array type sizes, element types, etc.).
-	// This is added to the finish setup phase to has access to all packages.
+	// This is added to the finish setup phase to have access to all packages.
 	TypeInitCode []byte
 	// JavaScript code that needs to be executed during the package init phase to
 	// set the symbol up (e.g. initialize package-level variable value).

--- a/compiler/internal/analysis/info_test.go
+++ b/compiler/internal/analysis/info_test.go
@@ -1632,13 +1632,13 @@ func newBlockingTest(t *testing.T, src string) *blockingTest {
 	tContext := types.NewContext()
 	tc := typeparams.Collector{
 		TContext:  tContext,
-		Info:      f.Info,
 		Instances: &typeparams.PackageInstanceSets{},
 	}
 
 	file := f.Parse(`test.go`, src)
 	testInfo, testPkg := f.Check(`pkg/test`, file)
-	tc.Scan(testPkg, file)
+	tc.Scan(testInfo, testPkg, file)
+	tc.Finish()
 
 	getImportInfo := func(path string) (*Info, error) {
 		return nil, fmt.Errorf(`getImportInfo should not be called in this test, called with %v`, path)
@@ -1658,7 +1658,6 @@ func newBlockingTestWithOtherPackage(t *testing.T, testSrc string, otherSrc stri
 	tContext := types.NewContext()
 	tc := typeparams.Collector{
 		TContext:  tContext,
-		Info:      f.Info,
 		Instances: &typeparams.PackageInstanceSets{},
 	}
 
@@ -1672,11 +1671,12 @@ func newBlockingTestWithOtherPackage(t *testing.T, testSrc string, otherSrc stri
 
 	otherFile := f.Parse(`other.go`, otherSrc)
 	_, otherPkg := f.Check(`pkg/other`, otherFile)
-	tc.Scan(otherPkg, otherFile)
+	tc.Scan(f.Info, otherPkg, otherFile)
 
 	testFile := f.Parse(`test.go`, testSrc)
 	_, testPkg := f.Check(`pkg/test`, testFile)
-	tc.Scan(testPkg, testFile)
+	tc.Scan(f.Info, testPkg, testFile)
+	tc.Finish()
 
 	otherPkgInfo := AnalyzePkg([]*ast.File{otherFile}, f.FileSet, f.Info, tContext, otherPkg, tc.Instances, getImportInfo)
 	pkgInfo[otherPkg.Path()] = otherPkgInfo

--- a/compiler/internal/typeparams/instance.go
+++ b/compiler/internal/typeparams/instance.go
@@ -202,7 +202,9 @@ func (iset *InstanceSet) next() (Instance, bool) {
 }
 
 // exhausted returns true if there are no unprocessed instances in the set.
-func (iset *InstanceSet) exhausted() bool { return len(iset.values) <= iset.unprocessed }
+func (iset *InstanceSet) exhausted() bool {
+	return len(iset.values) <= iset.unprocessed
+}
 
 // Values returns instances that are currently in the set. Order is not specified.
 func (iset *InstanceSet) Values() []Instance {
@@ -244,6 +246,17 @@ func (iset *InstanceSet) ObjHasInstances(obj types.Object) bool {
 // PackageInstanceSets stores an InstanceSet for each package in a program, keyed
 // by import path.
 type PackageInstanceSets map[string]*InstanceSet
+
+// allExhausted returns true if there are no unprocessed instances in
+// any of the instance sets.
+func (i PackageInstanceSets) allExhausted() bool {
+	for _, iset := range i {
+		if !iset.exhausted() {
+			return false
+		}
+	}
+	return true
+}
 
 // Pkg returns InstanceSet for objects defined in the given package.
 func (i PackageInstanceSets) Pkg(pkg *types.Package) *InstanceSet {

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -263,9 +263,14 @@ func PrepareAllSources(allSources []*sources.Sources, importer sources.Importer,
 	// Collect all the generic type instances from all the packages.
 	// This must be done for all sources prior to any analysis.
 	instances := &typeparams.PackageInstanceSets{}
-	for _, srcs := range allSources {
-		srcs.CollectInstances(tContext, instances)
+	tc := &typeparams.Collector{
+		TContext:  tContext,
+		Instances: instances,
 	}
+	for _, srcs := range allSources {
+		srcs.CollectInstances(tc)
+	}
+	tc.Finish()
 
 	// Analyze the package to determine type parameters instances, blocking,
 	// and other type information. This will not populate the information.

--- a/compiler/prelude/jsmapping.js
+++ b/compiler/prelude/jsmapping.js
@@ -392,16 +392,13 @@ var $internalize = (v, t, recv, seen, makeWrapper) => {
             }
             var n = new t.ptr();
             for (var i = 0; i < t.fields.length; i++) {
-              var f = t.fields[i];
-      
-              if (!f.exported) {
-                continue;
-              }
-              var jsProp = v[f.name];
-      
-              n[f.prop] = $internalize(jsProp, f.typ, recv, seen, makeWrapper);
+                var f = t.fields[i];
+                if (!f.exported) {
+                    continue;
+                }
+                var jsProp = v[f.name];
+                n[f.prop] = $internalize(jsProp, f.typ, recv, seen, makeWrapper);
             }
-      
             return n;
     }
     $throwRuntimeError("cannot internalize " + t.string);

--- a/compiler/sources/sources.go
+++ b/compiler/sources/sources.go
@@ -44,11 +44,11 @@ type Sources struct {
 	// JSFiles is the JavaScript files that are part of the package.
 	JSFiles []jsFile.JSFile
 
-	// TypeInfo is the type information this package.
+	// TypeInfo is the type information for this package.
 	// This is nil until set by Analyze.
 	TypeInfo *analysis.Info
 
-	// baseInfo is the base type information this package.
+	// baseInfo is the base type information for this package.
 	// This is nil until set by TypeCheck.
 	baseInfo *types.Info
 
@@ -163,13 +163,11 @@ func (s *Sources) TypeCheck(importer Importer, sizes types.Sizes, tContext *type
 //
 // This must be called before Analyze to have the type parameters instances
 // needed during analysis.
-func (s *Sources) CollectInstances(tContext *types.Context, instances *typeparams.PackageInstanceSets) {
-	tc := typeparams.Collector{
-		TContext:  tContext,
-		Info:      s.baseInfo,
-		Instances: instances,
-	}
-	tc.Scan(s.Package, s.Files...)
+//
+// Note that once all the sources are collected, the collector needs to be
+// finished to ensure all the instances are collected.
+func (s *Sources) CollectInstances(tc *typeparams.Collector) {
+	tc.Scan(s.baseInfo, s.Package, s.Files...)
 }
 
 // Analyze will determine the type parameters instances, blocking,

--- a/tests/gencircle_test.go
+++ b/tests/gencircle_test.go
@@ -18,27 +18,7 @@ func Test_GenCircle_PingPong(t *testing.T) { runGenCircleTest(t, `pingpong`) }
 
 func Test_GenCircle_Burninate(t *testing.T) { runGenCircleTest(t, `burninate`) }
 
-func Test_GenCircle_CatBox(t *testing.T) {
-	// TODO(grantnelson-wf): This test hits an error similar to
-	// `panic: info did not have function declaration instance for
-	// "collections.Push[box.Unboxer[cat.Cat]]"` from `analysis/Info:IsBlocking`.
-	//
-	// This is because no instance of `Stack` is used explicitly in code,
-	// i.e. the code doesn't have an `ast.Ident` for `Stack` found in `types.Info.Instances`
-	// since the only `Stack` identifiers are the ones for the generic declaration.
-	// `Stack[box.Unboxer[cat.Cat]]` is implicitly defined via the call
-	// `collections.NewStack[box.Unboxer[cat.Cat]]()` in main.go.
-	//
-	// We need to update the `typeparams.collector` to add these implicit types
-	// to the `PackageInstanceSets` so that `analysis/info` has the implicit
-	// instances of `Stack`.
-	//
-	// Simply adding `_ = collections.Stack[box.Unboxer[cat.Cat]]{}` is a
-	// work around for `Stack` issue but the code gets tripped up on `boxImp[T]`
-	// via `Box[T]` not being defined since again `boxImp` has not been collected.
-	t.Skip(`Implicit Instance Not Yet Collected`)
-	runGenCircleTest(t, `catbox`)
-}
+func Test_GenCircle_CatBox(t *testing.T) { runGenCircleTest(t, `catbox`) }
 
 // Cache buster: Keeping the tests from using cached results when only
 // the test application files are changed.


### PR DESCRIPTION
This fixes the issue causing the collector to miss instances.

### Problem

The problem was that we'd scan package X, then check if there are any unprocessed instances in the X package instance set before moving to the next package. However, with generics, package X could contain `Foo[T any]` that isn't instantiated anywhere within package X, then package Y could call `Foo[int]` causing the X package instance set to have an unprocessed instance in it. `Foo[int]` would never be processed because we had moved onto package Y.

This wouldn't be a problem for `Foo[int]` because it still got into the instance set for X. However, if inside of `Foo[T]` was the instantiation `Bar[T]` and `Bar[T]` isn't instantiated anywhere else, then we'd have to process `Foo[int]` to discover the instance `Bar[int]`. Since `Foo[int]` would never be processed, `Bar[int]` would be missing.

This is caused by how generics can invert dependencies. We process packages based on import order, but with generics, package Y could import X and therefore is scanned after X, however Y could create instances in X, thus inverting the dependencies because X now depends on instance information defined in Y.

### Fix

To fix this problem I moved all the processing of unprocessed instances until after all packages were scanned. The processing is allowed to recheck packages multiple times until every instance added before and added during processing has been processed (e.g. If `Bar[T]` used `Baz[T]` then `Foo[int]` being processed would add `Bar[int]` that would need to be processed to get `Baz[int]` and so on).

I also fixed some spelling and some odd spacing in the code.