### PR TITLE
[go1.21] Adding `new` / `replace` optional override directives

### DIFF
--- a/build/build_test.go
+++ b/build/build_test.go
@@ -724,7 +724,11 @@ func TestOriginalAugmentation(t *testing.T) {
 			fileSrc := f.Parse("test.go", pkgName+test.src)
 
 			augmentOriginalImports(importPath, fileSrc)
-			augmentOriginalFile(fileSrc, test.info)
+			found := make(map[string]struct{})
+			augmentOriginalFile(fileSrc, test.info, found)
+			if err := checkOverrides(test.info, found, importPath); err != nil {
+				t.Errorf("check overrides: %v", err)
+			}
 			pruneImports(fileSrc)
 
 			got := srctesting.Format(t, f.FileSet, fileSrc)

--- a/compiler/astutil/astutil.go
+++ b/compiler/astutil/astutil.go
@@ -133,6 +133,28 @@ func FuncReceiverKey(d *ast.FuncDecl) string {
 	}
 }
 
+// DirectiveReplace returns true if gopherjs:replace directive is present
+// on a struct, interface, type, variable, constant, or function.
+//
+// `//gopherjs:replace` is a GopherJS-specific directive, which can be
+// applied in native overlays and will instruct the augmentation logic to
+// ensure that the original code is present and has not been removed nor renamed,
+// otherwise an error will be raised.
+func DirectiveReplace(d ast.Node) bool {
+	return hasDirective(d, `replace`)
+}
+
+// DirectiveNew returns true if gopherjs:new directive is
+// present on a struct, interface, type, variable, constant, or function.
+//
+// `//gopherjs:new` is a GopherJS-specific directive, which can be
+// applied in native overlays and will instruct the augmentation logic to
+// ensure that the original code is not present so that this code does not
+// override any original code, otherwise an error will be raised.
+func DirectiveNew(d ast.Node) bool {
+	return hasDirective(d, `new`)
+}
+
 // KeepOriginal returns true if gopherjs:keep-original directive is present
 // before a function decl.
 //
@@ -141,6 +163,9 @@ func FuncReceiverKey(d *ast.FuncDecl) string {
 // logic to expose the original function such that it can be called. For a
 // function in the original called `foo`, it will be accessible by the name
 // `_gopherjs_original_foo`.
+//
+// This will also ensure that the original function exists and hasn't been
+// removed or renamed, otherwise an error will be raised.
 func KeepOriginal(d *ast.FuncDecl) bool {
 	return hasDirective(d, `keep-original`)
 }
@@ -156,6 +181,9 @@ func KeepOriginal(d *ast.FuncDecl) bool {
 // fully supported). It should be used with caution since it may remove needed
 // dependencies. If a type is purged, all methods using that type as
 // a receiver will also be purged.
+//
+// This will also ensure that the original code exists and hasn't been
+// removed or renamed, otherwise an error will be raised.
 func Purge(d ast.Node) bool {
 	return hasDirective(d, `purge`)
 }
@@ -167,6 +195,7 @@ func Purge(d ast.Node) bool {
 // be applied in native overlays and will instruct the augmentation logic to
 // replace the original function signature which has the same FuncKey with the
 // signature defined in the native overlays.
+//
 // This directive can be used to remove generics from a function signature or
 // to replace a receiver of a function with another one. The given native
 // overlay function will be removed, so no method body is needed in the overlay.
@@ -174,6 +203,9 @@ func Purge(d ast.Node) bool {
 // The new signature may not contain types which require a new import since
 // the imports will not be automatically added when needed, only removed.
 // Use a type alias in the overlay to deal manage imports.
+//
+// This will also ensure that the original code exists and hasn't been
+// removed or renamed, otherwise an error will be raised.
 func OverrideSignature(d *ast.FuncDecl) bool {
 	return hasDirective(d, `override-signature`)
 }

--- a/compiler/natives/src/internal/bytealg/bytealg.go
+++ b/compiler/natives/src/internal/bytealg/bytealg.go
@@ -2,6 +2,7 @@
 
 package bytealg
 
+//gopherjs:replace
 func Equal(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
@@ -14,6 +15,7 @@ func Equal(a, b []byte) bool {
 	return true
 }
 
+//gopherjs:replace
 func IndexByte(b []byte, c byte) int {
 	for i, x := range b {
 		if x == c {
@@ -23,6 +25,7 @@ func IndexByte(b []byte, c byte) int {
 	return -1
 }
 
+//gopherjs:replace
 func IndexByteString(s string, c byte) int {
 	for i := 0; i < len(s); i++ {
 		if s[i] == c {
@@ -30,4 +33,9 @@ func IndexByteString(s string, c byte) int {
 		}
 	}
 	return -1
+}
+
+//gopherjs:replace
+func MakeNoZero(n int) []byte {
+	return make([]byte, n)
 }


### PR DESCRIPTION
This is part of the proposal [issue #1330, "Proposal: More strict native override checking"](https://github.com/gopherjs/gopherjs/issues/1330). This adds the `gopherjs:new` and `gopherjs:replace` optional directives. Additionally, I added the new missing method to bytealg and added these directives as a test. Since this is being added to the go1.21 integration branch, CI will continue to fail. This code includes [the update to master](https://github.com/gopherjs/gopherjs/pull/1413) so that PR should be merged before this one.

Between Go1.20 and Go1.21, the Go developers refactored reflect and internal/reflectlite by moving a lot of code over to internal/abi. Since so much code was in internal packages; the developers weren't required to keep exported code consistent other than in reflect. Since there was so much code being moved, it was difficult for me to determine what was new code to go1.20, code being replaced in go1.20, then which code is new in go1.21 and replaced in go1.21. Any code that was a replacement for go1.20 of code that got moved, removed, or renamed in go1.21 would suddenly become new code we are adding.

I didn't want to leave around a bunch of code that hopefully had no effect (and hopefully just removed with dead code elimination), so I implemented this part of the proposal to help me track how our overrides are being applied.

These overrides are compiler enforced "developer intensions" just like the [override modifier in C#](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/override) and other modifiers in many languages. The code could quietly decide if we are overriding code or adding new code, or with these directives we can ensure that overrides work as the developer intended at compile time.

The full proposal is probably overkill at this time because of how strict is. These directives are not required so we don't have to add them to all of the overrides in one pass. The only change that this will effect is any of the existing override directives (i.e. `purge`, `keep-original`, and `override-signature`) will start acting like `gopherjs:replace` and raise an error if the code that they are attached to doesn't exist.

Instead of adding this code, then removing it once I have reflect, reflectlite, and abi working, I felt this would be a good time to add these directives. We already have to go through the native overrides while upgrading to go1.21 so any of the existing override directives can be updated as needed and we can add in these new directives if we feel it will help us when we upgrade to go1.22.

However, if you think that this is not a good idea to add; I have no problem skipping it and removing it from the reflect, reflectlite, and abi updates.

Related to https://github.com/gopherjs/gopherjs/issues/1415