### PR TITLE
Touchup of go1.20

### DIFF
--- a/.github/workflows/measure-size.yml
+++ b/.github/workflows/measure-size.yml
@@ -4,7 +4,6 @@ on: ['pull_request']
 
 env:
   GO_VERSION: '~1.20.14'
-  GOPHERJS_EXPERIMENT: generics
 
 jobs:
   measure:

--- a/compiler/natives/src/crypto/subtle/xor.go
+++ b/compiler/natives/src/crypto/subtle/xor.go
@@ -18,7 +18,7 @@ func XORBytes(dst, x, y []byte) int {
 		panic("subtle.XORBytes: dst too short")
 	}
 
-	// The original uses unsafe and uintptr for specific architecture
+	// GOPHERJS: The original uses unsafe and uintptr for specific architecture
 	// to pack registers full instead of doing one byte at a time.
 	// We can't do the unsafe conversions from []byte to []uintptr
 	// but we can convert a Uint8Array into a Uint32Array,
@@ -73,7 +73,5 @@ const supportsUnaligned = false
 //gopherjs:purge
 func xorBytes(dstb, xb, yb *byte, n int)
 
-// TODO(grantnelson-wf): Check if this should be removed or not with generics.
-//
 //gopherjs:purge
 func xorLoop[T byte | uintptr](dst, x, y []T) {}


### PR DESCRIPTION
Made three changes:

1. Removed the unneeded `GOPHERJS_EXPERIMENT` from a CI workflow

2. Removed a comment about checking if the `xorLoop` method should still be removed now that generics has been implemented. Yes, it should be because it is using `uintptr` and we'd need it to be `uint` if we were to use it. That's just as much work as purging it so we'll just remove the comment and continue to purge the function

3. Updated `chainedCtx.Import` to return the primary `Import` error if both fail since the secondary `Import` error will say that "$GOPATH not set." which can be confusing. This is because the secondary `Import` is for the virtual files in the gopherjs context so the context doesn't have GOPATH set in it. This is not specific to go1.20 but me and some other devs at Workiva were trying to help a new dev setup his computer and we kept getting "$GOPATH not set." I wanted to see why when his GOPATH was definitely setup correctly. (The problem ended up being that he was checking out repos into his home directory then symlinking them into the Go path and that was causing other conflicts finding packages.)

After these changes (the first two) were the only changes I saw that still needed to be made to the go1.20 branch before I felt it ready. They are based on comments in https://github.com/gopherjs/gopherjs/pull/1398