### PR TITLE
[go1.21] Removed TestLinknameReflectName

### DIFF
--- a/tests/linkname_test.go
+++ b/tests/linkname_test.go
@@ -38,30 +38,3 @@ func TestLinknameMethods(t *testing.T) {
 	}()
 	method.TestLinkname(t)
 }
-
-type (
-	name    struct{ bytes *byte }
-	nameOff int32
-	rtype   struct{}
-)
-
-//go:linkname rtype_nameOff reflect.(*rtype).nameOff
-func rtype_nameOff(r *rtype, off nameOff) name
-
-//go:linkname newName reflect.newName
-func newName(n, tag string, exported bool) name
-
-//go:linkname name_name reflect.name.name
-func name_name(name) string
-
-//go:linkname resolveReflectName reflect.resolveReflectName
-func resolveReflectName(n name) nameOff
-
-func TestLinknameReflectName(t *testing.T) {
-	info := "myinfo"
-	off := resolveReflectName(newName(info, "", false))
-	n := rtype_nameOff(nil, off)
-	if s := name_name(n); s != info {
-		t.Fatalf("to reflect.name got %q: want %q", s, info)
-	}
-}


### PR DESCRIPTION
`TestLinknameReflectName` hooks into unexported code in Go and GopherJS native overrides. With the go1.21 update to reflect that moved a lot of code from `reflect` (and `internal/reflectlite`) to `internal/abi` causing this test to break.

As stated in my message to the developer who added this test, https://github.com/goplusjs/reflectx/issues/10, I'm going to remove this test for now. It doesn't appear that their project will need the go1.21 update right away.

However, if they are going to use the go1.21 update and still need stable hooks for their repo, then I can put the test back and rework part of ABI and reflect to make it work for the same reason it was added. Or if they'd like to do the same kind of change to GopherJS to accommodate their projects, that's cool too.

This was the last issue in the `CI/Go Tests`, so those should be passing now.
Most of CI will fail since this is part of the go1.21 integration work.

Related to https://github.com/gopherjs/gopherjs/issues/1415