### PR TITLE
[go1.21] updating runtime package and godebug for "panic nil" flag

### DIFF
--- a/compiler/natives/src/internal/godebug/godebug_test.go
+++ b/compiler/natives/src/internal/godebug/godebug_test.go
@@ -1,0 +1,10 @@
+//go:build js
+
+package godebug_test
+
+import "testing"
+
+//gopherjs:replace
+func TestMetrics(t *testing.T) {
+	t.Skip(`This test requires runtime metrics to be implemented. GopherJS does not yet support runtime metrics.`)
+}

--- a/compiler/natives/src/runtime/coverage/coverage.go
+++ b/compiler/natives/src/runtime/coverage/coverage.go
@@ -10,7 +10,7 @@ import "internal/coverage/rtcov"
 // for the coverage instrumentation to write the coverage data into.
 // We don't support runtime coverage yet so instead of implementing
 // our own coverage blobs, we can simply return empty for these.
-// That will cause the callers to beleive no blobs are registered so no
+// That will cause the callers to believe no blobs are registered so no
 // coverage is being collected.
 
 //gopherjs:replace

--- a/compiler/natives/src/runtime/coverage/coverage.go
+++ b/compiler/natives/src/runtime/coverage/coverage.go
@@ -1,0 +1,23 @@
+//go:build js
+
+package coverage
+
+import "internal/coverage/rtcov"
+
+// GOPHERJS: runtime/coverage declares the following three functions as
+// forward declarations with //go:linkname to the runtime package.
+// When building with `-cover`, Go registers blobs via `runtime.addCovMeta`
+// for the coverage instrumentation to write the coverage data into.
+// We don't support runtime coverage yet so instead of implementing
+// our own coverage blobs, we can simply return empty for these.
+// That will cause the callers to beleive no blobs are registered so no
+// coverage is being collected.
+
+//gopherjs:replace
+func getCovMetaList() []rtcov.CovMetaBlob { return nil }
+
+//gopherjs:replace
+func getCovCounterList() []rtcov.CovCounterBlob { return nil }
+
+//gopherjs:replace
+func getCovPkgMap() map[int]int { return nil }

--- a/compiler/natives/src/runtime/metrics/sample.go
+++ b/compiler/natives/src/runtime/metrics/sample.go
@@ -1,0 +1,8 @@
+//go:build js
+
+package metrics
+
+import "unsafe"
+
+//gopherjs:replace No-op since runtime does not define metrics yet.
+func runtime_readMetrics(unsafe.Pointer, int, int) {}

