### PR TITLE
[go1.21] Updating more native overrides for go1.21

### DIFF
--- a/compiler/natives/src/crypto/tls/handshake_test.go
+++ b/compiler/natives/src/crypto/tls/handshake_test.go
@@ -10,7 +10,7 @@ import (
 
 // Same as upstream, except we check for GOARCH=ecmascript instead of wasm.
 // This override can be removed after https://github.com/golang/go/pull/51827
-// is available in the upstream (likely after Go 1.19).
+// is available in the upstream (likely in Go 1.25).
 func TestServerHandshakeContextCancellation(t *testing.T) {
 	c, s := localPipe(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -42,7 +42,7 @@ func TestServerHandshakeContextCancellation(t *testing.T) {
 
 // Same as upstream, except we check for GOARCH=ecmascript instead of wasm.
 // This override can be removed after https://github.com/golang/go/pull/51827
-// is available in the upstream (likely after Go 1.19).
+// is available in the upstream (likely in Go 1.25).
 func TestClientHandshakeContextCancellation(t *testing.T) {
 	c, s := localPipe(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -72,14 +72,23 @@ func TestClientHandshakeContextCancellation(t *testing.T) {
 	}
 }
 
+//gopherjs:replace
 func TestVerifyConnection(t *testing.T) {
-	// This should be rechecked after upgrading to Go 1.20 or later.
-	// go1.19.13/src/crypto/tls/handshake_test.go:testRSACertificateIssuer has expired.
+	// This should be rechecked after upgrading to Go 1.24 or later.
+	// go1.21.13/src/crypto/tls/handshake_test.go:testRSACertificate has expired.
 	t.Skip("Skipping test that uses predefined certificate that expired in Jan 1st 2025")
 }
 
+//gopherjs:replace
 func TestResumptionKeepsOCSPAndSCT(t *testing.T) {
-	// This should be rechecked after upgrading to Go 1.20 or later.
-	// go1.19.13/src/crypto/tls/handshake_test.go:testRSACertificateIssuer has expired.
+	// This should be rechecked after upgrading to Go 1.24 or later.
+	// go1.21.13/src/crypto/tls/handshake_test.go:testRSACertificate has expired.
+	t.Skip("Skipping test that uses predefined certificate that expired in Jan 1st 2025")
+}
+
+//gopherjs:replace
+func TestCrossVersionResume(t *testing.T) {
+	// This should be rechecked after upgrading to Go 1.24 or later.
+	// go1.21.13/src/crypto/tls/handshake_test.go:testRSACertificate has expired.
 	t.Skip("Skipping test that uses predefined certificate that expired in Jan 1st 2025")
 }

--- a/compiler/natives/src/log/slog/logger_test.go
+++ b/compiler/natives/src/log/slog/logger_test.go
@@ -1,0 +1,10 @@
+//go:build js
+
+package slog
+
+import "testing"
+
+//gopherjs:replace
+func TestAlloc(t *testing.T) {
+	t.Skip("testing.AllocsPerRun not supported in GopherJS")
+}

--- a/compiler/natives/src/runtime/metrics/description_test.go
+++ b/compiler/natives/src/runtime/metrics/description_test.go
@@ -1,0 +1,17 @@
+//go:build js
+
+package metrics_test
+
+import "testing"
+
+// GopherJS does not record any runtime metrics. The original test calls
+// `runtime_readMetricNames“ (a `//go:linkname` forward declaration that
+// resolves to `runtime.readMetricNames` in Go), which is not implemented
+// in GopherJS's runtime and would panic with "native function not implemented".
+// `runtime_readMetricNames` is only called by TestNames so doesn't need to
+// be overridden.
+//
+//gopherjs:replace
+func TestNames(t *testing.T) {
+	t.Skip("runtime metrics are not supported by GopherJS")
+}

--- a/compiler/natives/src/syscall/js/js_test.go
+++ b/compiler/natives/src/syscall/js/js_test.go
@@ -16,3 +16,15 @@ func TestIntConversion(t *testing.T) {
 func TestGarbageCollection(t *testing.T) {
 	t.Skip("GC is not supported by GopherJS")
 }
+
+// GopherJS does not currently support the //go:wasmimport directive
+// (see https://go.dev/blog/wasi and https://github.com/golang/go/issues/59149).
+// Functions declared with //go:wasmimport compile to "native function not
+// implemented" runtime stubs, which panic and crash the Node process before
+// the testing framework can recover. Skip the affected tests until proper
+// support is added; they cannot be overridden without defeating the test.
+//
+//gopherjs:replace
+func TestWasmImport(t *testing.T) {
+	t.Skip("//go:wasmimport is not supported by GopherJS")
+}


### PR DESCRIPTION
Adding some more native overrides for things we can't handle or fix at the moment.

Related to https://github.com/gopherjs/gopherjs/issues/1415