### PR TITLE
[go1.21] improving math/bits speed

### DIFF
--- a/compiler/expressions.go
+++ b/compiler/expressions.go
@@ -667,6 +667,12 @@ func (fc *funcContext) translateExpr(expr ast.Expr) *expression {
 						return fc.formatExpr("debugger")
 					case "InternalObject":
 						return fc.translateExpr(e.Args[0])
+					case "MakeUint64":
+						return fc.formatExpr("new $Uint64(%e, %e)", e.Args[0], e.Args[1])
+					case "Uint64High":
+						return fc.formatExpr("%e.$high", e.Args[0])
+					case "Uint64Low":
+						return fc.formatExpr("%e.$low", e.Args[0])
 					}
 				}
 				return fc.translateCall(e, sig, fc.translateExpr(f))

--- a/compiler/natives/src/crypto/internal/bigmod/nat.go
+++ b/compiler/natives/src/crypto/internal/bigmod/nat.go
@@ -1,0 +1,46 @@
+//go:build js
+
+package bigmod
+
+import "math/bits"
+
+// GOPHERJS: The original has specialized cases for 1024, 1536, and 2048 bit
+// sizes that use addMulVVW1024/1536/2048 which take *uint pointers.
+// Those functions then use unsafe.Slice to convert back to slices.
+// In GopherJS, creating pointers via &slice[i] generates an $indexPtr.
+// We avoid this by always using the no-asm slice-based implementation
+// which calls addMulVVW with slices directly.
+//
+//gopherjs:replace
+func (x *Nat) montgomeryMul(a *Nat, b *Nat, m *Modulus) *Nat {
+	n := len(m.nat.limbs)
+	mLimbs := m.nat.limbs[:n]
+	aLimbs := a.limbs[:n]
+	bLimbs := b.limbs[:n]
+
+	T := make([]uint, n*2)
+
+	var c uint
+	for i := 0; i < n; i++ {
+		_ = T[n+i] // bounds check elimination hint
+		d := bLimbs[i]
+		c1 := addMulVVW(T[i:n+i], aLimbs, d)
+		Y := T[i] * m.m0inv
+		c2 := addMulVVW(T[i:n+i], mLimbs, Y)
+		T[n+i], c = bits.Add(c1, c2, c)
+	}
+
+	copy(x.reset(n).limbs, T[n:])
+	x.maybeSubtractModulus(choice(c), m)
+
+	return x
+}
+
+//gopherjs:purge
+func addMulVVW1024(z, x *uint, y uint) (c uint)
+
+//gopherjs:purge
+func addMulVVW1536(z, x *uint, y uint) (c uint)
+
+//gopherjs:purge
+func addMulVVW2048(z, x *uint, y uint) (c uint)

--- a/compiler/natives/src/math/bits/bits.go
+++ b/compiler/natives/src/math/bits/bits.go
@@ -2,6 +2,8 @@
 
 package bits
 
