### PR TITLE
[go1.21] Some more updates to native overrides for go1.21

### DIFF
--- a/compiler/natives/src/bytes/bytes_js_wasm_test.go
+++ b/compiler/natives/src/bytes/bytes_js_wasm_test.go
@@ -1,0 +1,15 @@
+//go:build js && wasm
+
+package bytes_test
+
+import (
+	"testing"
+)
+
+//gopherjs:replace
+func TestIssue65571(t *testing.T) {
+	t.Skip("TestIssue65571 expects `int` to be greater than 32 bits")
+	// This fails with `1 << 31 + 1 (untyped int constant 2147483649) overflows int`
+	// since int is set to 32 bits when performing the type check even though
+	// JS can handle larger values during runtime.
+}

--- a/compiler/natives/src/cmd/internal/goobj/goobj.go
+++ b/compiler/natives/src/cmd/internal/goobj/goobj.go
@@ -1,0 +1,8 @@
+//go:build js
+
+package goobj
+
+//gopherjs:replace Used unsafeheader.String
+func toString(b []byte) string {
+	return string(b)
+}

--- a/compiler/natives/src/encoding/binary/binary_test.go
+++ b/compiler/natives/src/encoding/binary/binary_test.go
@@ -1,0 +1,14 @@
+//go:build js
+
+package binary
+
+import "testing"
+
+//gopherjs:replace The original cast the uint32 into a *byte which doesn't work in JS
+func TestNativeEndian(t *testing.T) {
+	const val = 0x12345678
+	s := []byte{0x78, 0x56, 0x34, 0x12} // LittleEndian
+	if v := NativeEndian.Uint32(s); v != val {
+		t.Errorf("NativeEndian.Uint32 returned %#x, expected %#x", v, val)
+	}
+}

--- a/compiler/natives/src/encoding/xml/read_test.go
+++ b/compiler/natives/src/encoding/xml/read_test.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package xml
+
+import "testing"
+
+func TestCVE202228131(t *testing.T) {
+	t.Skip(`Uses maxUnmarshalDepth in a depth test that will exceed maximum call stack in JS`)
+}

--- a/compiler/natives/src/go/token/token_test.go
+++ b/compiler/natives/src/go/token/token_test.go
@@ -4,6 +4,7 @@ package token
 
 import "testing"
 
+//gopherjs:replace
 func TestFileSetRace(t *testing.T) {
 	t.Skip("Fails with: WaitGroup counter not zero")
 	// "go/token" files are updated in build/build.go#augmentOriginalImports to

--- a/compiler/natives/src/internal/godebug/godebug.go
+++ b/compiler/natives/src/internal/godebug/godebug.go
@@ -7,6 +7,14 @@ import _ "unsafe" // go:linkname
 //go:linkname setUpdate runtime.godebug_setUpdate
 func setUpdate(update func(def, env string))
 
+// GOPHERJS: Changing from a linked function to a no-op since this is
+// part of recording metrics for runtime. The metrics take time and size
+// measurments for Go (listed in [runtime/metrics.go]). GopherJS does not
+// currently record that information.
+//
+//gopherjs:replace
+func registerMetric(name string, read func() uint64) {}
+
 // GOPHERJS: Changing from a linked function to a no-op since this is to give
 // runtime the ability to do `newNonDefaultInc(name)` instead of
 // `godebug.New(name).IncNonDefault` but GopherJS's runtime doesn't need that.

--- a/compiler/natives/src/internal/zstd/zstd_test.go
+++ b/compiler/natives/src/internal/zstd/zstd_test.go
@@ -1,0 +1,16 @@
+//go:build js
+
+package zstd
+
+import "testing"
+
+//gopehrjs:replace
+func TestAlloc(t *testing.T) {
+	t.Skip(`testing.AllocsPerRun not supported in GopherJS`)
+}
+
+//gopehrjs:replace
+func bigData(t testing.TB) []byte {
+	t.Skip(`test requires access to ../../testdata that is not avaiable in GopherJS`)
+	return nil
+}

--- a/compiler/natives/src/log/log_test.go
+++ b/compiler/natives/src/log/log_test.go
@@ -1,13 +1,13 @@
 //go:build js
 
-package token
+package log
 
 import "testing"
 
-func TestFileSetRace(t *testing.T) {
+func TestOutputRace(t *testing.T) {
 	t.Skip("Fails with: WaitGroup counter not zero")
-	// "go/token" files are updated in build/build.go#augmentOriginalImports to
+	// "log" files are updated in build/build.go#augmentOriginalImports to
 	// use the `gopherjs/nosync` package instead of `sync`.
 	// `nosync`'s WaitGroup Wait method panics if the counter is not zero since it assumes
-	// the code will be synchronously executed for specific packages including go/token.
+	// the code will be synchronously executed for specific packages including log.
 }

--- a/compiler/natives/src/log/log_test.go
+++ b/compiler/natives/src/log/log_test.go
@@ -4,6 +4,7 @@ package log
 
 import "testing"
 
+//gopherjs:replace
 func TestOutputRace(t *testing.T) {
 	t.Skip("Fails with: WaitGroup counter not zero")
 	// "log" files are updated in build/build.go#augmentOriginalImports to

--- a/compiler/natives/src/slices/slices_test.go
+++ b/compiler/natives/src/slices/slices_test.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package slices
+
+import "testing"
+
+func TestGrow(t *testing.T) {
+	t.Skip("testing.AllocsPerRun not supported in GopherJS")
+}


### PR DESCRIPTION
This contains some more changes to native overrides:
- Adding some of the updates to fix or skip tests in the native overrides
- Fixing some unsupported `//go:linkname` links
- Removing cast to an `unsafeheader.String`

This also contains the update to add comments to `TestOutputRace` as [discussed here](https://github.com/gopherjs/gopherjs/pull/1424#discussion_r3120424258)

CI will still fail since this is part of the go1.21 integration work.
Related to https://github.com/gopherjs/gopherjs/issues/1415
