### PR TITLE
Updated the list of reserved keywords

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -26,12 +26,12 @@ var (
 
 func init() {
 	keywords := []string{
-		"abstract", "arguments", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
-		"debugger", "default", "delete", "do", "double", "else", "enum", "eval", "export", "extends", "false",
+		"abstract", "arguments", "await", "async", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+		"continue", "debugger", "default", "delete", "do", "double", "else", "enum", "eval", "export", "extends", "false",
 		"final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof",
 		"int", "interface", "let", "long", "native", "new", "null", "package", "private", "protected", "public",
 		"return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient",
-		"true", "try", "typeof", "undefined", "var", "void", "volatile", "while", "with", "yield",
+		"true", "try", "typeof", "undefined", "using", "var", "void", "volatile", "while", "with", "yield",
 	}
 	for _, keyword := range keywords {
 		reservedKeywords[keyword] = true


### PR DESCRIPTION
While tinkering on an update to the gopherjs playground ([here](https://github.com/grantnelson-wf/gopherjs.github.io/tree/updateTo1_19)) I ran into an issue; the dependency "github.com/evanw/esbuild/internal/js_parser" uses the reserved keyword "await" and caused problems in the output JS.

I looked up the reserved keywords for JS ([using this source](https://www.w3schools.com/js/js_reserved.asp)) and found we were missing "await", "async", and "using". I added those words into the list. Now that dependency builds and runs just fine.