### PR TITLE
[go1.21] Updating some linking and a few other updates

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -379,6 +379,11 @@ func augmentOriginalImports(importPath string, file *ast.File) {
 // augmentOriginalFile is the part of parseAndAugment that processes an
 // original file AST to augment the source code using the overrides from
 // the overlay files.
+//
+// The overrides and found maps key with an identifier that uniquely identifies
+// the top-level object being augmented.
+// The overrides map should be populated with the overrides to apply.
+// Found will be populated with the objects that had an override applied.
 func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo, found map[string]struct{}) {
 	anyChange := false
 	for i, decl := range file.Decls {
@@ -480,6 +485,11 @@ func augmentOriginalFile(file *ast.File, overrides map[string]overrideInfo, foun
 // checkOverrides performs a final check of the overrides to ensure that
 // all overrides that were expected to be found were found and all overrides
 // that were not expected to be found were not found.
+//
+// The overrides and found maps key with an identifier
+// that uniquely identifies the top-level object being augmented.
+// Found is populated with the objects that had an override applied
+// so the found keys should be a subset of the keys in the overrides map.
 func checkOverrides(overrides map[string]overrideInfo, found map[string]struct{}, pkgPath string) error {
 	el := errlist.ErrorList{}
 	for name, info := range overrides {

--- a/compiler/natives/src/internal/godebug/godebug.go
+++ b/compiler/natives/src/internal/godebug/godebug.go
@@ -6,3 +6,10 @@ import _ "unsafe" // go:linkname
 
 //go:linkname setUpdate runtime.godebug_setUpdate
 func setUpdate(update func(def, env string))
+
+// GOPHERJS: Changing from a linked function to a no-op since this is to give
+// runtime the ability to do `newNonDefaultInc(name)` instead of
+// `godebug.New(name).IncNonDefault` but GopherJS's runtime doesn't need that.
+//
+//gopherjs:replace
+func setNewIncNonDefault(newIncNonDefault func(string) func()) {}

--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -501,6 +501,13 @@ func godebug_setUpdate(update func(def, env string)) {
 	godebug_notify(godebugEnvKey, godebugEnv)
 }
 
+// godebug_setNewIncNonDefault implements the setNewIncNonDefault in
+// src/internal/godebug/godebug.go.
+// GOPHERJS: The GopherJS runtime doesn't need this function so we can remove it.
+//
+//gopherjs:puge
+func godebug_setNewIncNonDefault(newIncNonDefault func(string) func())
+
 func getEnvString(key string) string {
 	process := js.Global.Get(`process`)
 	if process == js.Undefined {

--- a/compiler/natives/src/sync/sync.go
+++ b/compiler/natives/src/sync/sync.go
@@ -87,3 +87,13 @@ func runtime_nanotime() int64
 func throw(s string) {
 	js.Global.Call("$throwRuntimeError", s)
 }
+
+// GOPHERJS: This is identical to the original but without the go:linkname
+// that can not be handled right now, "can not insert local implementation..."
+// TODO(grantnelson-wf): Remove once linking works both directions.
+//
+//gopherjs:replace
+func syscall_hasWaitingReaders(rw *RWMutex) bool {
+	r := rw.readerCount.Load()
+	return r < 0 && r+rwmutexMaxReaders > 0
+}

--- a/compiler/natives/src/syscall/syscall_js_wasm.go
+++ b/compiler/natives/src/syscall/syscall_js_wasm.go
@@ -1,6 +1,7 @@
 package syscall
 
 import (
+	"sync"
 	"syscall/js"
 	_ "unsafe" // go:linkname
 )
@@ -51,6 +52,14 @@ func unsetenv_c(k string) {
 
 //go:linkname godebug_notify runtime.godebug_notify
 func godebug_notify(key, value string)
+
+// GOPHERJS: This was replaced so that we could add the go:linkname since
+// sync.syscall_hasWaitingReaders had a link we can't handle right now,
+// "can not insert local implementation..."
+// TODO(grantnelson-wf): Remove once linking works both directions.
+//
+//go:linkname hasWaitingReaders sync.syscall_hasWaitingReaders
+func hasWaitingReaders(rw *sync.RWMutex) bool
 
 func setStat(st *Stat_t, jsSt js.Value) {
 	// This method is an almost-exact copy of upstream, except for 4 places where

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -9,10 +9,10 @@ import (
 	"go/token"
 	"go/types"
 	"net/url"
+	"reflect"
 	"regexp"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -821,49 +821,7 @@ func encodeString(s string) string {
 }
 
 func getJsTag(tag string) string {
-	for tag != "" {
-		// skip leading space
-		i := 0
-		for i < len(tag) && tag[i] == ' ' {
-			i++
-		}
-		tag = tag[i:]
-		if tag == "" {
-			break
-		}
-
-		// scan to colon.
-		// a space or a quote is a syntax error
-		i = 0
-		for i < len(tag) && tag[i] != ' ' && tag[i] != ':' && tag[i] != '"' {
-			i++
-		}
-		if i+1 >= len(tag) || tag[i] != ':' || tag[i+1] != '"' {
-			break
-		}
-		name := string(tag[:i])
-		tag = tag[i+1:]
-
-		// scan quoted string to find value
-		i = 1
-		for i < len(tag) && tag[i] != '"' {
-			if tag[i] == '\\' {
-				i++
-			}
-			i++
-		}
-		if i >= len(tag) {
-			break
-		}
-		qvalue := string(tag[:i+1])
-		tag = tag[i+1:]
-
-		if name == "js" {
-			value, _ := strconv.Unquote(qvalue)
-			return value
-		}
-	}
-	return ""
+	return reflect.StructTag(tag).Get(`js`)
 }
 
 func needsSpace(c byte) bool {


### PR DESCRIPTION
These updates were ones that needed to be done for the reflect/reflectlite/abi update but weren't really related to that update specifically. I also added comments requested from the prior PR and replaced the tag parser using reflect.

I'm still not very confident in how links work in GopherJS. I haven't looked deeply into what it all does. So this update is kind of to bring light to the links that may have otherwise been consumed by the reflects update. That way if I'm doing something wrong, hopefully it will be caught. Even though, if it is wrong or needs changing in the future, I'm not too worried about it since this is going into the go1.21 integration branch. We'll get it working before that branch is done.

Related to https://github.com/gopherjs/gopherjs/issues/1415