### PR TITLE
[go1.21] Adding max, min, and clear builtin methods

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1064,6 +1064,26 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 		return fc.formatExpr("$recover()")
 	case "close":
 		return fc.formatExpr(`$close(%e)`, args[0])
+	case "min", "max":
+		if basic, isBasic := fc.typeOf(args[0]).Underlying().(*types.Basic); isBasic && isOrdered(basic) {
+			fnName := `$` + name
+			if is64Bit(basic) {
+				fnName += `64`
+			} else if isString(basic) {
+				fnName += `Str`
+			}
+			return fc.formatExpr("%s(%e, %s)", fnName, args[0], strings.Join(fc.translateExprSlice(args[1:], basic), `, `))
+		}
+		panic(fmt.Sprintf("Unhandled type for %s: %T\n", name, args[0]))
+	case "clear":
+		switch argType := fc.typeOf(args[0]).Underlying().(type) {
+		case *types.Slice:
+			return fc.formatExpr("$clearSlice(%e)", args[0])
+		case *types.Map:
+			return fc.formatExpr("$clearMap(%e)", args[0])
+		default:
+			panic(fmt.Sprintf("Unhandled clear type: %T\n", argType))
+		}
 	case "Sizeof":
 		return fc.formatExpr("%d", sizes32.Sizeof(fc.typeOf(args[0])))
 	case "Alignof":

--- a/compiler/prelude/numeric.js
+++ b/compiler/prelude/numeric.js
@@ -1,4 +1,12 @@
 var $min = Math.min;
+var $max = Math.max;
+
+var $less64 = (x, y) => x.$high < y.$high || (x.$high === y.$high && x.$low < y.$low);
+var $min64 = (first, ...rest) => rest.reduce((m, x) => $less64(x, m) ? x : m, first);
+var $max64 = (first, ...rest) => rest.reduce((m, x) => $less64(m, x) ? x : m, first);
+var $minStr = (first, ...rest) => rest.reduce((m, x) => x < m ? x : m, first);
+var $maxStr = (first, ...rest) => rest.reduce((m, x) => m < x ? x : m, first);
+
 var $mod = (x, y) => { return x % y; };
 var $parseInt = parseInt;
 var $parseFloat = f => {

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -626,3 +626,20 @@ var $sliceData = (slice, typ) => {
     }
     return $indexPtr(slice.$array, slice.$offset, typ.elem);
 };
+
+var $clearSlice = (slice) => {
+    const n = slice.$length;
+    if (n === 0) {
+        return
+    }
+    const arr = slice.$array;
+    const off = slice.$offset;
+    const zeroFn = slice.constructor.elem.zero;
+    for (let i = 0; i < n; i++) {
+        arr[off + i] = zeroFn();
+    }
+};
+
+var $clearMap = (m) => {
+    typeof m.clear === "function" && m.clear()
+};

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -728,6 +728,10 @@ func isNumeric(t *types.Basic) bool {
 	return t.Info()&types.IsNumeric != 0
 }
 
+func isOrdered(t *types.Basic) bool {
+	return t.Info()&types.IsOrdered != 0
+}
+
 func isString(t *types.Basic) bool {
 	return t.Info()&types.IsString != 0
 }

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -126,6 +126,18 @@ func Test_MapDelete(t *testing.T) {
 	delete(m, "key") // noop
 }
 
+func Test_MapClear(t *testing.T) {
+	var nilMap map[string]string
+	m := map[string]string{"key": "value"}
+
+	clear(nilMap) // noop
+	clear(m)
+	if len(m) != 0 {
+		t.Error("Got: entries still set, Want: map should be cleared")
+	}
+	clear(m) // noop
+}
+
 func assertMapApi(t *testing.T, myMap map[string]int) {
 	if len(myMap) != 3 {
 		t.Errorf("initial len of map Got: %d, Want: 3", len(myMap))

--- a/tests/numeric_test.go
+++ b/tests/numeric_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"cmp"
 	"fmt"
+	"math"
 	"math/bits"
 	"math/rand"
 	"runtime"
@@ -199,5 +201,114 @@ func Test_32BitEnvironment(t *testing.T) {
 				t.Errorf("got: %d\nwant: %d.", got, exp)
 			}
 		})
