### PR TITLE
Pinning macos version for Darwin CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,10 @@ jobs:
 
   darwin_smoke:
     name: Darwin Smoke
-    runs-on: macos-latest
+    # Switch to macos-latest when we reach go1.24 support. macos-26+ has a
+    # LC_UUID update that causes Go builds older than go1.24 to fail to link.
+    # See https://tip.golang.org/doc/go1.24#linker
+    runs-on: macos-15
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We were using `macos-latest` in our CI. However, [macos-26 was just released](https://github.com/actions/runner-images/issues/14167) and that causes the `dyld[4342]: missing LC_UUID load command` error for all versions of Go builds before [the fix added in go1.24](https://tip.golang.org/doc/go1.24#linker). Pinning to prior version, `macos-15`, should hopefully fix this but we should remove the pinning as soon as we are able to.