### PR TITLE
[go1.21] Fixing proxy conversion issue

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -1371,7 +1371,7 @@ func (fc *funcContext) translateImplicitConversion(expr ast.Expr, desiredType ty
 		return fc.formatExpr("%e", fc.zeroValue(desiredType))
 	}
 
-	switch desiredType.Underlying().(type) {
+	switch dt := desiredType.Underlying().(type) {
 	case *types.Slice:
 		return fc.formatExpr("$convertSliceType(%1e, %2s)", expr, fc.typeName(desiredType))
 
@@ -1385,6 +1385,18 @@ func (fc *funcContext) translateImplicitConversion(expr ast.Expr, desiredType ty
 		}
 		if _, isStruct := exprType.Underlying().(*types.Struct); isStruct {
 			return fc.formatExpr("new %1e.constructor.elem(%1e)", expr)
+		}
+
+	case *types.Pointer:
+		// Implicit conversion between named pointer-to-struct types or between
+		// one named pointer-to-struct type and an unnamed pointer-to-struct type
+		// needs the same proxy/unwrap that explicit conversions get so that
+		// the JS object has the methods for the type assigned to it and
+		// not just the JS prototype. See tests/testdata/proxyMethod/main.go
+		if _, isStruct := dt.Elem().Underlying().(*types.Struct); isStruct {
+			if sPtr, ok := exprType.Underlying().(*types.Pointer); ok && types.Identical(sPtr.Elem(), dt.Elem()) {
+				return fc.formatExpr("$pointerOfStructConversion(%e, %s)", expr, fc.typeName(desiredType))
+			}
 		}
 	}
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -13,3 +13,8 @@ func Test_JSSourceMap_Unminified(t *testing.T) { runOutputTest(t, `testdata`, `j
 // Test_JSSourceMap_Minified uses testdata/jsSourceMap/main.go
 // to test that the source map generated for the JS code is correct on minified output.
 func Test_JSSourceMap_Minified(t *testing.T) { runOutputTest(t, `testdata`, `jsSourceMap`, `-m`) }
+
+// Test_ProxyMethod uses testdata/proxyMethod/main.go
+// to test that a structure pointer cast into and out of a proxy can still have
+// its methods called on it.
+func Test_ProxyMethod(t *testing.T) { runOutputTest(t, `testdata`, `proxyMethod`) }

--- a/tests/testdata/proxyMethod/main.go
+++ b/tests/testdata/proxyMethod/main.go
@@ -1,0 +1,22 @@
+// This tests an issue where a pointer to a structure is cast into
+// and out of a proxy causing the resulting pointer to not contain the
+// methods that were on the pointer structure originally.
+package main
+
+type Cat struct{ name string }
+
+func (c *Cat) getName() string { return c.name }
+
+type CatPtr *Cat
+
+func sayHello(c *Cat) { println(`hello ` + c.getName()) }
+
+func main() {
+	a := &Cat{name: `mittens`}
+
+	b := CatPtr(a) // `b` can not call `getName()` because "b.getName undefined (type CatPtr has no field or method getName)"
+	sayHello(b)    // implicit cast of `b` to `*Cat` so it can call `getName()`.
+
+	c := (*Cat)(b) // explicit cast of `b` to `*Cat` so it can also call `getName()`.
+	println(c.getName() + ` says meow`)
+}

--- a/tests/testdata/proxyMethod/main.out
+++ b/tests/testdata/proxyMethod/main.out
@@ -1,0 +1,2 @@
+hello mittens
+mittens says meow


### PR DESCRIPTION
There was an issue in log/slog when reading a method on `time.Location`. Specifically the test `TestJSONAndTextHandlers` hit "TypeError: l.lookup is not a function".
I added a simplified test to reproduce the issue and track down the issue. The problem was in casting types to a proxy type that doesn't have methods copied on it, then implicit casting back before calling a function.

The tests in this PR may cause a merge conflict with the tests in https://github.com/gopherjs/gopherjs/pull/1440

Related to https://github.com/gopherjs/gopherjs/issues/1415