### PR TITLE
[go1.21] Setting testing.Testing to true when testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
   gopherjs_tests:
     name: GopherJS Tests (${{ matrix.filter.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /node-syscall/build
 /node_modules
+
+# Folders and files used by AI agents
+.agents/
+.cursor/
+AGENTS.md

--- a/build/build.go
+++ b/build/build.go
@@ -158,8 +158,6 @@ type overrideInfo struct {
 // Standard Go library packages are augmented with files in compiler/natives folder.
 // If isTest is true and pkg.ImportPath has no _test suffix, package is built for running internal tests.
 // If isTest is true and pkg.ImportPath has _test suffix, package is built for running external tests.
-// If isTestBuild is true, the build is producing a test (`gopherjs test`).
-// Otherwise the build is producing a library or command (runs `main()`) project.
 //
 // The native packages are augmented by the contents of natives.FS in the following way.
 // The file names do not matter except the usual `_test` suffix. The files for
@@ -185,12 +183,8 @@ type overrideInfo struct {
 //   - New identifiers that don't exist in original package get added.
 //     Use `gopherjs:new` to ensure that the identifier is new and there was
 //     no original code for it.
-func parseAndAugment(xctx XContext, pkg *PackageData, isTest, isTestBuild bool, fileSet *token.FileSet) ([]*ast.File, []incjs.File, error) {
+func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *token.FileSet) ([]*ast.File, []incjs.File, error) {
 	jsFiles, overlayFiles := parseOverlayFiles(xctx, pkg, isTest, fileSet)
-
-	if isTestBuild && pkg.ImportPath == `testing` {
-		overlayFiles = append(overlayFiles, getTestingInitFile(pkg, fileSet))
-	}
 
 	originalFiles, err := parserOriginalFiles(pkg, fileSet)
 	if err != nil {
@@ -264,32 +258,6 @@ func parseOverlayFiles(xctx XContext, pkg *PackageData, isTest bool, fileSet *to
 		files = append(files, file)
 	}
 	return jsFiles, files
-}
-
-// getTestingInitFile gets file to inject into the `testing` package when
-// GopherJS is building for a test (i.e. `gopherjs test`).
-//
-// The file adds an init to set `testing.testBinary` to "1" during the testing
-// package's own init phase, before any importing package's variable initializers
-// run. This is what makes `testing.Testing()` (added in Go 1.21) return true
-// from inside of test and false when running a project with from a main method.
-//
-// Go sets `testing.testBinary` by passing `-X testing.testBinary=1` to cmd/link
-// in `go test`. GopherJS does not implement the `-X` flag, so we inject this
-// init function instead.
-//
-// TODO(grantnelson-wf): If/when the build/cache is re-enabled, the cache key
-// for the `testing` package will need to incorporate the `isTestBuild` signal
-// so a cached non-test variant is not reused for a test build and vice versa.
-func getTestingInitFile(pkg *PackageData, fileSet *token.FileSet) *ast.File {
-	const source = "package testing\n\nfunc init() { testBinary = \"1\" }\n"
-	const filename = `gopherjs__testing_init.go`
-	filePath := path.Join(pkg.Dir, filename)
-	file, err := parser.ParseFile(fileSet, filePath, source, parser.ParseComments)
-	if err != nil {
-		panic(fmt.Errorf("failed to parse synthetic testing init overlay: %w", err))
-	}
-	return file
 }
 
 // parserOriginalFiles loads and parses the original files to augment.
@@ -963,6 +931,18 @@ func (s *Session) GoRelease() string {
 	return compiler.GoRelease(s.xctx.Env().GOROOT)
 }
 
+// TestBinary returns the testBinary value that is normally passed into
+// cmd/link by a -X option. The testBinary value is defined in the STL at
+// testing/testing.go for the `testing.Testing() bool` function.
+// It is set to "1" if the binary (the JS output in our case) is built
+// with "go test" and "0" otherwise.
+func (s *Session) TestBinary() string {
+	if s.options.TestedPackage != `` {
+		return `1`
+	}
+	return `0`
+}
+
 // BuildFiles passed to the GopherJS tool as if they were a package.
 //
 // A ephemeral package will be created with only the provided files. This
@@ -1246,8 +1226,7 @@ func (s *Session) LoadPackages(pkg *PackageData) (*sources.Sources, error) {
 	// by parsing and augmenting the original files with overlay files.
 	if srcs == nil {
 		fileSet := token.NewFileSet()
-		isTestBuild := s.options.TestedPackage != ``
-		files, overlayJsFiles, err := parseAndAugment(s.xctx, pkg, pkg.IsTest, isTestBuild, fileSet)
+		files, overlayJsFiles, err := parseAndAugment(s.xctx, pkg, pkg.IsTest, fileSet)
 		if err != nil {
 			return nil, err
 		}
@@ -1433,7 +1412,7 @@ func (s *Session) WriteCommandPackage(archive *compiler.Archive, pkgObj string) 
 	if err != nil {
 		return err
 	}
-	return compiler.WriteProgramCode(deps, sourceMapFilter, s.GoRelease())
+	return compiler.WriteProgramCode(deps, sourceMapFilter, s.GoRelease(), s.TestBinary())
 }
 
 // WaitForChange watches file system events and returns if either when one of

--- a/build/build.go
+++ b/build/build.go
@@ -158,6 +158,8 @@ type overrideInfo struct {
 // Standard Go library packages are augmented with files in compiler/natives folder.
 // If isTest is true and pkg.ImportPath has no _test suffix, package is built for running internal tests.
 // If isTest is true and pkg.ImportPath has _test suffix, package is built for running external tests.
+// If isTestBuild is true, the build is producing a test (`gopherjs test`).
+// Otherwise the build is producing a library or command (runs `main()`) project.
 //
 // The native packages are augmented by the contents of natives.FS in the following way.
 // The file names do not matter except the usual `_test` suffix. The files for
@@ -183,8 +185,12 @@ type overrideInfo struct {
 //   - New identifiers that don't exist in original package get added.
 //     Use `gopherjs:new` to ensure that the identifier is new and there was
 //     no original code for it.
-func parseAndAugment(xctx XContext, pkg *PackageData, isTest bool, fileSet *token.FileSet) ([]*ast.File, []incjs.File, error) {
+func parseAndAugment(xctx XContext, pkg *PackageData, isTest, isTestBuild bool, fileSet *token.FileSet) ([]*ast.File, []incjs.File, error) {
 	jsFiles, overlayFiles := parseOverlayFiles(xctx, pkg, isTest, fileSet)
+
+	if isTestBuild && pkg.ImportPath == `testing` {
+		overlayFiles = append(overlayFiles, getTestingInitFile(pkg, fileSet))
+	}
 
 	originalFiles, err := parserOriginalFiles(pkg, fileSet)
 	if err != nil {
@@ -258,6 +264,32 @@ func parseOverlayFiles(xctx XContext, pkg *PackageData, isTest bool, fileSet *to
 		files = append(files, file)
 	}
 	return jsFiles, files
+}
+
+// getTestingInitFile gets file to inject into the `testing` package when
+// GopherJS is building for a test (i.e. `gopherjs test`).
+//
+// The file adds an init to set `testing.testBinary` to "1" during the testing
+// package's own init phase, before any importing package's variable initializers
+// run. This is what makes `testing.Testing()` (added in Go 1.21) return true
+// from inside of test and false when running a project with from a main method.
+//
+// Go sets `testing.testBinary` by passing `-X testing.testBinary=1` to cmd/link
+// in `go test`. GopherJS does not implement the `-X` flag, so we inject this
+// init function instead.
+//
+// TODO(grantnelson-wf): If/when the build/cache is re-enabled, the cache key
+// for the `testing` package will need to incorporate the `isTestBuild` signal
+// so a cached non-test variant is not reused for a test build and vice versa.
+func getTestingInitFile(pkg *PackageData, fileSet *token.FileSet) *ast.File {
+	const source = "package testing\n\nfunc init() { testBinary = \"1\" }\n"
+	const filename = `gopherjs__testing_init.go`
+	filePath := path.Join(pkg.Dir, filename)
+	file, err := parser.ParseFile(fileSet, filePath, source, parser.ParseComments)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse synthetic testing init overlay: %w", err))
+	}
+	return file
 }
 
 // parserOriginalFiles loads and parses the original files to augment.
@@ -1214,7 +1246,8 @@ func (s *Session) LoadPackages(pkg *PackageData) (*sources.Sources, error) {
 	// by parsing and augmenting the original files with overlay files.
 	if srcs == nil {
 		fileSet := token.NewFileSet()
-		files, overlayJsFiles, err := parseAndAugment(s.xctx, pkg, pkg.IsTest, fileSet)
+		isTestBuild := s.options.TestedPackage != ``
+		files, overlayJsFiles, err := parseAndAugment(s.xctx, pkg, pkg.IsTest, isTestBuild, fileSet)
 		if err != nil {
 			return nil, err
 		}

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -92,7 +92,7 @@ func TestNativesDontImportExtraPackages(t *testing.T) {
 
 				// Use parseAndAugment to get a list of augmented AST files.
 				fset := token.NewFileSet()
-				files, _, err := parseAndAugment(stdOnly, pkgVariant, pkgVariant.IsTest, false, fset)
+				files, _, err := parseAndAugment(stdOnly, pkgVariant, pkgVariant.IsTest, fset)
 				if err != nil {
 					t.Fatalf("github.com/gopherjs/gopherjs/build.parseAndAugment: %v", err)
 				}

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -92,7 +92,7 @@ func TestNativesDontImportExtraPackages(t *testing.T) {
 
 				// Use parseAndAugment to get a list of augmented AST files.
 				fset := token.NewFileSet()
-				files, _, err := parseAndAugment(stdOnly, pkgVariant, pkgVariant.IsTest, fset)
+				files, _, err := parseAndAugment(stdOnly, pkgVariant, pkgVariant.IsTest, false, fset)
 				if err != nil {
 					t.Fatalf("github.com/gopherjs/gopherjs/build.parseAndAugment: %v", err)
 				}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -128,7 +128,7 @@ func DefaultFilter(w io.Writer) *sourcemapx.Filter {
 	return &sourcemapx.Filter{Writer: w}
 }
 
-func WriteProgramCode(pkgs []*Archive, w *sourcemapx.Filter, goVersion string) error {
+func WriteProgramCode(pkgs []*Archive, w *sourcemapx.Filter, goVersion, testBinary string) error {
 	mainPkg := pkgs[len(pkgs)-1]
 	minify := mainPkg.Minified
 
@@ -158,6 +158,9 @@ func WriteProgramCode(pkgs []*Archive, w *sourcemapx.Filter, goVersion string) e
 		return err
 	}
 	if _, err := writeF(w, false, "var $goVersion = %q;\n", goVersion); err != nil {
+		return err
+	}
+	if _, err := writeF(w, false, "var $testBinary = %q;\n", testBinary); err != nil {
 		return err
 	}
 	for _, preludeFile := range prelude.PreludeFiles() {

--- a/compiler/natives/src/testing/testing.go
+++ b/compiler/natives/src/testing/testing.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package testing
+
+import "github.com/gopherjs/gopherjs/js"
+
+func init() {
+	testBinary = js.Global.Get("$testBinary").String()
+}

--- a/tool.go
+++ b/tool.go
@@ -717,7 +717,7 @@ func (fs serveCommandFileSystem) Open(requestName string) (http.File, error) {
 						Error(`Failed to import dependencies`)
 					return err
 				}
-				if err := compiler.WriteProgramCode(deps, sourceMapFilter, s.GoRelease()); err != nil {
+				if err := compiler.WriteProgramCode(deps, sourceMapFilter, s.GoRelease(), s.TestBinary()); err != nil {
 					log.WithField(`request`, requestName).
 						WithField(`package`, pkg.ImportPath).
 						WithError(err).


### PR DESCRIPTION
Go1.21 added [`testing.Testing`](https://pkg.go.dev/testing#Testing) that returns true if the code was built with `go build`. To make this work for `gopherjs build` I added a native overlay that is hardcoded in `build/build.go` that will be added into the overlay files when building the `testing` package iff the program is being built for a test.

I also bumped timeout-minutes to 45 mins since 30 mins sometimes failed when other stuff was failing and I'd rather see all the failures not just a few.

I also added a gitignore for the AI agent files that the AI agent I'm using wrote. If we want to add agent files in we can always remove these ignores, I just didn't want to flood our repo with a bunch of files.

related to https://github.com/gopherjs/gopherjs/issues/1415