### PR TITLE
[wip][go1.21] Adding unsafe.Slice and other fixes

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1071,6 +1071,10 @@ func (fc *funcContext) translateBuiltin(name string, sig *types.Signature, args 
 	case "Offsetof":
 		sel, _ := fc.selectionOf(astutil.RemoveParens(args[0]).(*ast.SelectorExpr))
 		return fc.formatExpr("%d", typesutil.OffsetOf(sizes32, sel))
+	case "Slice":
+		ptrType := fc.typeOf(args[0]).Underlying().(*types.Pointer)
+		sliceType := types.NewSlice(ptrType.Elem())
+		return fc.formatExpr("$unsafeSlice(%e, %e, %s)", args[0], args[1], fc.typeName(sliceType))
 	case "SliceData":
 		t := fc.typeOf(args[0]).Underlying().(*types.Slice)
 		return fc.formatExpr(`$sliceData(%e, %s)`, args[0], fc.typeName(t))

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1172,7 +1172,8 @@ func (fc *funcContext) translateConversion(expr ast.Expr, desiredType types.Type
 						// The following are extensions of the ABI equivalent type to add more methods.
 						// e.g. `type structType struct { abi.StructType }`.
 						case `interfaceType`, `mapType`, `ptrType`, `sliceType`, `structType`:
-							return fc.formatExpr("toKindTypeExt(%e)", call.Args[0]) // unsafe conversion
+							obj := fc.pkgCtx.Pkg.Scope().Lookup(`toKindTypeExt`)
+							return fc.formatExpr("%s(%e)", fc.objectName(obj), call.Args[0]) // unsafe conversion
 						}
 					}
 					return fc.translateExpr(expr)

--- a/compiler/natives/src/internal/godebug/godebug.go
+++ b/compiler/natives/src/internal/godebug/godebug.go
@@ -5,7 +5,16 @@ package godebug
 import _ "unsafe" // go:linkname
 
 //go:linkname setUpdate runtime.godebug_setUpdate
+//gopherjs:replace
 func setUpdate(update func(def, env string))
+
+// GOPHERJS: Changing from a linked function to a no-op since this is
+// part of recording metrics for runtime. The metrics take time and size
+// measurments for Go (listed in [runtime/metrics.go]). GopherJS does not
+// currently record that information.
+//
+//gopherjs:replace
+func registerMetric(name string, read func() uint64) {}
 
 // GOPHERJS: Changing from a linked function to a no-op since this is to give
 // runtime the ability to do `newNonDefaultInc(name)` instead of

--- a/compiler/natives/src/log/log_test.go
+++ b/compiler/natives/src/log/log_test.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package log
+
+import "testing"
+
+func TestOutputRace(t *testing.T) {
+	t.Skip("Fails with: WaitGroup counter not zero")
+}

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -620,6 +620,20 @@ var $typeOf = x => {
     return typeof (x);
 };
 
+var $unsafeSlice = (ptr, len, typ) => {
+    if (ptr === typ.nil || ptr.$isNil) {
+        if (len > 0) {
+            $throwRuntimeError("unsafe.Slice: ptr is nil and len is not zero");
+        }
+        return typ.nil;
+    }
+    var s = new typ(ptr.$target);
+    s.$offset = ptr.$index;
+    s.$length = len;
+    s.$capacity = len;
+    return s;
+};
+
 var $sliceData = (slice, typ) => {
     if (slice === typ.nil) {
         return $ptrType(typ.elem).nil;

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -656,10 +656,22 @@ var $indexPtr = (array, index, constructor) => {
         // Pointers of different primitive types are non-comparable and stored in different caches.
         var typeCache = cache[array.name] = cache[array.name] || {};
         var cacheIdx = array.BYTES_PER_ELEMENT * index + array.byteOffset;
-        return typeCache[cacheIdx] || (typeCache[cacheIdx] = new constructor(() => { return array[index]; }, v => { array[index] = v; }));
+        var ptr = typeCache[cacheIdx];
+        if (!ptr) {
+            ptr = new constructor(() => { return array[index]; }, v => { array[index] = v; }, array);
+            ptr.$index = index;
+            typeCache[cacheIdx] = ptr;
+        }
+        return ptr;
     } else {
         array.$ptr = array.$ptr || {};
-        return array.$ptr[index] || (array.$ptr[index] = new constructor(() => { return array[index]; }, v => { array[index] = v; }));
+        var ptr = array.$ptr[index];
+        if (!ptr) {
+            ptr = new constructor(() => { return array[index]; }, v => { array[index] = v; }, array);
+            ptr.$index = index;
+            array.$ptr[index] = ptr;
+        }
+        return ptr;
     }
 };
 

--- a/tests/linkname_test.go
+++ b/tests/linkname_test.go
@@ -38,30 +38,3 @@ func TestLinknameMethods(t *testing.T) {
 	}()
 	method.TestLinkname(t)
 }
-
-type (
-	name    struct{ bytes *byte }
-	nameOff int32
-	rtype   struct{}
-)
-
-//go:linkname rtype_nameOff reflect.(*rtype).nameOff
-func rtype_nameOff(r *rtype, off nameOff) name
-
-//go:linkname newName reflect.newName
-func newName(n, tag string, exported bool) name
-
-//go:linkname name_name reflect.name.name
-func name_name(name) string
-
-//go:linkname resolveReflectName reflect.resolveReflectName
-func resolveReflectName(n name) nameOff
-
-func TestLinknameReflectName(t *testing.T) {
-	info := "myinfo"
-	off := resolveReflectName(newName(info, "", false))
-	n := rtype_nameOff(nil, off)
-	if s := name_name(n); s != info {
-		t.Fatalf("to reflect.name got %q: want %q", s, info)
-	}
-}


### PR DESCRIPTION
Adding `unsafe.Slice` and adding any native overrides that don't work with what we can do for `unsafe.Slice` in JS.

Related to https://github.com/gopherjs/gopherjs/issues/1415