### PR TITLE
Apply field-shadowing rule to method set computation (fixes #1228)

### DIFF
--- a/compiler/prelude/types.js
+++ b/compiler/prelude/types.js
@@ -288,7 +288,14 @@ var $newType = (size, kind, string, named, pkg, exported, constructor) => {
                 typ.ptr.nil.$val = typ.ptr.nil;
                 /* methods for embedded fields */
                 $addMethodSynthesizer(() => {
+                    // Names occupied by fields declared directly on this
+                    // struct shadow any same-named promoted method per Go's
+                    // selector rules, so do not synthesize a dispatcher for
+                    // a method whose name collides with a field.
+                    var shadowedNames = {};
+                    fields.forEach(f => { shadowedNames[f.name] = true; });
                     var synthesizeMethod = (target, m, f) => {
+                        if (shadowedNames[m.name]) { return; }
                         if (target.prototype[m.prop] !== undefined) { return; }
                         target.prototype[m.prop] = function(...args) {
                             var v = this.$val[f.prop];
@@ -425,6 +432,10 @@ var $methodSet = typ => {
     while (current.length > 0) {
         var next = [];
         var mset = [];
+        // Names occupied by non-method declarations (fields, embedded fields)
+        // at this depth. Per Go's selector rules they shadow any promoted
+        // method of the same name at deeper depths.
+        var fieldNames = [];
 
         current.forEach(e => {
             if (seen[e.typ.string]) {
@@ -442,6 +453,7 @@ var $methodSet = typ => {
             switch (e.typ.kind) {
                 case $kindStruct:
                     e.typ.fields.forEach(f => {
+                        fieldNames.push(f.name);
                         if (f.embedded) {
                             var fTyp = f.typ;
                             var fIsPtr = (fTyp.kind === $kindPtr);
@@ -462,12 +474,23 @@ var $methodSet = typ => {
             }
         });
 
+        // Reserve names occupied by fields at this depth so deeper-depth
+        // methods can't claim them. Uses null as a sentinel meaning
+        // "shadowed by a field, omit from the method set".
+        fieldNames.forEach(n => {
+            if (base[n] === undefined) {
+                base[n] = null;
+            }
+        });
+
         current = next;
     }
 
     typ.methodSetCache = [];
     Object.keys(base).sort().forEach(name => {
-        typ.methodSetCache.push(base[name]);
+        if (base[name] !== null) {
+            typ.methodSetCache.push(base[name]);
+        }
     });
     return typ.methodSetCache;
 };


### PR DESCRIPTION
## Summary

Fixes #1228. When an outer struct declares a non-embedded field with the same name as a method promoted from an embedded field, Go's selector rules require the field to shadow the method. The method should not appear in the outer type's method set, and direct selector access should resolve to the field.

GopherJS previously computed method sets purely from depth-ordered method walks, never consulting non-method field names at shallower depths. The same shallow-shadowing-by-field rule was also missed by the synthesized dispatcher installed on the outer struct's prototype.

The user-visible symptom from #1228 was `encoding/json` wrongly concluding that an anonymous struct with `Foo` embedded and a same-named `UnmarshalJSON` field implements `json.Unmarshaler`, then panicking at `h.UnmarshalJSON is not a function` when it tried to call the synthesized promoted method through what was actually the zero-value field.

## What changed

Two cooperating changes in `compiler/prelude/types.js`:

1. **`\$methodSet`** — at each BFS depth, after registering methods, reserve every field name on the current types with a `null` sentinel so any same-named method at a deeper depth is suppressed. The final pass strips the sentinels.
2. **Embedded-method synthesizer in `\$newType`'s struct-kind init** — build the set of field names declared directly on the outer struct and refuse to install a prototype dispatcher whose name collides with one. Stops direct-call sites (anything bypassing reflection) from finding the shadowed method.

Net diff: 24 inserts, 1 delete in one file.

## Test plan

- [x] Issue #1228 repro: `gopherjs run` prints \`{}\`, matching stock Go (pre-fix: \`TypeError: h.UnmarshalJSON is not a function\`).
- [x] Issue #1228 repro under \`-m\` minification: prints \`{}\`.
- [x] Sanity: promoted method with no shadowing still works.
- [x] Sanity: direct field access on shadowed name returns the field, not a method invocation.
- [x] \`TestSyntax1\` smoke test passes.
- [x] \`TestEmbeddedStruct\`, \`TestPointerEquality\`, \`TestMapStruct\` pass.
- [x] \`TestConcretePointerInGeneric\` (PR #1426 regression) still passes.
- [x] PR #1442 canonical minifyNaming repro (\`tests/testdata/minifyNaming/main.go\`) runs cleanly under \`-m\`.
- [ ] Full reflect-heavy sweep on a clean Linux testbed (the \`go test\` build at this commit fails on macOS due to a pre-existing 1.20-stdlib mismatch unrelated to this patch).

## Notes

- No regression test added to the repo in this commit — the right home is debatable (`gopherjs test` vs. `go test` shim like `Test_MinifyNaming`). Happy to add one in a follow-up commit on this branch in whichever flavor reviewers prefer.
- The fix is intentionally conservative: two narrow patches keeping shadow-checking logic at the two places it needs to apply, rather than restructuring the method-set computation pipeline. The trade-off is that future contributors editing one site need to remember the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)