--- a/compiler/natives/src/runtime/runtime.go
+++ b/compiler/natives/src/runtime/runtime.go
@@ -92,6 +92,8 @@ func init() {
 	js.Global.Set("$throwRuntimeError", js.InternalObject(throw))
 	js.Global.Set("$newPanicNilError", js.InternalObject(newPanicNilError))
 	buildVersion = js.Global.Get("$goVersion").String()
+	// Prepare the prelude's $panicnil flag from GODEBUG at startup.
+	syncPanicNilFromGodebug(getEnvString(godebugEnvKey))
 	// avoid dead code elimination
 	var e error
 	e = &TypeAssertionError{}
@@ -557,7 +559,7 @@ func godebug_setUpdate(update func(def, env string)) {
 // src/internal/godebug/godebug.go.
 // GOPHERJS: The GopherJS runtime doesn't need this function so we can remove it.
 //
-//gopherjs:puge
+//gopherjs:purge
 func godebug_setNewIncNonDefault(newIncNonDefault func(string) func())
 
 func getEnvString(key string) string {
@@ -580,13 +582,39 @@ func getEnvString(key string) string {
 }
 
 // godebug_notify is the function is called by syscall anytime an environment
-// variable is set or unset. It emit the GODEBUG setting if it was changed.
+// variable is set or unset. It emits the GODEBUG setting if it was changed.
 func godebug_notify(key, value string) {
-	update := godebugUpdate
-	if update == nil || key != godebugEnvKey {
+	if key != godebugEnvKey {
 		return
 	}
 
-	godebugDefault := ``
-	update(godebugDefault, value)
+	if update := godebugUpdate; update != nil {
+		godebugDefault := ``
+		update(godebugDefault, value)
+	}
+
+	// Keep the prelude's $panicnil flag in sync with GODEBUG even when the
+	// program never imported internal/godebug in which case `update` is nil.
+	syncPanicNilFromGodebug(value)
+}
+
+// syncPanicNilFromGodebug parses the given GODEBUG value for `panicnil=N`
+// and writes the result into the prelude's `$panicnil` value.
+// $panicnil mirrors the runtime's `debug.panicnil` GODEBUG setting.
+// When set to "1" (i.e. `GODEBUG=panicnil=1`), `panic(nil)` keeps the pre-go1.21
+// behavior of being recoverable as a real `nil`.
+// When "0" (the go1.21+ default), `panic(nil)` is wrapped into a
+// `*runtime.PanicNilError` so `recover()` returns a non-nil error.
+func syncPanicNilFromGodebug(godebug string) {
+	panicnil := `0`
+	if godebug != `` {
+		// Parse on the JS side to avoid pulling `strings` into the runtime package.
+		// The regex matches `panicnil=<digit>` in the comma-separated GODEBUG value.
+		re := js.Global.Get(`RegExp`).New(`(?:^|,)panicnil=(\d+)(?:,|$)`)
+		m := re.Call(`exec`, godebug)
+		if m != nil && m != js.Undefined && m.Length() >= 2 {
+			panicnil = m.Index(1).String()
+		}
+	}
+	js.Global.Set("$panicnil", panicnil)
 }

--- a/compiler/prelude/goroutines.js
+++ b/compiler/prelude/goroutines.js
@@ -109,8 +109,9 @@ var $callDeferred = (deferred, jsErr, fromPanic) => {
     }
 };
 
+var $panicnil = "0";
 var $panic = value => {
-    if (value === $ifaceNil) {
+    if (value === $ifaceNil && $panicnil !== "1") {
         value = $newPanicNilError();
     }
     $curGoroutine.panicStack.push(value);

--- a/tests/goroutine_test.go
+++ b/tests/goroutine_test.go
@@ -312,3 +312,22 @@ func TestIssue1106(t *testing.T) {
 		runtime.Gosched()
 	}
 }
+
+func TestPanicNil(t *testing.T) {
+	capturePanicNil := func() (result any) {
+		defer func() { result = recover() }()
+		panic(nil) //nolint:nilpanic
+	}
+
+	got := capturePanicNil()
+	if _, ok := got.(*runtime.PanicNilError); !ok {
+		t.Errorf("expected a runtime.PanicNilError but got: %v", got)
+	}
+
+	t.Setenv("GODEBUG", "panicnil=1")
+
+	got = capturePanicNil()
+	if got != nil {
+		t.Errorf("expected a nil but got: %v", got)
+	}
+}

--- a/tests/testdata/jsSourceMap/main.out
+++ b/tests/testdata/jsSourceMap/main.out
@@ -1,4 +1,4 @@
 doJSThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.inc.js:4)
 helper.DoGoThing	(gopherjs/tests/testdata/jsSourceMap/helper/helper.go:6)
 main.main	(gopherjs/tests/testdata/jsSourceMap/main.go:12)
-$goroutine	(gopherjs/compiler/prelude/goroutines.js:137)
+$goroutine	(gopherjs/compiler/prelude/goroutines.js:138)


### PR DESCRIPTION
Added some native overrides for runtime packages we don't support.

Added the `GODEBUG=panicnil=1` flag to control whether `panic(nil)` will be recovered as `nil` or as `*runtime.PanicNilError` that was added in go1.21. I added `PanicNilError` earlier without the flag. I went back and added the flag since the flag is specifically mentioned in the [docs for `PanicNilError`](https://pkg.go.dev/runtime#PanicNilError):

>Before Go 1.21, programs that called panic(nil) observed recover returning nil. Starting in Go 1.21, programs that call panic(nil) observe recover returning a *PanicNilError. Programs can change back to the old behavior by setting GODEBUG=panicnil=1.

related to https://github.com/gopherjs/gopherjs/issues/1415