+import "github.com/gopherjs/gopherjs/js"
+
 type _err string
 
 func (e _err) Error() string {
@@ -17,6 +19,93 @@ var (
 	divideError   error = _err("runtime error: integer divide by zero")
 )
 
+//gopherjs:replace
+func LeadingZeros32(x uint32) int {
+	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
+	return js.Global.Get("Math").Call("clz32", x).Int()
+}
+
+//gopherjs:replace
+func LeadingZeros64(x uint64) int {
+	if hi := js.Uint64High(x); hi != 0 {
+		return LeadingZeros32(hi)
+	}
+	return 32 + LeadingZeros32(js.Uint64Low(x))
+}
+
+//gopherjs:replace
+func TrailingZeros32(x uint32) int {
+	// See "ctrz" in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
+	if x == 0 {
+		return 32
+	}
+	return 31 - LeadingZeros32(x&-x)
+}
+
+//gopherjs:replace
+func TrailingZeros64(x uint64) int {
+	lo := js.Uint64Low(x)
+	if lo != 0 {
+		return 31 - LeadingZeros32(lo&-lo)
+	}
+	hi := js.Uint64High(x)
+	if hi == 0 {
+		return 64
+	}
+	return 63 - LeadingZeros32(hi&-hi)
+}
+
+//gopherjs:replace
+func OnesCount64(x uint64) int {
+	return OnesCount32(js.Uint64High(x)) + OnesCount32(js.Uint64Low(x))
+}
+
+//gopherjs:replace
+func RotateLeft64(x uint64, k int) uint64 {
+	s := uint32(k) & 63
+	if s == 0 {
+		return x
+	}
+	xHi := js.Uint64High(x)
+	xLo := js.Uint64Low(x)
+	if s >= 32 {
+		tmp := xLo
+		xLo = xHi
+		xHi = tmp
+		s -= 32
+	}
+	if s == 0 {
+		return js.MakeUint64(float64(xHi), float64(xLo))
+	}
+	rs := 32 - s
+	return js.MakeUint64(float64(xHi<<s|xLo>>rs), float64(xLo<<s|xHi>>rs))
+}
+
+//gopherjs:replace
+func Reverse64(x uint64) uint64 {
+	return js.MakeUint64(
+		float64(Reverse32(js.Uint64Low(x))),
+		float64(Reverse32(js.Uint64High(x))))
+}
+
+//gopherjs:replace
+func ReverseBytes64(x uint64) uint64 {
+	return js.MakeUint64(
+		float64(ReverseBytes32(js.Uint64Low(x))),
+		float64(ReverseBytes32(js.Uint64High(x))))
+}
+
+//gopherjs:replace
+func Len32(x uint32) int {
+	return 32 - LeadingZeros32(x)
+}
+
+//gopherjs:replace
+func Len64(x uint64) int {
+	return 64 - LeadingZeros64(x)
+}
+
+//gopherjs:replace
 func Mul32(x, y uint32) (hi, lo uint32) {
 	// Avoid slow 64-bit integers for better performance. Adapted from Mul64().
 	const mask16 = 1<<16 - 1
@@ -34,6 +123,100 @@ func Mul32(x, y uint32) (hi, lo uint32) {
 	return
 }
 
+//gopherjs:replace
+func Mul64(x, y uint64) (uint64, uint64) {
+	const mask16 = 1<<16 - 1
+	// Decompose x and y into 16-bit parts so each product fits in 32 bits.
+	// Compute the 128-bit product using 16-bit column accumulation.
+	// This code could be simplified using Mul32 but that will take longer
+	// to run since Mul32 would have to decompose into 16-bit parts then
+	// repack them into 32-bit numbers for every call, so it is faster
+	// to keep the values decomposed as 16-bit numbers.
+	xLo := js.Uint64Low(x)
+	x0 := xLo & mask16
+	x1 := xLo >> 16
+	xHi := js.Uint64High(x)
+	x2 := xHi & mask16
+	x3 := xHi >> 16
+	yLo := js.Uint64Low(y)
+	y0 := yLo & mask16
+	y1 := yLo >> 16
+	yHi := js.Uint64High(y)
+	y2 := yHi & mask16
+	y3 := yHi >> 16
+	// Column 0 (bits 0-15): 1 product
+	c0 := x0 * y0
+	c16 := c0 >> 16
+	c0 &= mask16
+	// Column 16 (bits 16-31): 2 products
+	c16 += x1 * y0
+	c32 := c16 >> 16
+	c16 &= mask16
+	c16 += x0 * y1
+	c32 += c16 >> 16
+	c16 &= mask16
+	// Pack lo.$low (bits 0-31)
+	loLo := c16<<16 | c0
+	// Column 32 (bits 32-47): 3 products
+	// First, split c32 so it's at most 16 bits before adding products
+	c48 := c32 >> 16
+	c32 &= mask16
+	c32 += x2 * y0
+	c48 += c32 >> 16
+	c32 &= mask16
+	c32 += x1 * y1
+	c48 += c32 >> 16
+	c32 &= mask16
+	c32 += x0 * y2
+	c48 += c32 >> 16
+	c32 &= mask16
+	// Column 48 (bits 48-63): 4 products
+	c64 := c48 >> 16
+	c48 &= mask16
+	c48 += x3 * y0
+	c64 += c48 >> 16
+	c48 &= mask16
+	c48 += x2 * y1
+	c64 += c48 >> 16
+	c48 &= mask16
+	c48 += x1 * y2
+	c64 += c48 >> 16
+	c48 &= mask16
+	c48 += x0 * y3
+	c64 += c48 >> 16
+	c48 &= mask16
+	// Pack lo.$high (bits 32-63)
+	loHi := c48<<16 | c32
+	// Column 64 (bits 64-79): 3 products
+	c80 := c64 >> 16
+	c64 &= mask16
+	c64 += x3 * y1
+	c80 += c64 >> 16
+	c64 &= mask16
+	c64 += x2 * y2
+	c80 += c64 >> 16
+	c64 &= mask16
+	c64 += x1 * y3
+	c80 += c64 >> 16
+	c64 &= mask16
+	// Column 80 (bits 80-95): 2 products
+	c96 := c80 >> 16
+	c80 &= mask16
+	c80 += x3 * y2
+	c96 += c80 >> 16
+	c80 &= mask16
+	c80 += x2 * y3
+	c96 += c80 >> 16
+	c80 &= mask16
+	// Pack hi.$low (bits 64-95)
+	hiLo := c80<<16 | c64
+	// Column 96 (bits 96-127): 1 product
+	c96 += x3 * y3
+	// hi.$high is c96 (bits 96-127, no masking needed at the top)
+	return js.MakeUint64(float64(c96), float64(hiLo)), js.MakeUint64(float64(loHi), float64(loLo))
+}
+
+//gopherjs:replace
 func Add32(x, y, carry uint32) (sum, carryOut uint32) {
 	// Avoid slow 64-bit integers for better performance. Adapted from Add64().
 	sum = x + y + carry
@@ -41,6 +224,46 @@ func Add32(x, y, carry uint32) (sum, carryOut uint32) {
 	return
 }
 
+//gopherjs:replace
+func Add64(x, y, carry uint64) (sum, carryOut uint64) {
+	// Decompose into 32-bit halves and perform the addition as float64,
+	// where JS can represent integers up to 2^53 exactly.
+	// js.MakeUint64 handles low->high carry propagation automatically.
+	hiSum := float64(js.Uint64High(x)) + float64(js.Uint64High(y))
+	loSum := float64(js.Uint64Low(x)) + float64(js.Uint64Low(y)) + float64(js.Uint64Low(carry))
+	sum = js.MakeUint64(hiSum, loSum)
+
+	// Carry-out = 1 iff (hiSum + low->high carry) >= 2^32.
+	if loSum >= 4294967296.0 {
+		hiSum++
+	}
+	if hiSum >= 4294967296.0 {
+		carryOut = 1
+	}
+	return
+}
+
+//gopherjs:replace
+func Sub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+	// Mirror of nativeAdd64. The $Uint64 constructor correctly handles a
+	// negative `low` value: Math.floor(negative/2^32) returns -1, which
+	// propagates the borrow into the high half automatically.
+	hiDiff := float64(js.Uint64High(x)) - float64(js.Uint64High(y))
+	loDiff := float64(js.Uint64Low(x)) - float64(js.Uint64Low(y)) - float64(js.Uint64Low(borrow))
+	diff = js.MakeUint64(hiDiff, loDiff)
+
+	// Borrow-out = 1 iff the conceptual signed result (hiDiff*2^32 + loDiff)
+	// is negative:
+	//   hiDiff > 0: result definitely >= 0 (loDiff > -2^32).
+	//   hiDiff = 0: result negative iff loDiff < 0.
+	//   hiDiff < 0: result definitely < 0.
+	if hiDiff < 0 || (hiDiff == 0 && loDiff < 0) {
+		borrowOut = 1
+	}
+	return
+}
+
+//gopherjs:replace
 func Div32(hi, lo, y uint32) (quo, rem uint32) {
 	// Avoid slow 64-bit integers for better performance. Adapted from Div64().
 	const (
@@ -89,6 +312,156 @@ func Div32(hi, lo, y uint32) (quo, rem uint32) {
 	return q1*two16 + q0, (un21*two16 + un0 - q0*y) >> s
 }
 
+//gopherjs:replace
+func Div64(hi, lo, y uint64) (quo, rem uint64) {
+	// This code is similar to the original math/bits.Div64	with all arithmetic
+	// operating on 32-bit halves to avoid using uint64 operations that we have
+	// to emulate in JS.
+	//
+	// The original math/bits.Div64 appears to be based on
+	// Algorithm D (Division of nonnegative integers) 4.3.1 starting on page 257 in
+	// "The Art of Computer Programming" (TAoCP) Vol. 2 by Knuth
+	// (a copy can be found at https://github.com/Code42Cate/The-Art-of-Computer-Programming/blob/master/Volume2.pdf)
+	yn1 := js.Uint64High(y)
+	yn0 := js.Uint64Low(y)
+	if yn1 == 0 && yn0 == 0 {
+		panic(divideError)
+	}
+	un32Hi := js.Uint64High(hi)
+	un32Lo := js.Uint64Low(hi)
+	if yn1 < un32Hi || (yn1 == un32Hi && yn0 <= un32Lo) {
+		panic(overflowError)
+	}
+	un1 := js.Uint64High(lo)
+	un0 := js.Uint64Low(lo)
+
+	// If divisor fits in 32 bits, then the y > hi precondition forces
+	// un32Hi == 0 and un32Lo < yn0, so neither Div32 below can overflow.
+	// (At this point the limb names still hold their pre-shift values.)
+	if yn1 == 0 {
+		q1, r1 := Div32(un32Lo, un1, yn0)
+		q0, r0 := Div32(r1, un0, yn0)
+		return js.MakeUint64(float64(q1), float64(q0)),
+			js.MakeUint64(0, float64(r0))
+	}
+
+	// yn1 != 0 (full 64-bit divisor).
+	// Normalize so the divisor's top bit is set; s is in [0, 31]. We update
+	// the six limbs in place — each assignment reads the OLD values of the
+	// variables on its right since they are not overwritten until subsequent
+	// lines. Because hi < y (precondition), hi << s still fits in 64 bits.
+	s := uint(LeadingZeros32(yn1))
+	rs := 32 - s
+	if s != 0 {
+		yn1 = yn1<<s | yn0>>rs
+		yn0 = yn0 << s
+		un32Hi = un32Hi<<s | un32Lo>>rs
+		un32Lo = un32Lo<<s | un1>>rs
+		un1 = un1<<s | un0>>rs
+		un0 = un0 << s
+	}
+
+	// --- First quotient digit q1 ≈ (un32Hi:un32Lo) / yn1 ---
+	// Precondition un32 < y gives un32Hi <= yn1. When un32Hi == yn1 the
+	// true digit is 2^32 or 2^32+1; Knuth's loop implicitly decrements it
+	// to 2^32-1 with rhat = un32Lo + yn1. If that sum overflows uint32 the
+	// loop's "rhat >= two32" early-exit fires and no further adjustment is
+	// possible from 32-bit rhat, so we mark skipAdj.
+	var q1, rhat uint32
+	var skipAdj bool
+	if un32Hi == 0 {
+		q1 = un32Lo / yn1
+		rhat = un32Lo - q1*yn1
+	} else if un32Hi >= yn1 {
+		q1 = 0xFFFFFFFF
+		sum, carry := Add32(un32Lo, yn1, 0)
+		if carry != 0 {
+			skipAdj = true
+		} else {
+			rhat = sum
+		}
+	} else {
+		q1, rhat = Div32(un32Hi, un32Lo, yn1)
+	}
+
+	// Track q1 * yn0 incrementally across the correction loop so we avoid
+	// re-multiplying every iteration and can reuse the final value for un21.
+	qynHi, qynLo := Mul32(q1, yn0)
+	if !skipAdj {
+		for qynHi > rhat || (qynHi == rhat && qynLo > un1) {
+			q1--
+			if qynLo < yn0 {
+				qynHi--
+			}
+			qynLo -= yn0
+			sum, carry := Add32(rhat, yn1, 0)
+			if carry != 0 {
+				break
+			}
+			rhat = sum
+		}
+	}
+
+	// un21 = (un32:un1) - q1*y, mod 2^64.
+	// (un32 << 32) mod 2^64 = (un32Lo : 0), so the top half of un21 is
+	// computed from un32Lo (not un32Hi). q1*y mod 2^64 has high 32 bits
+	// q1*yn1 + carry(q1*yn0); both intentionally wrap modulo 2^32.
+	qyHi := q1*yn1 + qynHi
+	un21Lo := un1 - qynLo
+	un21Hi := un32Lo - qyHi
+	if un1 < qynLo {
+		un21Hi--
+	}
+
+	// --- Second quotient digit q0 ≈ (un21Hi:un21Lo) / yn1 ---
+	var q0 uint32
+	skipAdj = false
+	if un21Hi >= yn1 {
+		q0 = 0xFFFFFFFF
+		sum, carry := Add32(un21Lo, yn1, 0)
+		if carry != 0 || un21Hi > yn1 {
+			skipAdj = true
+		} else {
+			rhat = sum
+		}
+	} else {
+		q0, rhat = Div32(un21Hi, un21Lo, yn1)
+	}
+
+	qynHi, qynLo = Mul32(q0, yn0)
+	if !skipAdj {
+		for qynHi > rhat || (qynHi == rhat && qynLo > un0) {
+			q0--
+			if qynLo < yn0 {
+				qynHi--
+			}
+			qynLo -= yn0
+			sum, carry := Add32(rhat, yn1, 0)
+			if carry != 0 {
+				break
+			}
+			rhat = sum
+		}
+	}
+
+	// Remainder = (un21:un0) - q0*y, mod 2^64, then >> s to denormalize.
+	// qyHi is dead after the un21 computation above, so reuse it here.
+	qyHi = q0*yn1 + qynHi
+	remLo := un0 - qynLo
+	remHi := un21Lo - qyHi
+	if un0 < qynLo {
+		remHi--
+	}
+	if s != 0 {
+		remLo = remLo>>s | remHi<<rs
+		remHi = remHi >> s
+	}
+
+	return js.MakeUint64(float64(q1), float64(q0)),
+		js.MakeUint64(float64(remHi), float64(remLo))
+}
+
+//gopherjs:replace
 func Rem32(hi, lo, y uint32) uint32 {
 	// We scale down hi so that hi < y, then use Div32 to compute the
 	// rem with the guarantee that it won't panic on quotient overflow.

--- a/js/js.go
+++ b/js/js.go
@@ -260,6 +260,16 @@ type M map[string]any
 // S is a simple slice type. It is intended as a shorthand for JavaScript arrays (before conversion).
 type S []any
 
+// MakeUint64 will take the high and low parts to construct a uint64 number.
+// Since JS doesn't have a 64-bit integer we store it as a high and low 32-bit integers.
+func MakeUint64(hi, lo float64) uint64 { return 0 }
+
+// Uint64High will get the high 32-bit integer used when storing uint64.
+func Uint64High(x uint64) uint32 { return 0 }
+
+// Uint64Low will get the low 32-bit integer used when storing uint64.
+func Uint64Low(x uint64) uint32 { return 0 }
+
 func init() {
 	// Avoid dead code elimination.
 	e := Error{}

--- a/tests/numeric_test.go
+++ b/tests/numeric_test.go
@@ -312,3 +312,132 @@ func Test_MinMax(t *testing.T) {
 		t.Errorf("max(..NaN..): got: %v, want: %v", got, math.NaN())
 	}
 }
+
+func Benchmark_Native_MathBits(b *testing.B) {
+	if runtime.GOOS != "js" {
+		b.Skip("native bit functions use JS-specific features")
+	}
+
+	const (
+		inputSize = 1024
+		randSeed  = 0xC0FFEE
+		// set trial count and randomize to take multiple samples and randomize
+		// the order of the tests to help reduce burn-in error and noise.
+		trialCount = 1
+		randomize  = false
+	)
+
+	type mathBitsBenchArg struct {
+		x8                      uint8
+		x16                     uint16
+		x32, y32, z32, w32, c32 uint32
+		x64, y64, z64, w64, c64 uint64
+		k                       int
+	}
+
+	r := rand.New(rand.NewSource(randSeed))
+	ins := make([]*mathBitsBenchArg, inputSize)
+	for i := 0; i < inputSize; i++ {
+		x32 := r.Uint32()
+		y32 := r.Uint32()
+		c32 := r.Uint32() & 1 // carry or borrow must be 0 or 1
+		w32 := r.Uint32()     // w32 != 0
+		if w32 == 0 {
+			w32 = 1
+		}
+		z32 := r.Uint32() % w32 // z32 < w32
+		x64 := r.Uint64()
+		y64 := r.Uint64()
+		c64 := r.Uint64() & 1
+		w64 := r.Uint64() | 1 // w64 != 0
+		if w64 == 0 {
+			w64 = 1
+		}
+		z64 := r.Uint64() % w64 // z64 < w64
+		k := int(r.Uint32())
+		ins[i] = &mathBitsBenchArg{
+			x8: uint8(x32), x16: uint16(x32),
+			x32: x32, y32: y32, z32: z32, w32: w32, c32: c32,
+			x64: x64, y64: y64, z64: z64, w64: w64, c64: c64, k: k,
+		}
+	}
+
+	type testFn struct {
+		name string
+		fn   func(*mathBitsBenchArg)
+	}
+
+	tests := []testFn{
+		// --- LeadingZeros ---
+		{name: `LeadingZeros8`, fn: func(arg *mathBitsBenchArg) { _ = bits.LeadingZeros8(arg.x8) }},
+		{name: `LeadingZeros16`, fn: func(arg *mathBitsBenchArg) { _ = bits.LeadingZeros16(arg.x16) }},
+		{name: `LeadingZeros32`, fn: func(arg *mathBitsBenchArg) { _ = bits.LeadingZeros32(arg.x32) }},
+		{name: "LeadingZeros64", fn: func(arg *mathBitsBenchArg) { _ = bits.LeadingZeros64(arg.x64) }},
+		// --- TrailingZeros ---
+		{name: `TrailingZeros8`, fn: func(arg *mathBitsBenchArg) { _ = bits.TrailingZeros8(arg.x8) }},
+		{name: `TrailingZeros16`, fn: func(arg *mathBitsBenchArg) { _ = bits.TrailingZeros16(arg.x16) }},
+		{name: `TrailingZeros32`, fn: func(arg *mathBitsBenchArg) { _ = bits.TrailingZeros32(arg.x32) }},
+		{name: "TrailingZeros64", fn: func(arg *mathBitsBenchArg) { _ = bits.TrailingZeros64(arg.x64) }},
+		// --- OnesCount ---
+		{name: `OnesCount8`, fn: func(arg *mathBitsBenchArg) { _ = bits.OnesCount8(arg.x8) }},
+		{name: `OnesCount16`, fn: func(arg *mathBitsBenchArg) { _ = bits.OnesCount16(arg.x16) }},
+		{name: `OnesCount32`, fn: func(arg *mathBitsBenchArg) { _ = bits.OnesCount32(arg.x32) }},
+		{name: "OnesCount64", fn: func(arg *mathBitsBenchArg) { _ = bits.OnesCount64(arg.x64) }},
+		// --- RotateLeft ---
+		{name: "RotateLeft8", fn: func(arg *mathBitsBenchArg) { _ = bits.RotateLeft8(arg.x8, arg.k) }},
+		{name: "RotateLeft16", fn: func(arg *mathBitsBenchArg) { _ = bits.RotateLeft16(arg.x16, arg.k) }},
+		{name: "RotateLeft32", fn: func(arg *mathBitsBenchArg) { _ = bits.RotateLeft32(arg.x32, arg.k) }},
+		{name: "RotateLeft64", fn: func(arg *mathBitsBenchArg) { _ = bits.RotateLeft64(arg.x64, arg.k) }},
+		// --- Reverse ---
+		{name: "Reverse8", fn: func(arg *mathBitsBenchArg) { _ = bits.Reverse8(arg.x8) }},
+		{name: "Reverse16", fn: func(arg *mathBitsBenchArg) { _ = bits.Reverse16(arg.x16) }},
+		{name: "Reverse32", fn: func(arg *mathBitsBenchArg) { _ = bits.Reverse32(arg.x32) }},
+		{name: "Reverse64", fn: func(arg *mathBitsBenchArg) { _ = bits.Reverse64(arg.x64) }},
+		// --- ReverseBytes ---
+		{name: "ReverseBytes16", fn: func(arg *mathBitsBenchArg) { _ = bits.ReverseBytes16(arg.x16) }},
+		{name: "ReverseBytes32", fn: func(arg *mathBitsBenchArg) { _ = bits.ReverseBytes32(arg.x32) }},
+		{name: "ReverseBytes64", fn: func(arg *mathBitsBenchArg) { _ = bits.ReverseBytes64(arg.x64) }},
+		// --- Len ---
+		{name: `Len8`, fn: func(arg *mathBitsBenchArg) { _ = bits.Len8(arg.x8) }},
+		{name: `Len16`, fn: func(arg *mathBitsBenchArg) { _ = bits.Len16(arg.x16) }},
+		{name: `Len32`, fn: func(arg *mathBitsBenchArg) { _ = bits.Len32(arg.x32) }},
+		{name: "Len64", fn: func(arg *mathBitsBenchArg) { _ = bits.Len64(arg.x64) }},
+		// --- Add with carry ---
+		{name: "Add32", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Add32(arg.x32, arg.y32, arg.c32) }},
+		{name: "Add64", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Add64(arg.x64, arg.y64, arg.c64) }},
+		// --- Subtract with borrow ---
+		{name: "Sub32", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Sub32(arg.x32, arg.y32, arg.c32) }},
+		{name: "Sub64", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Sub64(arg.x64, arg.y64, arg.c64) }},
+		// --- Full-width multiply ---
+		{name: "Mul32", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Mul32(arg.x32, arg.y32) }},
+		{name: "Mul64", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Mul64(arg.x64, arg.y64) }},
+		// --- Full-width divide ---
+		{name: "Div32", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Div32(arg.z32, arg.y32, arg.w32) }},
+		{name: "Div64", fn: func(arg *mathBitsBenchArg) { _, _ = bits.Div64(arg.z64, arg.y64, arg.w64) }},
+		{name: "Rem32", fn: func(arg *mathBitsBenchArg) { _ = bits.Rem32(arg.z32, arg.y32, arg.w32) }},
+		{name: "Rem64", fn: func(arg *mathBitsBenchArg) { _ = bits.Rem64(arg.z64, arg.y64, arg.w64) }},
+	}
+
+	trials := make([]testFn, 0, trialCount*len(tests))
+	for i := 0; i < trialCount; i++ {
+		for _, t := range tests {
+			trials = append(trials, testFn{
+				name: fmt.Sprintf(`%s.%d`, t.name, i),
+				fn:   t.fn,
+			})
+		}
+	}
+	if randomize {
+		r.Shuffle(len(trials), func(i, j int) {
+			trials[i], trials[j] = trials[j], trials[i]
+		})
+	}
+
+	for _, tt := range trials {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				tt.fn(ins[i%inputSize])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- I added some optimizations for the `math/bits` package that is used in several other packages like crypto
- I added `MakeUint64`, `Uint64High`, and `Uint64Low` to the `js` package to help with these optimizations
- I tested existing optimizations in `math/bits` and the implementations for `$mul64` and `$div64`. I found that they were already better than anything I could think up

## Detailed

A test in `http/net` kept timing out so I profiled it and found the problem was the `crypto`, specifically `montgomeryMul`, was too slow. It was hitting a lot of `$indexPtr`s. After looking into it, it was because they were getting a pointer to the slice and then calling into a specific implementation of `addMulVVW`. In JS, we couldn't use any of the hardware improved `addMulVVW` implementations so would fall back to the default that would use `unsafe.Slice` to get the slice back from the pointer.

So, I added a native override for `montgomeryMul` that calls the default `addMulVVW` without using a pointer. This fixed the huge number of `$indexPtr`s being used but `addMulVVW` itself was still fairly slow. In the profiles I could see that `addMulVVW` called `bits.Mul` and `bits.Add` a lot.

I started investigating the `math/bits` package and running it's benchmarks. I found that the current overrides for `Add32` and `Mul32` were already great. So I looked for other cases and found that `LeadingZeros32` could be improved as well as the `uint64` functions.

I used [`Math.clz32`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32) to greatly improve the speed of `LeadingZeros32` and related `uint32` functions. I wanted to fix the `uint64` functions as well but it was prohibitively slow to get the high and low `uint32` out of `uint64` using the tools we have. So, I added some new tools to the `js` package. I added `js.MakeUint64(hi, lo float64) uint64`, `js.Uint64High(x uint64) uint32`, and `js.Uint64Low(x uint64) uint32` that transpile into `new $Uint64(hi, lo)`, `x.$high`, and `x.$low` respectively. That fixed the overhead in getting the high and low `uint32` and made it faster to create a `uint64` via a high and low `uint32`.

Using that new tool I went about trying to optimize the `math/bits` `uint64` functions. I tried several things and found that similar code to the existing `$mul64`, `$div64`, `bits.Mul32`, etc worked the best. (I did try a few things for `$mul64` and `$div64` but found they were already the best solution.)

## Results 

### From Benchmark_Native_MathBits

The following is from the benchmarks from `Benchmark_Native_MathBits`. The "before" is the benchmarks before the commit in this PR and "after" is after the commit in this PR. The "diff" is $\frac{\text{after}}{\text{before}} \times 100$ meaning that it is the percentage of the "before" time that the "after" time takes (i.e. 50% is means "after" takes half the time that "before" took).

The ones that aren't marked as changed may be different because they call one of the changed methods (e.g. `Div32` calls `LeadingZeros32` once). There is also a lot of noise when doing measurements this small, hence ones like `LeadingZeros16` which was not changed shows $102.64\\%$. I left in the unchanged ones so that we can see the variance caused by noise. It seems to be about $\pm 2 \\%$. To help reduce the noise I ran 10 trials and randomized the order of the tests to ensure that time, burn-in, the tasks on my laptop taking more time, etc is not a much of a factor.

| funcName | before (ns/op) | after (ns/op) | diff (%) | changed |
|:---------|-----------------:|---------------:|---------:|:-------:|
| Add32           |   12.295 |  12.284 |   99.91 |     |
| Add64           |   62.157 |  24.484 |   39.39 |  X  |
| Div32           |   42.738 |  38.010 |   88.94 |     |
| Div64           | 1482.774 | 132.504 |    8.94 |  X  |
| LeadingZeros16  |    9.176 |   9.418 |  102.64 |     |
| LeadingZeros32  |   17.521 |  10.507 |   59.97 |  X  |
| LeadingZeros64  |   53.967 |  13.433 |   24.89 |  X  |
| LeadingZeros8   |    9.066 |   9.045 |   99.77 |     |
| Len16           |    8.908 |   8.872 |   99.60 |     |
| Len32           |   17.321 |  11.073 |   63.93 |  X  |
| Len64           |   46.118 |  13.679 |   29.66 |  X  |
| Len8            |    8.654 |   8.617 |   99.58 |     |
| Mul32           |    7.917 |   8.052 |  101.71 |     |
| Mul64           |  256.841 |  38.424 |   14.96 |  X  |
| OnesCount16     |    9.169 |   9.173 |  100.05 |     |
| OnesCount32     |   12.079 |  12.273 |  101.61 |     |
| OnesCount64     |  206.456 |  17.290 |    8.37 |  X  |
| OnesCount8      |    8.685 |   8.640 |   99.47 |     |
| Rem32           |   49.160 |  48.404 |   98.46 |     |
| Rem64           | 1477.660 | 150.802 |   10.21 |     |
| Reverse16       |    9.091 |   9.030 |   99.34 |     |
| Reverse32       |   10.478 |  10.487 |  100.09 |     |
| Reverse64       |  301.358 |  13.343 |    4.43 |  X  |
| Reverse8        |    8.683 |   8.669 |   99.84 |     |
| ReverseBytes16  |    7.988 |   8.067 |  100.98 |     |
| ReverseBytes32  |    7.399 |   7.461 |  100.84 |     |
| ReverseBytes64  |  162.200 |  12.280 |    7.57 |  X  |
| RotateLeft16    |    7.984 |   8.037 |  100.66 |     |
| RotateLeft32    |    7.975 |   8.038 |  100.80 |     |
| RotateLeft64    |   29.015 |  16.540 |   57.01 |  X  |
| RotateLeft8     |    8.016 |   8.062 |  100.57 |     |
| Sub32           |   12.129 |  12.176 |  100.39 |     |
| Sub64           |   86.204 |  26.561 |   30.81 |  X  |
| TrailingZeros16 |    9.359 |   9.304 |   99.41 |     |
| TrailingZeros32 |   11.924 |  11.959 |  100.29 |  X  |
| TrailingZeros64 |   61.172 |  13.907 |   22.73 |  X  |
| TrailingZeros8  |    8.647 |   8.685 |  100.44 |     |

Here are just the changed ones sorted by diff:

| funcName | before (ns/op) | after (ns/op) | diff (%) |
|:---------|-----------------:|---------------:|---------:|
| Reverse64       |  301.358 |  13.343 |    4.43 |
| ReverseBytes64  |  162.200 |  12.280 |    7.57 |
| OnesCount64     |  206.456 |  17.290 |    8.37 |
| Div64           | 1482.774 | 132.504 |    8.94 |
| Mul64           |  256.841 |  38.424 |   14.96 |
| TrailingZeros64 |   61.172 |  13.907 |   22.73 | 
| LeadingZeros64  |   53.967 |  13.433 |   24.89 |
| Len64           |   46.118 |  13.679 |   29.66 |
| Sub64           |   86.204 |  26.561 |   30.81 |
| Add64           |   62.157 |  24.484 |   39.39 |
| RotateLeft64    |   29.015 |  16.540 |   57.01 |
| LeadingZeros32  |   17.521 |  10.507 |   59.97 |
| Len32           |   17.321 |  11.073 |   63.93 |
| TrailingZeros32 |   11.924 |  11.959 |  100.29 |

I was hoping `TrailingZeros32` would be faster using the `Math.clz32` method but it seems doing the `x&-x` and possibly the method call made the overall change negligible. I might come back and tinker with that later since I have several ideas for that, `Len32`, `LeadingZeros32`, and `RotateLeft64`, but I didn't want to spend so much time on those that I never get these changes out.

The benchmarks in `math/bits` got similar results. I didn't use them while doing these updates because their benchmarks are centered around their implementation. For example they don't measure `Len64` since they know it is part of other calls. I wanted a more generalized version that I could randomize ([importance of randomization in experimental design](https://biostatistics.letgen.org/mikes-biostatistics-book/experimental-design/importance-of-randomization-in-experimental-design/)) so I wrote `Benchmark_Native_MathBits`. 
