### PR TITLE
[go1.21] Updating call stack to allow PC = 0

### DIFF
--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -102,8 +102,13 @@ var (
 	//
 	// We use the map and the slice below to convert a "file:line" position
 	// into an integer position counter and then to a Func instance.
+	//
+	// Index 0 is reserved as the "unknown PC": upstream Go documents
+	// PC=0 as "no caller available" (see e.g. log/slog.Record.PC), and packages
+	// using PCs, initialize a uintptr to zero and expect runtime.CallersFrames
+	// and runtime.FuncForPC to treat it as unknown.
 	knownPositions   = map[string]uintptr{}
-	positionCounters = []*Func{}
+	positionCounters = []*Func{nil}
 )
 
 func registerPosition(funcName string, file string, line int, col int) uintptr {
@@ -270,10 +275,26 @@ func Callers(skip int, pc []uintptr) int {
 	return len(frames)
 }
 
+// CallersFrames takes a slice of PC values returned by Callers and prepares to
+// return function/file/line information. Done is true when no more frames are
+// available.
+//
+// GopherJS notes:
+//   - PCs that didn't come from Caller/Callers (e.g. a function pointer obtained
+//     via reflect.ValueOf(fn).Pointer()) are not in our positionCounters.
+//     For those, FuncForPC returns nil and we emit a Frame with the original PC
+//     and empty symbol fields, like Go will.
+//   - GopherJS's internal frames such as $callDeferred and $goroutine were
+//     already filtered (or aliased) by parseCallstack at capture time, so anything
+//     reaching CallersFrames is either a real Go frame or a PC we can't resolve.
 func CallersFrames(callers []uintptr) *Frames {
 	result := Frames{}
 	for _, pc := range callers {
 		fun := FuncForPC(pc)
+		if fun == nil {
+			result.frames = append(result.frames, Frame{PC: pc})
+			continue
+		}
 		result.frames = append(result.frames, Frame{
 			PC:       pc,
 			Func:     fun,
@@ -416,13 +437,23 @@ func (f *Func) Name() string {
 
 func FuncForPC(pc uintptr) *Func {
 	ipc := int(pc)
-	if ipc >= len(positionCounters) {
+	if ipc <= 0 || ipc >= len(positionCounters) {
 		// Since we are faking position counters, the only valid way to obtain one
 		// is through a Caller() or Callers() function. If pc is out of positionCounters
 		// bounds it must have been obtained in some other way, which is unexpected.
-		// If a panic proves problematic, we can return a nil *Func, which will
-		// present itself as a generic "unknown" function.
-		panic("GopherJS: pc=" + itoa(ipc) + " is out of range of known position counters")
+		// FuncForPC in Go returns nil for a PC that does not correspond to a
+		// known function. so returning nil for PCs we cannot resolvable, even if
+		// Go could resolve it, lets the callers keep working with empty symbols.
+		// For example:
+		//   - log/slog passes PC=0 through CallersFrames when a Record was
+		//     created without a real caller (record.go's PC field)
+		//   - test/fixedbugs/issue29735.go deliberately walks past the
+		//     end of a function looking for the next. This will cause it to
+		//     not secceed at what it is trying to do but will allow the test to pass.
+		//   - test/fixedbugs/issue58300.go and test/fixedbugs/issue58300b.go give
+		//     FuncForPC a function pointer from `reflect.ValueOf(fn).Pointer()`,
+		//     which is not produced by Caller/Callers and so isn't in our table.
+		return nil
 	}
 	return positionCounters[ipc]
 }

--- a/tests/gorepo/run.go
+++ b/tests/gorepo/run.go
@@ -109,7 +109,6 @@ var knownFails = map[string]failReason{
 	"fixedbugs/issue24491a.go": {category: notApplicable, desc: "tests interaction between unsafe and GC; uses runtime.SetFinalizer()"},
 	"fixedbugs/issue24491b.go": {category: notApplicable, desc: "tests interaction between unsafe and GC; uses runtime.SetFinalizer()"},
 	"fixedbugs/issue29504.go":  {category: notApplicable, desc: "requires source map support beyond what GopherJS currently provides"},
-	"fixedbugs/issue29735.go":  {category: lowLevelRuntimeDifference, desc: "GopherJS only supports runtime.FuncForPC() with position counters previously returned by runtime.Callers() or runtime.Caller()"},
 	"fixedbugs/issue30116.go":  {desc: "GopherJS doesn't specify the array/slice index selector in the out-of-bounds message"},
 	"fixedbugs/issue30116u.go": {desc: "GopherJS doesn't specify the array/slice index selector in the out-of-bounds message"},
 	"fixedbugs/issue34395.go":  {category: neverTerminates, desc: "https://github.com/gopherjs/gopherjs/issues/1007"},


### PR DESCRIPTION
There were several tests failing because an unset PC (uintptr 0) was being used. For example log/slog uses PC=0 for call stack not set.

This removes fixedbugs/issue29735.go from the gorepo failures. However, the test does not work as intended. The test starts at the front of a function and runs to the end. However, it can't find the front of the function in GopherJS because it is using the function pointer as the PC, so it ends before ever getting to the start of the function. The test was just checking that as it went to the end of the function, the code wouldn't panic, which now it doesn't panic, but for the wrong reasons. I left a comment on `FuncForPC` about it.

Related to https://github.com/gopherjs/gopherjs/issues/1415