### PR TITLE
Cache imports to improve performance

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -772,6 +772,10 @@ type Session struct {
 	// is the unresolved import path and source directory.
 	importPaths map[string]map[string]string
 
+	// packages caches imported package metadata by resolved import path.
+	// This avoids repeated xctx.Import calls for the same package.
+	packages map[string]*PackageData
+
 	// sources is a map of parsed packages that have been built and augmented.
 	// This is keyed using resolved import paths. This is used to avoid
 	// rebuilding and augmenting packages that are imported by several packages.
@@ -792,6 +796,7 @@ func NewSession(options *Options) (*Session, error) {
 	s := &Session{
 		options:          options,
 		importPaths:      make(map[string]map[string]string),
+		packages:         make(map[string]*PackageData),
 		sources:          make(map[string]*sources.Sources),
 		UpToDateArchives: make(map[string]*compiler.Archive),
 	}
@@ -1013,6 +1018,16 @@ func (s *Session) loadTestPackage(pkg *PackageData) (*sources.Sources, error) {
 // Relative import paths are interpreted relative to the passed srcDir.
 // If srcDir is empty, current working directory is assumed.
 func (s *Session) loadImportPathWithSrcDir(path, srcDir string) (*PackageData, *sources.Sources, error) {
+	if pkg, ok := s.cachedPackageFor(path, srcDir); ok {
+		// Cache this srcDir lookup as well, so later getImportPath lookups avoid xctx.Import.
+		s.cacheImportPath(path, srcDir, pkg.ImportPath)
+		srcs, err := s.LoadPackages(pkg)
+		if err != nil {
+			return nil, nil, err
+		}
+		return pkg, srcs, nil
+	}
+
 	pkg, err := s.xctx.Import(path, srcDir, 0)
 	if s.Watcher != nil && pkg != nil { // add watch even on error
 		s.Watcher.Add(pkg.Dir)
@@ -1021,6 +1036,7 @@ func (s *Session) loadImportPathWithSrcDir(path, srcDir string) (*PackageData, *
 		return nil, nil, err
 	}
 
+	s.packages[pkg.ImportPath] = pkg
 	srcs, err := s.LoadPackages(pkg)
 	if err != nil {
 		return nil, nil, err
@@ -1028,6 +1044,20 @@ func (s *Session) loadImportPathWithSrcDir(path, srcDir string) (*PackageData, *
 
 	s.cacheImportPath(path, srcDir, pkg.ImportPath)
 	return pkg, srcs, nil
+}
+
+func (s *Session) cachedPackageFor(path, srcDir string) (*PackageData, bool) {
+	if resolved, ok := s.importPaths[srcDir][path]; ok {
+		pkg, found := s.packages[resolved]
+		return pkg, found
+	}
+
+	if !build.IsLocalImport(path) {
+		pkg, found := s.packages[path]
+		return pkg, found
+	}
+
+	return nil, false
 }
 
 // cacheImportPath stores the resolved import path for the build package
@@ -1206,6 +1236,19 @@ func (s *Session) getImportPath(path, srcDir string) (string, error) {
 	// Check if the import path is already cached.
 	if importPath, ok := s.importPaths[srcDir][path]; ok {
 		return importPath, nil
+	}
+
+	// Fast-path for non-local imports when we already have their metadata.
+	if !build.IsLocalImport(path) {
+		if _, ok := s.sources[path]; ok {
+			// Sources are keyed by canonical import path.
+			s.cacheImportPath(path, srcDir, path)
+			return path, nil
+		}
+		if pkg, ok := s.packages[path]; ok {
+			s.cacheImportPath(path, srcDir, pkg.ImportPath)
+			return pkg.ImportPath, nil
+		}
 	}
 
 	// Fall back to the slow import of the build package.

--- a/build/context.go
+++ b/build/context.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"golang.org/x/tools/go/buildutil"
 
@@ -81,8 +82,9 @@ type XContext interface {
 // features.
 type simpleCtx struct {
 	bctx         build.Context
-	isVirtual    bool // Imported packages don't have a physical directory on disk.
-	noPostTweaks bool // Don't apply post-load tweaks to packages. For tests only.
+	stdPkgCache  *sync.Map // map[importPath]bool
+	isVirtual    bool      // Imported packages don't have a physical directory on disk.
+	noPostTweaks bool      // Don't apply post-load tweaks to packages. For tests only.
 }
 
 // Import implements XContext.Import().
@@ -274,11 +276,33 @@ func (sc simpleCtx) applyPostloadTweaks(pkg *build.Package) *build.Package {
 // isStd returns true if the given importPath resolves into a standard library
 // package. Relative paths are interpreted relative to srcDir.
 func (sc simpleCtx) isStd(importPath, srcDir string) bool {
-	pkg, err := sc.bctx.Import(importPath, srcDir, build.FindOnly)
-	if err != nil {
+	if !isGopherJSImportPath(importPath) && isDefinitelyNotStdImportPath(importPath) {
 		return false
 	}
+
+	cacheKey := importPath
+	if cachedValue, ok := sc.stdPkgCache.Load(cacheKey); ok {
+		return cachedValue.(bool)
+	}
+
+	pkg, err := sc.bctx.Import(importPath, srcDir, build.FindOnly)
+	if err != nil {
+		sc.stdPkgCache.Store(cacheKey, false)
+		return false
+	}
+	sc.stdPkgCache.Store(cacheKey, pkg.Goroot)
 	return pkg.Goroot
+}
+
+// isGopherJSImportPath reports whether importPath is one of the special
+// GopherJS runtime packages that may be resolved from embedded std-like sources.
+func isGopherJSImportPath(importPath string) bool {
+	switch importPath {
+	case "github.com/gopherjs/gopherjs/js", "github.com/gopherjs/gopherjs/nosync":
+		return true
+	default:
+		return false
+	}
 }
 
 var defaultBuildTags = []string{
@@ -328,6 +352,7 @@ func gopherjsCtx(e Env) *simpleCtx {
 // or Go Modules.
 func goCtx(e Env) *simpleCtx {
 	gc := simpleCtx{
+		stdPkgCache: &sync.Map{},
 		bctx: build.Context{
 			GOROOT:        e.GOROOT,
 			GOPATH:        e.GOPATH,
@@ -350,6 +375,22 @@ func goCtx(e Env) *simpleCtx {
 		},
 	}
 	return &gc
+}
+
+// A hauristic that will identify some import paths that definitely don't belong
+// to the standard library, so we can skip expensive checks for them.
+func isDefinitelyNotStdImportPath(importPath string) bool {
+	// Relative import paths and local imports can't be standard library packages.
+	if importPath == "" || build.IsLocalImport(importPath) {
+		return true
+	}
+
+	// Standard library packages don't contain dots in the first path element
+	firstElement := importPath
+	if i := strings.Index(firstElement, "/"); i >= 0 {
+		firstElement = firstElement[:i]
+	}
+	return strings.Contains(firstElement, ".")
 }
 
 // chainedCtx combines two build contexts. Secondary context acts as a fallback

--- a/build/context_test.go
+++ b/build/context_test.go
@@ -203,6 +203,55 @@ func TestIsStd(t *testing.T) {
 	}
 }
 
+func TestIsDefinitelyNotStdImportPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		importPath string
+		expected   bool
+	}{
+		{
+			name:     "empty path",
+			expected: true,
+		},
+		{
+			name:       "relative local import",
+			importPath: "./pkg",
+			expected:   true,
+		},
+		{
+			name:       "parent local import",
+			importPath: "../pkg",
+			expected:   true,
+		},
+		{
+			name:       "dot in first element",
+			importPath: "github.com/gopherjs/gopherjs/build",
+			expected:   true,
+		},
+		{
+			name:       "standard package",
+			importPath: "fmt",
+		},
+		{
+			name:       "standard subpackage",
+			importPath: "net/http",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name,
+			func(t *testing.T) {
+				actual := isDefinitelyNotStdImportPath(test.importPath)
+				if actual != test.expected {
+					t.Errorf("isDefinitelyNotStdImportPath(%q) = %v, expected %v",
+						test.importPath,
+						actual,
+						test.expected)
+				}
+			})
+	}
+}
+
 func expectedPackage(bctx *build.Context, importPath string, goarch string) *build.Package {
 	targetRoot := filepath.Clean(filepath.Join(bctx.GOROOT, "pkg", bctx.GOOS+"_"+goarch))
 	return &build.Package{

--- a/build/context_test.go
+++ b/build/context_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -107,14 +108,16 @@ func TestChainedCtx(t *testing.T) {
 				"primaryonly": {"po.go": "package primaryonly"},
 				"both":        {"both.go": "package both"},
 			}),
-			isVirtual: false,
+			isVirtual:   false,
+			stdPkgCache: &sync.Map{},
 		},
 		secondary: simpleCtx{
 			bctx: *buildutil.FakeContext(map[string]map[string]string{
 				"both":          {"both_secondary.go": "package both"},
 				"secondaryonly": {"so.go": "package secondaryonly"},
 			}),
-			isVirtual: true,
+			isVirtual:   true,
+			stdPkgCache: &sync.Map{},
 		},
 	}
 


### PR DESCRIPTION
We have been looking into allowing our project to exist outside of a GOPATH and we've noticed that GopherJS compile times are much slower in that case.

After some investigation, it appears that resolving imports simply takes a longer time when using Go modules. While there's not a lot that can be done about that root issue, we can establish a caching system that can help avoid resolving imports for the same thing multiple times.

In our case, which is admittedly a sizable code base, compiling our GopherJS code takes around 40 seconds in GOPATH, a little bit over 8 minutes outside of GOPATH without this change and roughly a minute outside of GOPATH with this change. This change does not seem to make much of an impact on compile times in GoPath because those imports are already fast enough that the caching doesn't provide a significant boost.