### PR TITLE
[go1.21] Adding more nil-aware checks

### DIFF
--- a/.std_test_pkg_exclusions
+++ b/.std_test_pkg_exclusions
@@ -2,7 +2,6 @@ encoding/xml
 go/build
 go/internal/srcimporter
 go/types
-internal/abi
 internal/intern
 internal/syscall/windows
 internal/syscall/windows/registry

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1329,7 +1329,7 @@ func (fc *funcContext) translateConversion(expr ast.Expr, desiredType types.Type
 			//
 			// TODO(nevkontakte): Should this only apply when exprType is a pointer to a
 			// struct as well?
-			return fc.formatExpr("(%1e === %2s.nil ? %3s.nil : $pointerOfStructConversion(%1e, %3s))", expr, fc.typeName(exprType), fc.typeName(desiredType))
+			return fc.formatExpr("$pointerOfStructConversion(%e, %s)", expr, fc.typeName(desiredType))
 		}
 
 		if types.Identical(exprType, types.Typ[types.UnsafePointer]) {

--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -271,7 +271,12 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 				newSel := &ast.SelectorExpr{X: fc.newIdent("this.$target", fc.typeOf(x.X)), Sel: x.Sel}
 				fc.setType(newSel, exprType)
 				fc.pkgCtx.additionalSelections[newSel] = sel
-				return fc.formatExpr("(%1e.$ptr_%2s || (%1e.$ptr_%2s = new %3s(function() { return %4e; }, function($v) { %5s }, %1e)))", x.X, x.Sel.Name, fc.typeName(exprType), newSel, fc.translateAssign(newSel, fc.newIdent("$v", exprType), false))
+				if _, ok := fc.typeOf(x.X).Underlying().(*types.Pointer); ok {
+					return fc.formatExpr("(%1e === %2s.nil && $throwNilPointerError(), (%1e.$ptr_%3s || (%1e.$ptr_%3s = new %4s(function() { return %5e; }, function($v) { %6s }, %1e))))",
+						x.X, fc.typeName(fc.typeOf(x.X)), x.Sel.Name, fc.typeName(exprType), newSel, fc.translateAssign(newSel, fc.newIdent("$v", exprType), false))
+				}
+				return fc.formatExpr("(%1e.$ptr_%2s || (%1e.$ptr_%2s = new %3s(function() { return %4e; }, function($v) { %5s }, %1e)))",
+					x.X, x.Sel.Name, fc.typeName(exprType), newSel, fc.translateAssign(newSel, fc.newIdent("$v", exprType), false))
 			case *ast.IndexExpr:
 				// To allow a slice to be recreated from a `&s[i]` via casting a pointer back into the slice or using `unsafe.Slice`,
 				// we have to create pointer objects via `$indexPtr` even if the element is a struct or array, meaning ignore the `opIsStructOrArray` case.
@@ -797,6 +802,10 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 		}
 		switch exprType.Underlying().(type) {
 		case *types.Struct, *types.Array:
+			innerTyp := fc.typeOf(e.X)
+			if _, ok := innerTyp.Underlying().(*types.Pointer); ok {
+				return fc.formatExpr("(%1e === %2s.nil && $throwNilPointerError(), %1e)", e.X, fc.typeName(innerTyp))
+			}
 			return fc.translateExpr(e.X)
 		}
 		return fc.formatExpr("%e.$get()", e.X)
