### PR TITLE
Removing "beta" from go1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ version, you can use an [older GopherJS release](https://github.com/gopherjs/gop
 Install GopherJS with `go install`:
 
 ```
-go install github.com/gopherjs/gopherjs@v1.20.0-beta1  # Or replace 'v1.20.0-beta1' with another version.
+go install github.com/gopherjs/gopherjs@v1.20.0  # Or replace 'v1.20.0' with another version.
 ```
 
 If your local Go distribution as reported by `go version` is newer than Go 1.20, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.20 distribution. For example:

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version is the GopherJS compiler version string.
-const Version = "1.20.0-beta1+go1.20.14"
+const Version = "1.20.0+go1.20.14"
 
 // GoVersion is the current Go 1.x version that GopherJS is compatible with.
 const GoVersion = 20


### PR DESCRIPTION
After the discussion in slack, we determined it may be reasonable to drop the "-beta1" from go1.20 release tag. To facilitate the tagging, this PR removes the "-beta1" from the code.