### PR TITLE
[go1.22] Initial version bump for go1.22 integration branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21.13
+  GO_VERSION: 1.22.12
   NODE_VERSION: 24
   GOLANGCI_VERSION: v1.59.1
   SOURCE_MAP_SUPPORT: true

--- a/.github/workflows/measure-size.yml
+++ b/.github/workflows/measure-size.yml
@@ -3,7 +3,7 @@ name: Measure canonical app size
 on: ['pull_request']
 
 env:
-  GO_VERSION: '~1.21.13'
+  GO_VERSION: '~1.22.12'
 
 jobs:
   measure:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ GopherJS compiles Go code ([go.dev](https://go.dev/)) to pure JavaScript code. I
 
 ### What's new?
 
+- 2026-06-26: Go 1.21 support is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.21.0)!
+- 2026-01-02: Go 1.20 support is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.20.0)!
 - 2025-08-19: Go 1.19 beta2 is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.19.0-beta2), with full generics support!
 - 2024-02-24: Go 1.19 support is [available](https://github.com/gopherjs/gopherjs/releases/tag/v1.19.0-beta1)!
 - 2022-08-18: Go 1.18 support is [available](https://github.com/gopherjs/gopherjs/releases/tag/v1.18.0-beta2%2Bgo1.18.5)!
@@ -33,21 +35,21 @@ Nearly everything, including Goroutines ([compatibility documentation](https://g
 
 ### Installation and Usage
 
-GopherJS [requires Go 1.21 or newer](https://github.com/gopherjs/gopherjs/blob/master/doc/compatibility.md#go-version-compatibility). If you need an older Go
+GopherJS [requires Go 1.22 or newer](https://github.com/gopherjs/gopherjs/blob/master/doc/compatibility.md#go-version-compatibility). If you need an older Go
 version, you can use an [older GopherJS release](https://github.com/gopherjs/gopherjs/releases).
 
 Install GopherJS with `go install`:
 
-```
-go install github.com/gopherjs/gopherjs@v1.21.0  # Or replace 'v1.21.0' with another version.
+```bash
+go install github.com/gopherjs/gopherjs@v1.22.0  # Or replace 'v1.22.0' with another version.
 ```
 
-If your local Go distribution as reported by `go version` is newer than Go 1.21, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.21 distribution. For example:
+If your local Go distribution as reported by `go version` is newer than Go 1.22, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.22 distribution. For example:
 
-```
-go install golang.org/dl/go1.21.13@latest
-go1.21.13 download
-export GOPHERJS_GOROOT="$(go1.21.13 env GOROOT)"  # Also add this line to your .profile or equivalent.
+```bash
+go install golang.org/dl/go1.22.12@latest
+go1.22.12 download
+export GOPHERJS_GOROOT="$(go1.22.12 env GOROOT)"  # Also add this line to your .profile or equivalent.
 ```
 
 Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherjs install [package]` which behave similar to the `go` tool. For `main` packages, these commands create a `.js` file and `.js.map` source map in the current directory or in `$GOPATH/bin`. The generated JavaScript file can be used as usual in a website. Use `gopherjs help [command]` to get a list of possible command line flags, e.g. for minification and automatically watching for changes.
@@ -55,6 +57,22 @@ Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherj
 `gopherjs` uses your platform's default `GOOS` value when generating code. Supported `GOOS` values are: `linux`, `darwin`. If you're on a different platform (e.g., Windows or FreeBSD), you'll need to set the `GOOS` environment variable to a supported value. For example, `GOOS=linux gopherjs build [package]`.
 
 _Note: GopherJS will try to write compiled object files of the core packages to your $GOROOT/pkg directory. If that fails, it will fall back to $GOPATH/pkg._
+
+#### Mac LC_UUID Error
+
+On Macs, if you compile the `gopherjs` app with anything less than go1.24, you may get the following error:
+
+```plain
+dyld[60166]: missing LC_UUID load command in ...
+```
+
+This is a Go + Mac issued [fixed in go1.24](https://tip.golang.org/doc/go1.24#linker).
+This is only an issue because gopherjs hasn't reached go1.24 support yet.
+
+If you get this error, build the `gopherjs` app with go1.24+. However, because of how
+we target specific STL versions, you must still use the correct STL for the version
+of gopherjs that you have. See how to set `GOPHERJS_GOROOT` above for how to select
+the correct STL that gopherjs will use.
 
 #### gopherjs run, gopherjs test
 
@@ -70,7 +88,7 @@ For example, navigating to `http://localhost:8080/example.com/user/project/` sho
 
 Refreshing in the browser will rebuild the served files if needed. Compilation errors will be displayed in terminal, and in browser console. Additionally, it will serve $GOROOT and $GOPATH for sourcemaps.
 
-If you include an argument, it will be the root from which everything is served. For example, if you run `gopherjs serve github.com/user/project` then the generated JavaScript for the package github.com/user/project/mypkg will be served at http://localhost:8080/mypkg/mypkg.js.
+If you include an argument, it will be the root from which everything is served. For example, if you run `gopherjs serve github.com/user/project` then the generated JavaScript for the package github.com/user/project/mypkg will be served at <http://localhost:8080/mypkg/mypkg.js>.
 
 #### Environment Variables
 
@@ -85,7 +103,7 @@ There are some GopherJS-specific environment variables:
 ### Performance Tips
 
 - Use the `-m` command line flag to generate minified code.
-- Apply gzip compression (https://en.wikipedia.org/wiki/HTTP_compression).
+- Apply gzip compression (<https://en.wikipedia.org/wiki/HTTP_compression>).
 - Use `int` instead of `(u)int8/16/32/64`.
 - Use `float64` instead of `float32`.
 

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -49,7 +49,7 @@ func goRootVersion(goroot string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("`go version` command failed: %w", err)
 	}
-	// Expected output: go version go1.21.13 linux/amd64
+	// Expected output: go version go1.22.12 linux/amd64
 	parts := strings.Split(string(out), " ")
 	if len(parts) != 4 {
 		return "", fmt.Errorf("unexpected `go version` output %q, expected 4 words", string(out))

--- a/compiler/version_check.go
+++ b/compiler/version_check.go
@@ -1,4 +1,4 @@
-//go:build go1.21
+//go:build go1.22
 
 package compiler
 
@@ -12,10 +12,10 @@ import (
 )
 
 // Version is the GopherJS compiler version string.
-const Version = "1.21.0+go1.21.13"
+const Version = "1.22.0+go1.22.12"
 
 // GoVersion is the current Go 1.x version that GopherJS is compatible with.
-const GoVersion = 21
+const GoVersion = 22
 
 // CheckGoVersion checks the version of the Go distribution
 // at goroot, and reports an error if it's not compatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopherjs/gopherjs
 
-go 1.21
+go 1.22
 
 require (
 	github.com/evanw/esbuild v0.25.4

--- a/tests/js_test.go
+++ b/tests/js_test.go
@@ -1101,12 +1101,6 @@ func TestSliceDataFromPointer(t *testing.T) {
 	})
 }
 
-// TODO(grantnelson-wf): When calling into `unsafe.Slice` the type checker does
-// not understand that `[]T` or `~[]T` is slice. This is a known issue,
-// https://github.com/golang/go/issues/64406 in go1.21. The type checker was
-// fixed in go1.22. Until then the following will only work if gopherjs was
-// built with a go version above go1.21. Once on go1.22, this test can be restored.
-/*
 func TestSliceDataWithDifferentTypes(t *testing.T) {
 	checkSliceDataRoundTrip(t, []bool(nil))
 	checkSliceDataRoundTrip(t, []bool{})
@@ -1172,7 +1166,6 @@ func checkSliceDataRoundTrip[T comparable, S ~[]T](t *testing.T, s S) {
 		})
 	}
 }
-*/
 
 func TestSliceDataEdgeCases(t *testing.T) {
 	catch := func(h func()) (r string) {


### PR DESCRIPTION
Starting the go1.22 integration branch by bumping the go versions. This branch's CI will fail since we don't support go1.22 yet.

related to https://github.com/gopherjs/gopherjs/issues/1334