### PR TITLE
[go1.21] Fixed int64/uint64 indexes when creating index pointers

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -276,10 +276,10 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 				// To allow a slice to be recreated from a `&s[i]` via casting a pointer back into the slice or using `unsafe.Slice`,
 				// we have to create pointer objects via `$indexPtr` even if the element is a struct or array, meaning ignore the `opIsStructOrArray` case.
 				if _, ok := fc.typeOf(x.X).Underlying().(*types.Slice); ok {
-					pattern := rangeCheck("$indexPtr(%1e.$array, %1e.$offset + %2e, %3s)", fc.pkgCtx.Types[x.Index].Value != nil, false)
+					pattern := rangeCheck("$indexPtr(%1e.$array, %1e.$offset + %2f, %3s)", fc.pkgCtx.Types[x.Index].Value != nil, false)
 					return fc.formatExpr(pattern, x.X, x.Index, fc.typeName(exprType))
 				}
-				pattern := rangeCheck("$indexPtr(%1e, %2e, %3s)", fc.pkgCtx.Types[x.Index].Value != nil, true)
+				pattern := rangeCheck("$indexPtr(%1e, %2f, %3s)", fc.pkgCtx.Types[x.Index].Value != nil, true)
 				return fc.formatExpr(pattern, x.X, x.Index, fc.typeName(exprType))
 			case *ast.StarExpr:
 				return fc.translateExpr(x.X)

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -1288,3 +1288,46 @@ func TestStringData(t *testing.T) {
 		}
 	})
 }
+
+func TestPointerToSliceIndex64(t *testing.T) {
+	// This test repeated an issue when using an int64 index in an pointer to a
+	// slice or array element causing the element to be resolved to the zero value
+	// of the structure. Since int64 and uint64 are stored as an object with a
+	// high/low value, we should use `%f` when creating the pattern for the
+	// expression to ensure they are flattened into a num.
+	type symbol struct {
+		name  string
+		value int
+		size  int
+	}
+	arr := [4]symbol{
+		{name: `a12b`, value: 8, size: 8},
+		{name: `a10`, value: 42, size: 64},
+		{name: `b4`, value: 3, size: 16},
+	}
+	slc := arr[:]
+
+	want := `&{a10 42 64}` // Must not be the zero value of the struct
+	check := func(p *symbol) {
+		if got := fmt.Sprintf(`%v`, p); got != want {
+			t.Errorf(`expected the pointer to the struct to be %s but it was %s`, want, got)
+		}
+	}
+
+	t.Run("Int64Array", func(t *testing.T) {
+		var index int64 = 1
+		check(&arr[index])
+	})
+	t.Run("Uint64Array", func(t *testing.T) {
+		var index uint64 = 1
+		check(&arr[index])
+	})
+	t.Run("Int64Slice", func(t *testing.T) {
+		var index int64 = 1
+		check(&slc[index])
+	})
+	t.Run("Uint64Slice", func(t *testing.T) {
+		var index uint64 = 1
+		check(&slc[index])
+	})
+}


### PR DESCRIPTION
When I was working on the update to indexPtrs for unsafe.Slice, I used a `%e` instead of a `%f` by mistake. This fixes that mistake and adds a test to check the fix.

CI will still fail since this is part of the go1.21 integration work.
Related to https://github.com/gopherjs/gopherjs/issues/1415