### PR TITLE
[go1.21] Pull master into go1.21

### DIFF
--- a/compiler/functions.go
+++ b/compiler/functions.go
@@ -38,6 +38,7 @@ func (fc *funcContext) nestedFunctionContext(info *analysis.FuncInfo, inst typep
 		parent:       fc,
 		allVars:      make(map[string]int, len(fc.allVars)),
 		localVars:    []string{},
+		varPtrNames:  make(map[*types.Var]string),
 		flowDatas:    map[*types.Label]*flowData{nil: {}},
 		caseCounter:  1,
 		labelCases:   make(map[*types.Label]int),

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -30,7 +30,10 @@ type pkgContext struct {
 	typeNames typesutil.TypeNames
 	// Mapping from package import paths to JS variables that were assigned to an
 	// imported package and can be used to access it.
-	pkgVars      map[string]string
+	pkgVars map[string]string
+	// varPtrNames is for unexported package-level pointer var names only.
+	// Exported package-level names are always the full name from the Var.
+	// Function-level pointer var names are stored in the funcContext.varPtrNames.
 	varPtrNames  map[*types.Var]string
 	anonTypes    []*types.TypeName
 	anonTypeMap  typeutil.Map
@@ -84,6 +87,9 @@ type funcContext struct {
 	// auxiliary variables the compiler needs. It is used to generate `var`
 	// declaration at the top of the function, as well as context save/restore.
 	localVars []string
+	// varPtrNames are very similar to the package level pkgContext.varPtrNames
+	// except contains pointer var names that are local to within this function context.
+	varPtrNames map[*types.Var]string
 	// AST expressions representing function's named return values. nil if the
 	// function has no return values or they are not named.
 	resultNames []ast.Expr
@@ -134,6 +140,7 @@ func newRootCtx(tContext *types.Context, srcs *sources.Sources, minify bool) *fu
 			instanceSet:  srcs.TypeInfo.InstanceSets,
 		},
 		allVars:     make(map[string]int),
+		varPtrNames: make(map[*types.Var]string),
 		flowDatas:   map[*types.Label]*flowData{nil: {}},
 		caseCounter: 1,
 		labelCases:  make(map[*types.Label]int),

--- a/compiler/utils.go
+++ b/compiler/utils.go
@@ -488,34 +488,29 @@ func (fc *funcContext) methodName(fun *types.Func) string {
 }
 
 func (fc *funcContext) varPtrName(o *types.Var) string {
-	if isPkgLevel(o) && o.Exported() {
-		return fc.pkgVar(o.Pkg()) + "." + o.Name() + "$ptr"
-	}
+	if isPkgLevel(o) {
+		if o.Exported() {
+			return fc.pkgVar(o.Pkg()) + "." + o.Name() + "$ptr"
+		}
 
-	name, ok := fc.pkgCtx.varPtrNames[o]
-	if !ok {
-		name = fc.newVariable(o.Name()+"$ptr", isPkgLevel(o))
-		fc.pkgCtx.varPtrNames[o] = name
+		// Unexported package-level pointer types must share a name
+		// so use the package level varPtrNames.
+		name, ok := fc.pkgCtx.varPtrNames[o]
+		if !ok {
+			name = fc.newVariable(o.Name()+"$ptr", true)
+			fc.pkgCtx.varPtrNames[o] = name
+		}
 		return name
 	}
 
-	// If name already exists for the package, check that the function's instantiation
-	// also has the name in its localVars. This is to handle generics where `o` is
-	// shared among multiple instantiations of the same generic, but `newVariable`
-	// is only called for the first.
-	if !fc.instance.IsTrivial() && !containsString(fc.localVars, name) {
-		fc.localVars = append(fc.localVars, name)
+	// Local pointer types are in a function context scope and not shared
+	// across functions so use the function level varPtrNames.
+	name, ok := fc.varPtrNames[o]
+	if !ok {
+		name = fc.newVariable(o.Name()+"$ptr", false)
+		fc.varPtrNames[o] = name
 	}
 	return name
-}
-
-func containsString(s []string, v string) bool {
-	for i := len(s) - 1; i >= 0; i-- {
-		if v == s[i] {
-			return true
-		}
-	}
-	return false
 }
 
 // typeName returns a JS identifier name for the given Go type.

--- a/node-syscall/package-lock.json
+++ b/node-syscall/package-lock.json
@@ -393,13 +393,10 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -421,11 +418,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -774,11 +766,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -798,11 +791,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/ssri": {
       "version": "8.0.1",

--- a/tests/gencircle_test.go
+++ b/tests/gencircle_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"embed"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,20 +49,26 @@ func runOutputTest(t *testing.T, basePath, testPkg string, extraArgs ...string) 
 	mainPath := filepath.Join(basePath, testPkg, mainFile)
 	args := append([]string{`run`, mainPath}, extraArgs...)
 	gotBytes, err := exec.Command(`gopherjs`, args...).CombinedOutput()
-	got := normalizeOut(gotBytes)
-	if err != nil {
-		if _, ok := err.(*exec.ExitError); !ok {
-			t.Fatalf("unexpected error from exec: %v:\n%s", err, got)
-		}
+	if err != nil && !errors.Is(err, &exec.ExitError{}) {
+		t.Fatalf("unexpected error from exec: %v:\n%s", err, string(gotBytes))
 	}
 
 	outPath := filepath.Join(basePath, testPkg, outFile)
 	wantBytes, err := os.ReadFile(outPath)
 	if err != nil {
-		t.Fatalf(`error reading %s file: %v`, outFile, err)
-	}
-	want := normalizeOut(wantBytes)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf(`error reading %s file: %v`, outFile, err)
+		}
 
+		// Has no output file so check if output was empty
+		if len(gotBytes) > 0 {
+			t.Errorf("Expected no output but got:\n%s", string(gotBytes))
+		}
+		return
+	}
+
+	got := normalizeOut(gotBytes)
+	want := normalizeOut(wantBytes)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Got diff (-want,+got):\n%s", diff)
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -13,3 +13,8 @@ func Test_JSSourceMap_Unminified(t *testing.T) { runOutputTest(t, `testdata`, `j
 // Test_JSSourceMap_Minified uses testdata/jsSourceMap/main.go
 // to test that the source map generated for the JS code is correct on minified output.
 func Test_JSSourceMap_Minified(t *testing.T) { runOutputTest(t, `testdata`, `jsSourceMap`, `-m`) }
+
+// Test_MinifyNaming uses testdata/minifyNaming/main.go
+// to test that the package level type names do not conflict with function level
+// variable names when the code is minified.
+func Test_MinifyNaming(t *testing.T) { runOutputTest(t, `testdata`, `minifyNaming`, `-m`) }

--- a/tests/testdata/minifyNaming/main.go
+++ b/tests/testdata/minifyNaming/main.go
@@ -1,0 +1,36 @@
+// This reproduces a minified-name collision triggered by generics
+// and causes a JS exception like: `TypeError: b.Inc is not a function`
+//
+// This is a simplification of a bug found by the `TestStructSorts`
+// in the `slices` package.
+//
+// The issue was that when determining minified identifiers:
+// The first instantiation of a method has a type pointer added to it `allVars`.
+// The second instantiation hit the cached type pointer so did not add
+// it to `allVars` causing the next local variable to use the same identifier
+// as that type pointer. The duplicate identifiers can then clobber eachother
+// that can lead to trying to call a method for the type pointer on a local
+// variable without that method.
+package main
+
+type rng int64
+
+func (r *rng) Inc() { *r++ }
+
+// For the first instantiation `r`, `&r`, and `extra` get minified to `a`, `b`,
+// and `c` respectively, but for the second instantiation, `extra` gets minified
+// to `b` causing a conflict between `&r` and `extra`.
+//
+//go:noinline
+func shape[T any](_ T) {
+	r := rng(0)
+	r.Inc()
+	extra := 42
+	_ = extra
+	r.Inc() // In second instantiation this fails with `int(42).Inc()`.
+}
+
+func main() {
+	shape[int](0)
+	shape[string](``)
+}


### PR DESCRIPTION
Pulling master branch into go1.21 integration branch to keep go1.21 up-to-date with master

Related to https://github.com/gopherjs/gopherjs/issues/1415