+	}
+}
+
+// checkMinMax2 is a helper for Test_MinMax that checks the builtin min
+// and max methods. The x value must be less than y.
+func checkMinMax2[T cmp.Ordered](t *testing.T, x, y T) {
+	t.Helper()
+	check := func(a, b T) {
+		if got, want := min(a, b), x; got != want {
+			t.Errorf("min[%T](%v, %v): got: %v, want: %v", want, a, b, got, want)
+		}
+		if got, want := max(a, b), y; got != want {
+			t.Errorf("max[%T](%v, %v): got: %v, want: %v", want, a, b, got, want)
+		}
+	}
+	check(x, y)
+	check(y, x)
+}
+
+// checkMinMax4 is a helper for Test_MinMax that checks the builtin min
+// and max methods. The builtin min and max are not actually veriadic,
+// so cannot be tested via `min(first, rest...)`, but they do allow 1 or more
+// arguments, so this one checks 4 arguments. v1 must be the actual min,
+// and v4 must be the actual max.
+func checkMinMax4[T cmp.Ordered](t *testing.T, v1, v2, v3, v4 T) {
+	t.Helper()
+	check := func(a, b, c, d T) {
+		if got, want := min(a, b, c, d), v1; got != want {
+			t.Errorf("min[%T](%v, %v, %v, %v): got: %v, want: %v", want, a, b, c, d, got, want)
+		}
+		if got, want := max(a, b, c, d), v4; got != want {
+			t.Errorf("max[%T](%v, %v, %v, %v): got: %v, want: %v", want, a, b, c, d, got, want)
+		}
+	}
+	check(v1, v2, v3, v4)
+	check(v1, v2, v4, v3)
+	check(v1, v4, v2, v3)
+	check(v1, v4, v3, v2)
+	check(v2, v1, v3, v4)
+	check(v2, v1, v4, v3)
+	check(v2, v4, v1, v3)
+	check(v2, v4, v3, v1)
+	check(v3, v1, v2, v4)
+	check(v3, v1, v4, v2)
+	check(v3, v4, v1, v2)
+	check(v3, v4, v2, v1)
+	check(v4, v1, v2, v3)
+	check(v4, v1, v3, v2)
+	check(v4, v3, v1, v2)
+	check(v4, v3, v2, v1)
+}
+
+// checkMinMax1 is a helper for Test_MinMax that checks the builtin min
+// and max methods. This checks the edge case with 1 argument.
+func checkMinMax1[T cmp.Ordered](t *testing.T, x T) {
+	t.Helper()
+	if got := min(x); got != x {
+		t.Errorf("min[%T](%v): got: %v, want: %v", x, x, got, x)
+	}
+	if got := max(x); got != x {
+		t.Errorf("max[%T](%v): got: %v, want: %v", x, x, got, x)
+	}
+}
+
+func Test_MinMax(t *testing.T) {
+	checkMinMax2(t, 0, 1)     // int
+	checkMinMax2(t, -1, 0)    // int
+	checkMinMax2(t, 12, 42)   // int
+	checkMinMax2(t, -42, -12) // int
+	checkMinMax2[int8](t, -9, 13)
+	checkMinMax2[int16](t, 0, 23)
+	checkMinMax2[int32](t, -87, 1234)
+	checkMinMax2[int64](t, -0xDEAD_BEEF, 0x7FFF_FFFF_FFFF_FFFF)
+	checkMinMax2[uint8](t, 9, 13)
+	checkMinMax2[uint16](t, 0, 23)
+	checkMinMax2[uint32](t, 87, 1234)
+	checkMinMax2[uint64](t, 0xDEAD_BEEF, 0x7FFF_FFFF_FFFF_FFFF)
+	checkMinMax2[uintptr](t, 12345, 54321)
+	checkMinMax2[float32](t, 1.41421356237, 3.14159265359)
+	checkMinMax2(t, -3.14159265359, 1.41421356237) // float64
+	checkMinMax2(t, ``, `a`)                       // string
+	checkMinMax2(t, `a`, `z`)                      // string
+	checkMinMax2(t, `a`, `aa`)                     // string
+	checkMinMax2(t, `banana`, `cat`)               // string
+	checkMinMax2(t, `Dog`, `dog`)                  // string
+
+	checkMinMax4(t, -4, -3, -2, -1) // int
+	checkMinMax4(t, 1, 2, 3, 4)     // int
+	checkMinMax4[int64](t, -4, -3, -2, -1)
+	checkMinMax4[int64](t, 1, 2, 3, 4)
+	checkMinMax4[uint64](t, 1, 2, 3, 4)
+	checkMinMax4(t, `apple`, `banana`, `carrot`, `durian`) // string
+
+	checkMinMax1(t, 1) // int
+	checkMinMax1[int64](t, -19)
+	checkMinMax1[uint64](t, 244)
+	checkMinMax1(t, 2.3)    // float64
+	checkMinMax1(t, `Ludo`) // string
+
+	// Note that math.Min and math.Max act differently for NaN than max and min,
+	// see [https://github.com/golang/go/issues/60616]
+	// Fortunelty the builtin max and min act like JS's Math.max and Math.min,
+	// see [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min]
+	// If any argument is NaN, then NaN will be returned.
+	if got := min(42, math.NaN(), -81); !math.IsNaN(got) {
+		t.Errorf("min(..NaN..): got: %v, want: %v", got, math.NaN())
+	}
+	if got := max(42, math.NaN(), -81); !math.IsNaN(got) {
+		t.Errorf("max(..NaN..): got: %v, want: %v", got, math.NaN())
 	}
 }

