### PR TITLE
Adding JS writer to source map filter

### DIFF
--- a/build/cache/cache.go
+++ b/build/cache/cache.go
@@ -30,7 +30,6 @@ type Cacheable interface {
 
 // Cache defines methods to store and load cacheable objects.
 type Cache interface {
-
 	// Store stores the package with the given import path in the cache.
 	// Any error inside this method will cause the cache not to be persisted.
 	//

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -222,6 +222,7 @@ func Compile(srcs *sources.Sources, tContext *types.Context, minify bool) (_ *Ar
 		FileSet:      srcs.FileSet,
 		Minified:     minify,
 		GoLinknames:  srcs.GoLinknames,
+		IncJSCode:    srcs.JSFiles,
 	}, nil
 }
 

--- a/compiler/prelude/prelude.go
+++ b/compiler/prelude/prelude.go
@@ -2,13 +2,10 @@ package prelude
 
 import (
 	_ "embed"
-
-	"github.com/evanw/esbuild/pkg/api"
-	log "github.com/sirupsen/logrus"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
 )
-
-// Prelude is the GopherJS JavaScript interop layer.
-var Prelude = prelude + numeric + types + goroutines + jsmapping
 
 //go:embed prelude.js
 var prelude string
@@ -25,24 +22,48 @@ var jsmapping string
 //go:embed goroutines.js
 var goroutines string
 
-func Minified() string {
-	result := api.Transform(Prelude, api.TransformOptions{
-		Target:            api.ES2015,
-		MinifyWhitespace:  true,
-		MinifyIdentifiers: true,
-		MinifySyntax:      true,
-		KeepNames:         true,
-		Charset:           api.CharsetUTF8,
-		LegalComments:     api.LegalCommentsEndOfFile,
-	})
-	for _, w := range result.Warnings {
-		log.Warnf("%d:%d: %s\n%s\n", w.Location.Line, w.Location.Column, w.Text, w.Location.LineText)
+type PreludeFile struct {
+	Name   string
+	Source string
+}
+
+// PreludeFiles gets the GopherJS JavaScript interop layers.
+func PreludeFiles() (files []PreludeFile) {
+	basePath := getPackagePath()
+	add := func(name, src string) {
+		files = append(files, PreludeFile{
+			Name:   filepath.Join(basePath, name),
+			Source: src,
+		})
 	}
-	if errCount := len(result.Errors); errCount > 0 {
-		for _, e := range result.Errors {
-			log.Errorf("%d:%d: %s\n%s\n", e.Location.Line, e.Location.Column, e.Text, e.Location.LineText)
+
+	add(`prelude.js`, prelude)
+	add(`numberic.js`, numeric)
+	add(`types.js`, types)
+	add(`goroutines.js`, goroutines)
+	add(`jsmapping.js`, jsmapping)
+	return
+}
+
+// getPackagePath attempts to determine the package path of the prelude package
+// by inspecting the runtime stack. This is used to set the correct paths for
+// the prelude files so that source maps work correctly. This should get the
+// path that the prelude package is locating when GopherJS is compiled.
+func getPackagePath() string {
+	// Line 0 is goroutine number, line 1 and 2 is runtime/debug.Stack and path,
+	// line 3 is this function itself, with line 4 being the path for this function.
+	const pathLineIndex = 4
+	stack := string(debug.Stack())
+	lines := strings.Split(stack, "\n")
+	if len(lines) >= pathLineIndex {
+		tracePath := strings.TrimSpace(lines[pathLineIndex])
+		// tracePath should be in the form: "/full/path/to/compiler/prelude/prelude.go:42 +0x123"
+		// so drop the ending to isolate the folder path.
+		if index := strings.LastIndex(tracePath, `/`); index >= 0 {
+			return tracePath[:index]
 		}
-		log.Fatalf("Prelude minification failed with %d errors", errCount)
 	}
-	return string(result.Code)
+	// Fallback to a default path. The source maps may not have the correct path
+	// to open the file in an editor but it will be close enough to be useful.
+	return `github.com/gopherjs/gopherjs/compiler/prelude/`
 }

--- a/compiler/sources/serializer.go
+++ b/compiler/sources/serializer.go
@@ -128,7 +128,6 @@ func unpackFile(file *ast.File) {
 // an interface field in the AST.
 var prepareGob = func() func() {
 	registerTypes := func() {
-
 		// Register expression nodes.
 		gob.Register(&ast.BadExpr{})
 		gob.Register(&ast.Ident{})

--- a/internal/sourcemapx/doc.go
+++ b/internal/sourcemapx/doc.go
@@ -1,5 +1,7 @@
 // Package sourcemapx contains utilities for passing source map information
-// around, intended to work with github.com/neelance/sourcemap.
+// around, intended to work with a [neelance sourcemap].
+//
+// # Mapping Go source coude
 //
 // GopherJS code generator outputs hints about correspondence between the
 // generated code and original sources inline. Such hints are marked by the
@@ -13,7 +15,7 @@
 // The hinting mechanism is designed to be extensible, the Hint type able to
 // wrap different types containing different information:
 //
-//   - go/token.Pos indicates position in the original source the current
+//   - [go/token.Pos] indicates position in the original source the current
 //     location in the generated code corresponds to.
 //   - Identifier maps a JS identifier to the original Go identifier it
 //     represents.
@@ -23,4 +25,14 @@
 // Filter type is used to extract the hints from the written code stream and
 // pass them into source map generator. It also ensures that the encoded inline
 // hints don't make it into the final output, since they are not valid JS.
+//
+// # Mapping JS source code
+//
+// The filter also provides a WriteJS methods that can be used to write pure JS
+// code (without hints) through the filter. While it is passing through the filter,
+// it will produce a source map for the JS code and pass that source map
+// information to a [neelance sourcemap]. This uses [esbuild]
+//
+// [neelance sourcemap]:github.com/neelance/sourcemap
+// [esbuild]: https://esbuild.github.io/
 package sourcemapx

--- a/internal/sourcemapx/filter.go
+++ b/internal/sourcemapx/filter.go
@@ -5,18 +5,52 @@ import (
 	"fmt"
 	"go/token"
 	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/evanw/esbuild/pkg/api"
+	"github.com/neelance/sourcemap"
+	log "github.com/sirupsen/logrus"
+)
+
+type (
+	goMappingCallbackHandle func(generatedLine, generatedColumn int, originalPos token.Position, originalName string)
+	jsMappingCallbackHandle func(isolated *sourcemap.Mapping)
 )
 
 // Filter implements io.Writer which extracts source map hints from the written
 // stream and passed them to the MappingCallback if it's not nil. Encoded hints
 // are always filtered out of the output stream.
 type Filter struct {
-	Writer          io.Writer
-	FileSet         *token.FileSet
-	MappingCallback func(generatedLine, generatedColumn int, originalPos token.Position, originalName string)
+	Writer            io.Writer
+	FileSet           *token.FileSet
+	goMappingCallback goMappingCallbackHandle
+	jsMappingCallback jsMappingCallbackHandle
+
+	m        *sourcemap.Map
+	goroot   string
+	gopath   string
+	localMap bool
 
 	line   int
 	column int
+}
+
+func (f *Filter) EnableMapping(jsFileName, goroot, gopath string, localMap bool) {
+	f.m = &sourcemap.Map{File: jsFileName}
+	f.goroot = goroot
+	f.gopath = gopath
+	f.localMap = localMap
+	f.goMappingCallback = f.defaultGoMappingCallback
+	f.jsMappingCallback = f.defaultJSMappingCallback
+}
+
+func (f *Filter) IsMapping() bool {
+	return f.goMappingCallback != nil || f.jsMappingCallback != nil
+}
+
+func (f *Filter) WriteMappingTo(w io.Writer) error {
+	return f.m.WriteTo(w)
 }
 
 func (f *Filter) Write(p []byte) (n int, err error) {
@@ -45,16 +79,16 @@ func (f *Filter) Write(p []byte) (n int, err error) {
 			return
 		}
 		h, length := ReadHint(p[i:])
-		if f.MappingCallback != nil {
+		if f.goMappingCallback != nil {
 			value, err := h.Unpack()
 			if err != nil {
 				panic(fmt.Errorf("failed to unpack source map hint: %w", err))
 			}
 			switch value := value.(type) {
 			case token.Pos:
-				f.MappingCallback(f.line+1, f.column, f.FileSet.Position(value), "")
+				f.goMappingCallback(f.line+1, f.column, f.FileSet.Position(value), "")
 			case Identifier:
-				f.MappingCallback(f.line+1, f.column, f.FileSet.Position(value.OriginalPos), value.OriginalName)
+				f.goMappingCallback(f.line+1, f.column, f.FileSet.Position(value.OriginalPos), value.OriginalName)
 			default:
 				panic(fmt.Errorf("unexpected source map hint type: %T", value))
 			}
@@ -62,4 +96,129 @@ func (f *Filter) Write(p []byte) (n int, err error) {
 		p = p[i+length:]
 		n += length
 	}
+}
+
+func (f *Filter) WriteJS(jsSource, jsFilePath string, minify bool) (n int, err error) {
+	if !minify && f.jsMappingCallback == nil {
+		// If not minimifying and not mapping, write source as-is.
+		return f.Write([]byte(jsSource))
+	}
+
+	options := api.TransformOptions{
+		Target:         api.ES2015,
+		Charset:        api.CharsetUTF8,
+		LegalComments:  api.LegalCommentsEndOfFile,
+		JSX:            api.JSXPreserve,
+		JSXSideEffects: true,
+		TreeShaking:    api.TreeShakingFalse,
+	}
+
+	if minify {
+		options.MinifyWhitespace = true
+		options.MinifyIdentifiers = true
+		options.MinifySyntax = true
+		options.KeepNames = true
+	}
+
+	if f.jsMappingCallback != nil {
+		options.Sourcefile = jsFilePath
+		options.Sourcemap = api.SourceMapExternal
+		options.SourcesContent = api.SourcesContentExclude
+	}
+
+	result := api.Transform(jsSource, options)
+	for _, w := range result.Warnings {
+		log.Warnf("%d:%d: %s\n%s\n", w.Location.Line, w.Location.Column, w.Text, w.Location.LineText)
+	}
+	if errCount := len(result.Errors); errCount > 0 {
+		for _, e := range result.Errors {
+			log.Errorf("%d:%d: %s\n%s\n", e.Location.Line, e.Location.Column, e.Text, e.Location.LineText)
+		}
+		log.Fatalf(`JS minification failed with %d errors`, errCount)
+	}
+
+	if f.jsMappingCallback != nil {
+		sm, err := sourcemap.ReadFrom(bytes.NewReader(result.Map))
+		if err != nil {
+			return 0, fmt.Errorf(`failed to read source map: %w`, err)
+		}
+		mappings := sm.DecodedMappings()
+		for _, mapping := range mappings {
+			f.jsMappingCallback(mapping)
+		}
+	}
+
+	return f.Write(result.Code)
+}
+
+// defaultGoMappingCallback is the default callback for source map generatio for Go sources.
+func (f *Filter) defaultGoMappingCallback(generatedLine, generatedColumn int, originalPos token.Position, originalName string) {
+	mapping := &sourcemap.Mapping{GeneratedLine: generatedLine, GeneratedColumn: generatedColumn}
+
+	if originalPos.IsValid() {
+		mapping.OriginalFile = f.normalizePath(originalPos.Filename)
+		mapping.OriginalLine = originalPos.Line
+		mapping.OriginalColumn = originalPos.Column
+	}
+
+	if originalName != "" {
+		mapping.OriginalName = originalName
+	}
+
+	f.m.AddMapping(mapping)
+}
+
+// defaultJSMappingCallback is the default callback for source map generatio for JS sources.
+// The given mapping is from the JS file isolated and needs to be adjusted
+// before adding to the filter's source map.
+func (f *Filter) defaultJSMappingCallback(isolated *sourcemap.Mapping) {
+	isolated.OriginalFile = f.normalizePath(isolated.OriginalFile)
+
+	// Adjust line and column numbers to account for existing offset.
+	if isolated.GeneratedLine == 0 {
+		isolated.GeneratedColumn += f.column
+	}
+	isolated.GeneratedLine += f.line
+
+	// Remove original names since esbuild causes an issue in some cases where
+	// a parameter name is used instead of the function name.
+	// For example, `var $panic = value => { ... };` from goroutine.js will
+	// be minimized to `$panic=a(e=>{ ... },"$panic")` where `a` is
+	// Object.defineProperty added by esbuild and `e` is the minimized `value`.
+	// They write `value` to the source map but that causes JS to use `value`
+	// instead of `$panic` when viewing the stack trace.
+	// This may be a configuration issue with esbuild, but for now we just
+	// remove the "original names" and allow JS to fall back to the preserved
+	// function names to avoid this problem.
+	isolated.OriginalName = ``
+
+	// Add mapping to the filter's source map.
+	f.m.AddMapping(isolated)
+}
+
+func (f *Filter) normalizePath(file string) string {
+	switch hasGopathPrefix, prefixLen := hasGopathPrefix(file, f.gopath); {
+	case f.localMap:
+		// no-op:  keep file as-is
+		return file
+	case hasGopathPrefix:
+		return filepath.ToSlash(file[prefixLen+4:])
+	case strings.HasPrefix(file, f.goroot):
+		return filepath.ToSlash(file[len(f.goroot)+4:])
+	default:
+		return filepath.Base(file)
+	}
+}
+
+// hasGopathPrefix returns true and the length of the matched GOPATH workspace,
+// iff file has a prefix that matches one of the GOPATH workspaces.
+func hasGopathPrefix(file, gopath string) (hasGopathPrefix bool, prefixLen int) {
+	gopathWorkspaces := filepath.SplitList(gopath)
+	for _, gopathWorkspace := range gopathWorkspaces {
+		gopathWorkspace = filepath.Clean(gopathWorkspace)
+		if strings.HasPrefix(file, gopathWorkspace) {
+			return true, len(gopathWorkspace)
+		}
+	}
+	return false, 0
 }

--- a/internal/sourcemapx/filter_test.go
+++ b/internal/sourcemapx/filter_test.go
@@ -23,7 +23,7 @@ func TestFilter(t *testing.T) {
 
 	filter := &Filter{
 		Writer: code,
-		MappingCallback: func(generatedLine, generatedColumn int, originalPos token.Position, originalName string) {
+		goMappingCallback: func(generatedLine, generatedColumn int, originalPos token.Position, originalName string) {
 			entries = append(entries, entry{
 				GenLine:  generatedLine,
 				GenCol:   generatedColumn,

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5,3 +5,11 @@ import "testing"
 // Test_JSReservedWords uses testdata/reserved/main.go
 // to test that JS reserved words can be used as labels, variable names, etc.
 func Test_JSReservedWords(t *testing.T) { runOutputTest(t, `testdata`, `reserved`) }
+
+// Test_JSSourceMap_Unminified uses testdata/jsSourceMap/main.go
+// to test that the source map generated for the JS code is correct on unminified output.
+func Test_JSSourceMap_Unminified(t *testing.T) { runOutputTest(t, `testdata`, `jsSourceMap`) }
+
+// Test_JSSourceMap_Minified uses testdata/jsSourceMap/main.go
+// to test that the source map generated for the JS code is correct on minified output.
+func Test_JSSourceMap_Minified(t *testing.T) { runOutputTest(t, `testdata`, `jsSourceMap`, `-m`) }

--- a/tests/testdata/jsSourceMap/helper/helper.go
+++ b/tests/testdata/jsSourceMap/helper/helper.go
@@ -1,0 +1,7 @@
+package helper
+
+import "github.com/gopherjs/gopherjs/js"
+
+func DoGoThing() string {
+	return js.Global.Call(`doJSThing`).String()
+}

--- a/tests/testdata/jsSourceMap/helper/helper.inc.js
+++ b/tests/testdata/jsSourceMap/helper/helper.inc.js
@@ -1,0 +1,8 @@
+// Helper JavaScript code for jsSourceMap tests that gets the stack trace
+// so that the stack frames can be checked for expected source mapping.
+function doJSThing() {
+    return Error().stack;
+}
+
+// Give access to the function from Go code via js.Global.
+this.doJSThing = doJSThing;

--- a/tests/testdata/jsSourceMap/main.go
+++ b/tests/testdata/jsSourceMap/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/tests/testdata/jsSourceMap/helper"
+)
+
+func main() {
+	trace := helper.DoGoThing()
+	lines := strings.Split(trace, "\n")
+
+	// Print out part of the stack trace that includes Go code, JS prelude, and .inc.js sources.
+	printStackFrame(lines[1]) // doJSThing from .inc.js
+	printStackFrame(lines[2]) // helper.DoGoThing from helper.go
+	printStackFrame(lines[3]) // main.main from main.go (here)
+	printStackFrame(lines[5]) // $goroutine from prelude/goroutines.js
+}
+
+var frameSplitter = regexp.MustCompile(`^\s+at\s+(.*)\s+\((.*):(\d+):(\d+)\)$`)
+
+func printStackFrame(line string) {
+	matches := frameSplitter.FindStringSubmatch(line)
+	method := matches[1]
+	if index := strings.LastIndex(method, `/`); index >= 0 {
+		// Trim off the package path for readability.
+		method = method[index+1:]
+	}
+
+	// Normalize path separators to '/' for consistency across platforms.
+	file := strings.ReplaceAll(matches[2], `\`, `/`)
+	if index := strings.LastIndex(file, "gopherjs"); index >= 0 {
+		// Remove the repo root so that this test works for forks as well.
+		file = file[index:]
+	}
+	lineNum := matches[3]
+	// colNum := matches[4]
+	// ignore the column number for now since for some reason it shifts
+	// between minimized and non-minimized builds, e.g. helper.inc.js
+	// has column 12 in non-minimized (at front of `Error`)
+	// but 20 in minimized (at front of `stack`) builds.
+	// This seems to be caused by esbuild and not something we control.
+	fmt.Printf("%s\t(%s:%s)\n", method, file, lineNum)
+}

--- a/tests/testdata/jsSourceMap/main.out
+++ b/tests/testdata/jsSourceMap/main.out
@@ -1,0 +1,4 @@
+doJSThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.inc.js:4)
+helper.DoGoThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.go:6)
+main.main	(gopherjs/tests/testdata/jsSourceMap/main.go:12)
+$goroutine	(gopherjs/compiler/prelude/goroutines.js:134)

--- a/tool.go
+++ b/tool.go
@@ -23,7 +23,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/neelance/sourcemap"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -651,8 +650,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 				}
 
 				sourceMapFilter := &sourcemapx.Filter{Writer: buf}
-				m := &sourcemap.Map{File: base + ".js"}
-				sourceMapFilter.MappingCallback = s.SourceMappingCallback(m)
+				s.EnableMapping(sourceMapFilter, base+`.js`)
 
 				deps, err := compiler.ImportDependencies(archive, s.ImportResolverFor(""))
 				if err != nil {
@@ -663,7 +661,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 				}
 
 				mapBuf := new(bytes.Buffer)
-				m.WriteTo(mapBuf)
+				sourceMapFilter.WriteMappingTo(mapBuf)
 				buf.WriteString("//# sourceMappingURL=" + base + ".js.map\n")
 				fs.sourceMaps[name+".map"] = mapBuf.Bytes()
 


### PR DESCRIPTION
Adding JS writer to source map filter so that we can also map the JS files (prelude and .inc.js) into the source map. When doing this, it moved more of the source mapping code into `sourcemapx`. This will help with debugging when the error comes from the preludes. For example, if we call `"Hello"[1:800]` it will panic for the out-of-bounds index, but that error comes from the prelude JS files it wasn't being mapped. To make the mapping work, I reused the `esbuild` dependency that was added to the prelude for minimization for creating a source map for JS even when not minimized.

`esbuild` does some stuff to the JS code when not being minimized. I turned as much of that off as I could figure out how to do. It looks like most of the added stuff is to define properties and help with tree shaking. There will still be some differences between the prelude and output, but they are negligible. The minimized version is nearly identical with the JS changes turned off as they were prior to this PR.

This might be related to https://github.com/gopherjs/gopherjs/issues/943

------

I also fixed the lint issue that got into master (I'm not sure why lint issues aren't being reported all the time in PRs and we should probably fix that so we don't get a red `x` on master just because of an extra line).

------

The change in the js size is not significant but obviously it will increase the js.map size.

|  Branch       | minimized | js (bytes)  | js.map (bytes) |
|:--------------|:---------:|------------:|---------------:|
| srcMapPrelude |           |   5,079,824 |        397,761 |
| srcMapPrelude |     X     |   3,218,929 |        377,690 |
| master        |           |   5,091,184 |        349,192 |
| master        |     X     |   3,217,561 |        335,166 |
| diff          |           |     -11,360 |        +48,569 |
| diff          |     X     |      +1,368 |        +42,524 |
| diff (%)      |           |      -0.233 |        +13.909 |
| diff (%)      |     X     |      +0.043 |        +12.687 |