@@ -1320,7 +1329,7 @@ func (fc *funcContext) translateConversion(expr ast.Expr, desiredType types.Type
 			//
 			// TODO(nevkontakte): Should this only apply when exprType is a pointer to a
 			// struct as well?
-			return fc.formatExpr("$pointerOfStructConversion(%e, %s)", expr, fc.typeName(desiredType))
+			return fc.formatExpr("(%1e === %2s.nil ? %3s.nil : $pointerOfStructConversion(%1e, %3s))", expr, fc.typeName(exprType), fc.typeName(desiredType))
 		}
 
 		if types.Identical(exprType, types.Typ[types.UnsafePointer]) {

--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -65,11 +65,32 @@ func (e *TypeAssertionError) Error() string {
 		": missing method " + e.missingMethod
 }
 
+// A PanicNilError happens when code calls panic(nil).
+//
+// Before Go 1.21, programs that called panic(nil) observed recover returning nil.
+// Starting in Go 1.21, programs that call panic(nil) observe recover returning a *PanicNilError.
+// Programs can change back to the old behavior by setting GODEBUG=panicnil=1.
+type PanicNilError struct {
+	// This field makes PanicNilError structurally different from
+	// any other struct in this package, and the _ makes it different
+	// from any struct in other packages too.
+	// This avoids any accidental conversions being possible
+	// between this struct and some other struct sharing the same fields,
+	// like happened in go.dev/issue/56603.
+	_ [0]*PanicNilError
+}
+
+func (*PanicNilError) Error() string { return "panic called with nil argument" }
+func (*PanicNilError) RuntimeError() {}
+
+func newPanicNilError() *PanicNilError { return new(PanicNilError) }
+
 func init() {
 	jsPkg := js.Global.Get("$packages").Get("github.com/gopherjs/gopherjs/js")
 	js.Global.Set("$jsObjectPtr", jsPkg.Get("Object").Get("ptr"))
 	js.Global.Set("$jsErrorPtr", jsPkg.Get("Error").Get("ptr"))
 	js.Global.Set("$throwRuntimeError", js.InternalObject(throw))
+	js.Global.Set("$newPanicNilError", js.InternalObject(newPanicNilError))
 	buildVersion = js.Global.Get("$goVersion").String()
 	// avoid dead code elimination
 	var e error

--- a/compiler/prelude/goroutines.js
+++ b/compiler/prelude/goroutines.js
@@ -110,6 +110,9 @@ var $callDeferred = (deferred, jsErr, fromPanic) => {
 };
 
 var $panic = value => {
+    if (value === $ifaceNil) {
+        value = $newPanicNilError();
+    }
     $curGoroutine.panicStack.push(value);
     $callDeferred(null, null, true);
 };

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -72,6 +72,7 @@ var $packages = {}, $idCounter = 0;
 var $keys = m => { return m ? Object.keys(m) : []; };
 var $flushConsole = () => { };
 var $throwRuntimeError; /* set by package "runtime" */
+var $newPanicNilError; /* set by package "runtime" — returns a new *PanicNilError */
 var $throwNilPointerError = () => { $throwRuntimeError("invalid memory address or nil pointer dereference"); };
 var $call = (fn, rcvr, args) => { return fn.apply(rcvr, args); };
 var $makeFunc = fn => { return function(...args) { return $externalize(fn(this, new ($sliceType($jsObjectPtr))($global.Array.prototype.slice.call(args, []))), $emptyInterface); }; };

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -409,6 +409,9 @@ var $clone = (src, type) => {
 };
 
 var $pointerOfStructConversion = (obj, type) => {
+    if (obj === (obj.constructor && obj.constructor.nil)) {
+        return type.nil;
+    }
     if (obj.$proxies === undefined) {
         obj.$proxies = {};
         obj.$proxies[obj.constructor.string] = obj;

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -82,7 +82,6 @@ var knownFails = map[string]failReason{
 			"runtime error: invalid memory address or nil pointer dereference"
 		want:
 			"value method main.T.F called using nil *T pointer"`},
-	"fixedbugs/issue19246.go": {desc: "expected nil pointer dereference panic"}, // Issue https://golang.org/issues/19246: Failed to evaluate some zero-sized values when converting them to interfaces.
 
 	// These are new tests in Go 1.10.
 	"fixedbugs/issue21887.go": {desc: "incorrect output (although within spec, not worth fixing) for println(^uint64(0)). got: { '$high': 4294967295, '$low': 4294967295, '$val': [Circular] } want: 18446744073709551615"},
@@ -95,7 +94,6 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue24547.go": {desc: "incorrect computing method sets with shadowed methods"},
 
 	// These are new tests in Go 1.12.
-	"fixedbugs/issue23837.go":  {desc: "missing panic on nil pointer-to-empty-struct dereference"},
 	"fixedbugs/issue27201.go":  {desc: "incorrect stack trace for nil dereference in inlined function"},
 	"fixedbugs/issue27518b.go": {desc: "sigpanic can make dead pointer live again"},
 	"fixedbugs/issue29190.go":  {desc: "append does not fail when length overflows", category: neverTerminates},
@@ -151,11 +149,11 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue25897a.go": {category: neverTerminates, desc: "does for { runtime.GC() }"},
 	"fixedbugs/issue54343.go":  {category: notApplicable, desc: "uses runtime.SetFinalizer() and runtime.GC()."},
 	"fixedbugs/issue57823.go":  {category: notApplicable, desc: "uses runtime.SetFinalizer() and runtime.GC()."},
-	"fixedbugs/issue59293.go":  {category: usesUnsupportedPackage, desc: "uses unsafe.SliceData() and unsafe.StringData()."},
 	"fixedbugs/issue43942.go":  {category: other, desc: "https://github.com/gopherjs/gopherjs/issues/1126"},
 
 	// These are new tests in Go 1.21
-	// TODO(grantnelson-wf): Fill out
+	"fixedbugs/issue58300.go":  {category: usesUnsupportedPackage, desc: "runtime.FuncForPC from outside of Caller() or Callers() which is not supported yet"},
+	"fixedbugs/issue58300b.go": {category: usesUnsupportedPackage, desc: "runtime.FuncForPC from outside of Caller() or Callers() which is not supported yet"},
 }
 
 type failCategory uint8

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"go/token"
 	"math"
 	"reflect"
@@ -205,6 +206,24 @@ func TestPointerOfStructConversion(t *testing.T) {
 
 	if got := reflect.TypeOf((AP)(&A{Value: 1})); got.String() != "tests.AP" {
 		t.Errorf("Got: reflect.TypeOf((AP)(&A{Value: 1})) = %v. Want: tests.AP.", got)
+	}
+}
+
+// TestNilPointerOfStructConversion is from https://github.com/gopherjs/gopherjs/issues/843.
+// The pointer for the new type should not be non-nil pointing to a nil pointer.
+// Originally, printing the new type did not work because the nil check did not
+// work on the non-nil pointer so the printer attempted to dereference the pointer
+// but at that point the "nil pointer dereference" error would panic.
+func TestNilPointerOfStructConversion(t *testing.T) {
+	type FooType struct{ ourField int }
+	type BarType struct{ ourField int }
+	var foo *FooType = nil
+	var bar *BarType = (*BarType)(foo)
+	if bar != nil {
+		t.Errorf(`nil pointer casted to a new type should still be nil but it was not`)
+	}
+	if want, got := `<nil>`, fmt.Sprintf(`%v`, bar); want != got {
+		t.Errorf("nil pointer casted to a new type printed the wrong result\n\twant: %q\n\tgot:  %q", want, got)
 	}
 }
 
@@ -982,6 +1001,124 @@ func TestCrossPackageGenericCasting(t *testing.T) {
 	var wantInt int
 	if got := fn(); got != wantInt {
 		t.Errorf(`Got: otherpkg.GetterHandle[int](otherpkg.Zero[int]) = %v, Want: %v`, got, wantInt)
+	}
+}
+
+// TestNilPointerDereference was added because fixedbugs/issue63657.go
+// pointed out an error where a pointer was being made to a field on a nil struct.
+// It should panic on creation of the pointer but wasn't because the pointer wrapped
+// a get and set around the field such that if get or set were called then the panic
+// may occur. Go expects the panic to be at the creation of the pointer.
+func TestNilPointerDereference(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{
+			// based on fixedbugs/issue63657.go
+			name: `pointer to int field on a nil struct`,
+			fn: func() {
+				type X struct{ a, b int }
+				x := (*X)(nil)
+				_ = &x.b //nolint:nilderef
+			},
+		},
+		{
+			name: `pointer to struct field on nil struct`,
+			fn: func() {
+				type Y struct{ a int }
+				type X struct{ b Y }
+				x := (*X)(nil)
+				_ = &x.b //nolint:nilderef
+			},
+		},
+		{
+			name: `pointer to field of nil struct in slice`,
+			fn: func() {
+				type X struct{ b int }
+				x := []*X{nil}
+				_ = &x[0].b //nolint:nilderef
+			},
+		},
+		{
+			name: `pointer to nil array`,
+			fn: func() {
+				x := (*[3]int)(nil)
+				_ = *x //nolint:nilderef
+			},
+		},
+		{
+			name: `pointer to nil struct`,
+			fn: func() {
+				type X struct{ b int }
+				x := (*X)(nil)
+				_ = *x //nolint:nilderef
+			},
+		},
+		{
+			name: `named pointer to nil struct`,
+			fn: func() {
+				type X struct{ b int }
+				type P *X
+				x := P(nil)
+				_ = *x //nolint:nilderef
+			},
+		},
+		{
+			// based on fixedbugs/issue19246.go
+			// see: https://github.com/golang/go/issues/19246
+			name: `pointer dereferenced in function call`,
+			fn: func() {
+				type B struct{}
+				f := func(i any) {}
+				var b *B
+				f(*b) //nolint:nilderef
+			},
+		},
+		{
+			// based on fixedbugs/issue23837.go (1 of 3)
+			name: `unnamed struct comparison`,
+			fn: func() {
+				f := func(p, q *struct{}) bool { return *p == *q }
+				f(nil, nil)
+			},
+		},
+		{
+			// based on fixedbugs/issue23837.go (2 of 3)
+			name: `named struct comparison`,
+			fn: func() {
+				type T struct {
+					x struct{}
+					y int
+				}
+				g := func(p, q *T) bool { return *p == *q }
+				g(nil, nil)
+			},
+		},
+		{
+			// based on fixedbugs/issue23837.go (3 of 3)
+			name: `calling nil functions`,
+			fn: func() {
+				h := func(p, q func() struct{}) bool { return p() == q() }
+				h(nil, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := func() (r any) {
+				defer func() { r = recover() }()
+				test.fn()
+				return
+			}()
+
+			want := `runtime error: invalid memory address or nil pointer dereference`
+			if got := fmt.Sprint(r); got != want {
+				t.Errorf("expected a panic for reading a field from a nil structure"+
+					"\n\twant: %v\n\tgot:  %v", want, got)
+			}
+		})
 	}
 }
 

--- a/tests/testdata/jsSourceMap/main.out
+++ b/tests/testdata/jsSourceMap/main.out
@@ -1,4 +1,4 @@
 doJSThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.inc.js:4)
 helper.DoGoThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.go:6)
 main.main	(gopherjs/tests/testdata/jsSourceMap/main.go:12)
-$goroutine	(gopherjs/compiler/prelude/goroutines.js:134)
+$goroutine	(gopherjs/compiler/prelude/goroutines.js:137)


### PR DESCRIPTION
Changes:
- Fixes the issue https://github.com/gopherjs/gopherjs/issues/843 about nil casts
- Fixes several places where a nil dereference should panic
- Adds the go1.21 update for `panic(nil)` to return [`PanicNilError`](https://pkg.go.dev/runtime#PanicNilError) from recover. (This does not add the disable using `GODEBUG=panicnil=1` since I wasn't sure if we wanted to support that nor how to work that into the prelude smoothly without simply adding a flag that gets set in JS to skip the `if (value === $ifaceNil) {` statement.)
- Several of the gorepo tests got fixed with this change so I updated the knownFails for gorepo
- The change to `goroutine` offset the expected result in the jsSourceMap test, so I updated that too
- Lastly, I realized that tests for `internal/abi` weren't being run so I fixed that (even though that isn't directly related to nil aware things).

I tried to think of all the different ways through the expressions part of the compiler that would need a nil check, but if anyone notices any that I missed, we definitely should add them to the tests and fix them too.

CI will still fail since this is part of the go1.21 integration work.
Related to https://github.com/gopherjs/gopherjs/issues/1415