### PR TITLE
Fixing bug in generics function instances

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
   ubuntu_smoke:
     name: Ubuntu Smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +49,7 @@ jobs:
   windows_smoke:
     name: Window Smoke
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -70,6 +72,7 @@ jobs:
   darwin_smoke:
     name: Darwin Smoke
     runs-on: macos-latest
+    timeout-minutes: 10
     env:
       # Node version '12' is not found for darwin.
       NODE_VERSION: 20
@@ -93,6 +96,7 @@ jobs:
   lint:
     name: Lint Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,6 +122,7 @@ jobs:
   go_tests:
     name: Go Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -136,6 +141,7 @@ jobs:
   todomvc_check:
     name: TodoMVC GO111MODULE Check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -177,6 +183,7 @@ jobs:
   gopherjs_tests:
     name: GopherJS Tests (${{ matrix.filter.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -208,6 +215,7 @@ jobs:
   gorepo_tests:
     name: Gorepo Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -496,8 +496,26 @@ func (fc *funcContext) varPtrName(o *types.Var) string {
 	if !ok {
 		name = fc.newVariable(o.Name()+"$ptr", isPkgLevel(o))
 		fc.pkgCtx.varPtrNames[o] = name
+		return name
+	}
+
+	// If name already exists for the package, check that the function's instantiation
+	// also has the name in its localVars. This is to handle generics where `o` is
+	// shared among multiple instantiations of the same generic, but `newVariable`
+	// is only called for the first.
+	if !fc.instance.IsTrivial() && !containsString(fc.localVars, name) {
+		fc.localVars = append(fc.localVars, name)
 	}
 	return name
+}
+
+func containsString(s []string, v string) bool {
+	for i := len(s) - 1; i >= 0; i-- {
+		if v == s[i] {
+			return true
+		}
+	}
+	return false
 }
 
 // typeName returns a JS identifier name for the given Go type.

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -984,3 +984,32 @@ func TestCrossPackageGenericCasting(t *testing.T) {
 		t.Errorf(`Got: otherpkg.GetterHandle[int](otherpkg.Zero[int]) = %v, Want: %v`, got, wantInt)
 	}
 }
+
+func incIntPtr(count *int) { *count++ }
+
+func poorlyCountElements[T any](data []T) int {
+	var count int
+	for range data {
+		incIntPtr(&count)
+	}
+	return count
+}
+
+// TestConcretePointerInGeneric tests a problem were the `&count` pointer
+// in `poorlyCountElements` was creating a pointer var (e.g. "count$24ptr")
+// that was only being added to the vars in the first instantiation of generic
+// function and not the second, so `poorlyCountElements[string]` would work
+// but `poorlyCountElements[int]` would fail with "count$24ptr is not defined".
+func TestConcretePointerInGeneric(t *testing.T) {
+	cats := []string{"meowser", "mittens", "wiskers"}
+	count := poorlyCountElements(cats)
+	if count != 3 {
+		t.Errorf("Unexpected value from count with [string]: got %d, want 3", count)
+	}
+
+	numbers := []int{4, 8, 15, 16, 23, 42}
+	count = poorlyCountElements(numbers)
+	if count != 6 {
+		t.Errorf("Unexpected value from count with [int]: got %d, want 6", count)
+	}
+}


### PR DESCRIPTION
When there is a non-escaping variable that creates a variable type internal to a generic function, such as `var count int` being used as `&count` without an explicit `*int` definition (as seen in the test added in this PR), the first instantiation of the generic function will get the generated pointer reference assigned to the function's `localVars` list but the following instantiations will be missing that variable since "it was already created".

To fix this, I added code to check if a function already contains a variable name when the package already knows the name. This means that all the function instantiations that are currently missing the variable from `localVars` will now get them added.

The fix could probably be improved by using a map to keep track of the localVars (or a map in addition to the current slice), but I just opted to linearly search the slice. I search backwards assuming that the variables in instantiations of a generic function would be closer together at the end. Something happened one of the times I was testing this and CI ran for way way too long, so I also looked up how to set time limits to prevent it from running so long again.