--- a/tests/slice_test.go
+++ b/tests/slice_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_SliceClear_Bytes(t *testing.T) {
+	var s []byte
+	clear(s) // noop
+
+	s = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	clear(s[3:7])
+	if want := []byte{1, 2, 3, 0, 0, 0, 0, 8, 9}; !reflect.DeepEqual(s, want) {
+		t.Errorf("Got: %v after partial clear, Want: %v", s, want)
+	}
+
+	clear(s)
+	if want := make([]byte, 9); !reflect.DeepEqual(s, want) {
+		t.Errorf("Got: %v after full clear, Want: %v", s, want)
+	}
+}
+
+func Test_SliceClear_Structs(t *testing.T) {
+	type name struct {
+		first string
+		last  string
+	}
+
+	var s []name
+	clear(s) // noop
+
+	s = []name{
+		{first: `bob`, last: `bobson`},
+		{first: `jill`, last: `jillton`},
+		{first: `brian`, last: `o'brian`},
+		{first: `brian`, last: `o'brian`},
+	}
+	clear(s[1:3])
+	if want := []name{s[0], {}, {}, s[3]}; !reflect.DeepEqual(s, want) {
+		t.Errorf("Got: %v after partial clear, Want: %v", s, want)
+	}
+
+	clear(s)
+	if want := make([]name, 4); !reflect.DeepEqual(s, want) {
+		t.Errorf("Got: %v after full clear, Want: %v", s, want)
+	}
+}


### PR DESCRIPTION
Adding [max](https://pkg.go.dev/builtin@go1.21.0#max), [min](https://pkg.go.dev/builtin@go1.21.0#min), and [clear](https://pkg.go.dev/builtin@go1.21.0#clear) builtin methods that are new to go1.21

The tests will run if we comment out `TestLinknameReflectName` and the links it creates since those links broke in the reflect / reflectlite / ABI update. I've put up a PR to remove this test and why.

Related to https://github.com/gopherjs/gopherjs/issues/1415