### PR TITLE
[go1.21] Updating slices and maps for go1.21

### DIFF
--- a/compiler/natives/src/maps/maps.go
+++ b/compiler/natives/src/maps/maps.go
@@ -1,0 +1,23 @@
+//go:build js
+
+package maps
+
+// Clone returns a copy of m.  This is a shallow clone:
+// the new keys and values are set using ordinary assignment.
+//
+//gopherjs:replace
+func Clone[M ~map[K]V, K comparable, V any](m M) M {
+	if m == nil {
+		return nil
+	}
+
+	// A simple Go copy version of clone may be slower for large maps
+	// and faster for small maps than using the JS Map constructor to create
+	// a copy. However, the Go copy ensures that we don't run into a
+	// potentical issue with JS objects not being properly copied during clone.
+	mcopy := make(M, len(m))
+	for k, v := range m {
+		mcopy[k] = v
+	}
+	return mcopy
+}

--- a/compiler/natives/src/slices/slices.go
+++ b/compiler/natives/src/slices/slices.go
@@ -1,0 +1,14 @@
+//go:build js
+
+package slices
+
+import "github.com/gopherjs/gopherjs/js"
+
+//gopherjs:replace
+func overlaps[E any](a, b []E) bool {
+	// GopherJS: We can't rely on pointer arithmetic, so use GopherJS slice internals.
+	return len(a) > 0 && len(b) > 0 &&
+		js.InternalObject(a).Get("$array") == js.InternalObject(b).Get("$array") &&
+		js.InternalObject(a).Get("$offset").Int() <= js.InternalObject(b).Get("$offset").Int()+len(b)-1 &&
+		js.InternalObject(b).Get("$offset").Int() <= js.InternalObject(a).Get("$offset").Int()+len(a)-1
+}

--- a/compiler/prelude/prelude.js
+++ b/compiler/prelude/prelude.js
@@ -236,7 +236,7 @@ var $convertSliceType = (slice, desiredType) => {
         return desiredType.nil; // Preserve nil value.
     }
 
-    return $subslice(new desiredType(slice.$array), slice.$offset, slice.$offset + slice.$length);
+    return $subslice(new desiredType(slice.$array), slice.$offset, slice.$offset + slice.$length, slice.$offset + slice.$capacity);
 }
 
 var $decodeRune = (str, pos) => {
@@ -644,6 +644,22 @@ var $unsafeSlice = (ptr, len, typ, methodName = "Slice") => {
             $throwRuntimeError("unsafe."+methodName+": ptr is nil and len is not zero");
         }
         return typ.nil;
+    }
+    if (len === 0) {
+        var s = new typ(ptr.$target);
+        s.$offset = ptr.$index !== undefined ? ptr.$index : 0;
+        s.$length = 0;
+        s.$capacity = 0;
+        return s;
+    }
+    if (ptr.$index === undefined) {
+        // Go can cast a footprint of memory for some data into an array, but JS can not.
+        // If the $index is undefined then the pointer is for a struct field,
+        // a non-escaping scalar pointer, or something else, but not an array or slice.
+        $throwRuntimeError("unsafe." + methodName + ": pointer does not address a slice or array element (missing index)");
+    }
+    if (ptr.$target.buffer && ptr.$target.BYTES_PER_ELEMENT && ptr.$target.constructor !== $nativeArray(typ.elem.kind)) {
+        $throwRuntimeError("unsafe." + methodName + ": pointer does not match slice element storage layout");
     }
     if (ptr.$index + len > ptr.$target.length) {
         // Go can grab abritraty footprints of memory, JS can not. Instead of trying

--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -155,7 +155,7 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                         if (src.$length < dst.length) {
                             $throwRuntimeError("cannot convert slice with length "+src.$length+" to array or pointer to array with length "+dst.length);
                         }
-                        $copyArray(dst, src.$array, 0, 0, dst.length, elem);
+                        $copyArray(dst, src.$array, 0, src.$offset, dst.length, elem);
                     } else {
                         // copy from another array
                         $copyArray(dst, src, 0, 0, src.length, elem);

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -1295,6 +1295,9 @@ func TestPointerToSliceIndex64(t *testing.T) {
 	// of the structure. Since int64 and uint64 are stored as an object with a
 	// high/low value, we should use `%f` when creating the pattern for the
 	// expression to ensure they are flattened into a num.
+	// This does mean we are limited to 53 bit JS indices which is fine since
+	// JS's Array will error with a RangeError if the length goes over 32 bits.
+	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length
 	type symbol struct {
 		name  string
 		value int

--- a/tests/slice_test.go
+++ b/tests/slice_test.go
@@ -62,3 +62,24 @@ func Test_UnsafeSlice(t *testing.T) {
 		t.Errorf("Got: %v after unsafe slice, Want: %v", a, want)
 	}
 }
+
+func Test_OffsetSliceToArray(t *testing.T) {
+	s := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	s2 := s[2:6]
+	if want := []byte{3, 4, 5, 6}; !reflect.DeepEqual(s2, want) {
+		t.Errorf("Got: %v after getting sub-slice, Want: %v", s2, want)
+	}
+
+	// Originally there was an issue where this cast would clone the underlying array
+	// from s2 and copy it without the offset so the result would be `[4]byte{1, 2, 3, 4}`
+	// instead of the correct offset values.
+	a := [4]byte(s2)
+	if want := [4]byte{3, 4, 5, 6}; !reflect.DeepEqual(a, want) {
+		t.Errorf("Got: %v after casting to array, Want: %v", a, want)
+	}
+
+	s2[1] = 42
+	if want, got := byte(4), a[1]; want != got {
+		t.Errorf("Got: %v after casting to array, Want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Adding updates to slices and maps for go1.21.

This includes the request to add a comment about limiting indices to exclude int64/uint64 as discussed in https://github.com/gopherjs/gopherjs/pull/1434#discussion_r3156986721

Related to [go1.21](https://github.com/gopherjs/gopherjs/issues/1415)