### PR TITLE
[go1.22] Adding push linknames

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ GopherJS compiles Go code ([go.dev](https://go.dev/)) to pure JavaScript code. I
 
 ### What's new?
 
+- 2026-06-26: Go 1.21 support is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.21.0)!
+- 2026-01-02: Go 1.20 support is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.20.0)!
 - 2025-08-19: Go 1.19 beta2 is [released](https://github.com/gopherjs/gopherjs/releases/tag/v1.19.0-beta2), with full generics support!
 - 2024-02-24: Go 1.19 support is [available](https://github.com/gopherjs/gopherjs/releases/tag/v1.19.0-beta1)!
 - 2022-08-18: Go 1.18 support is [available](https://github.com/gopherjs/gopherjs/releases/tag/v1.18.0-beta2%2Bgo1.18.5)!
@@ -38,13 +40,13 @@ version, you can use an [older GopherJS release](https://github.com/gopherjs/gop
 
 Install GopherJS with `go install`:
 
-```
+```bash
 go install github.com/gopherjs/gopherjs@v1.21.0  # Or replace 'v1.21.0' with another version.
 ```
 
 If your local Go distribution as reported by `go version` is newer than Go 1.21, then you need to set the `GOPHERJS_GOROOT` environment variable to a directory that contains a Go 1.21 distribution. For example:
 
-```
+```bash
 go install golang.org/dl/go1.21.13@latest
 go1.21.13 download
 export GOPHERJS_GOROOT="$(go1.21.13 env GOROOT)"  # Also add this line to your .profile or equivalent.
@@ -55,6 +57,22 @@ Now you can use `gopherjs build [package]`, `gopherjs build [files]` or `gopherj
 `gopherjs` uses your platform's default `GOOS` value when generating code. Supported `GOOS` values are: `linux`, `darwin`. If you're on a different platform (e.g., Windows or FreeBSD), you'll need to set the `GOOS` environment variable to a supported value. For example, `GOOS=linux gopherjs build [package]`.
 
 _Note: GopherJS will try to write compiled object files of the core packages to your $GOROOT/pkg directory. If that fails, it will fall back to $GOPATH/pkg._
+
+#### Mac LC_UUID Error
+
+On Macs, if you compile the `gopherjs` app with anything less than go1.24, you may get the following error:
+
+```plain
+dyld[60166]: missing LC_UUID load command in ...
+```
+
+This is a Go + Mac issued [fixed in go1.24](https://tip.golang.org/doc/go1.24#linker).
+This is only an issue because gopherjs hasn't reached go1.24 support yet.
+
+If you get this error, build the `gopherjs` app with go1.24+. However, because of how
+we target specific STL versions, you must still use the correct STL for the version
+of gopherjs that you have. See how to set `GOPHERJS_GOROOT` above for how to select
+the correct STL that gopherjs will use.
 
 #### gopherjs run, gopherjs test
 
@@ -70,7 +88,7 @@ For example, navigating to `http://localhost:8080/example.com/user/project/` sho
 
 Refreshing in the browser will rebuild the served files if needed. Compilation errors will be displayed in terminal, and in browser console. Additionally, it will serve $GOROOT and $GOPATH for sourcemaps.
 
-If you include an argument, it will be the root from which everything is served. For example, if you run `gopherjs serve github.com/user/project` then the generated JavaScript for the package github.com/user/project/mypkg will be served at http://localhost:8080/mypkg/mypkg.js.
+If you include an argument, it will be the root from which everything is served. For example, if you run `gopherjs serve github.com/user/project` then the generated JavaScript for the package github.com/user/project/mypkg will be served at <http://localhost:8080/mypkg/mypkg.js>.
 
 #### Environment Variables
 
@@ -85,7 +103,7 @@ There are some GopherJS-specific environment variables:
 ### Performance Tips
 
 - Use the `-m` command line flag to generate minified code.
-- Apply gzip compression (https://en.wikipedia.org/wiki/HTTP_compression).
+- Apply gzip compression (<https://en.wikipedia.org/wiki/HTTP_compression>).
 - Use `int` instead of `(u)int8/16/32/64`.
 - Use `float64` instead of `float32`.
 

--- a/compiler/linkname/linkname.go
+++ b/compiler/linkname/linkname.go
@@ -112,9 +112,11 @@ func isMitigatedInsertLinkname(sym symbol.Name) bool {
 //   - External linkname must be specified.
 //   - The directive must be applied to a package-level function or method (variables
 //     are not supported).
-//   - The local function referenced by the directive must have no body (in other
-//     words, it can only "import" an external function implementation into the
-//     local scope).
+//   - The local function may either be body-less, in which case the directive
+//     is a "pull" that imports the external implementation into the local
+//     scope, or have a body, in which case the directive is a "push" that
+//     exports the local implementation to the external body-less stub. When
+//     both sides carry matching directives ("handshake").
 func ParseGoLinknames(fset *token.FileSet, pkgPath string, file *ast.File) ([]GoLinkname, error) {
 	var errs errlist.ErrorList = nil
 	var directives []GoLinkname
@@ -149,10 +151,14 @@ func ParseGoLinknames(fset *token.FileSet, pkgPath string, file *ast.File) ([]Go
 			if isMitigatedInsertLinkname(link.Reference) {
 				return nil
 			}
-			return fmt.Errorf("gopherjs: //go:linkname can not insert local implementation into an external package %q", link.Implementation.PkgPath)
+			// Push link: Local function has a body meaning it is the implementation
+			// that is referencing the stub. Swap the sides so the link is the same as the pull form.
+			link.Implementation, link.Reference = link.Reference, link.Implementation
+			directives = append(directives, *link)
+			return nil
 		}
 
-		// Local function has no body, treat it as a reference to an external implementation.
+		// Pull link: Local function has no body, treat it as a reference to an external implementation.
 		directives = append(directives, *link)
 		return nil
 	}
@@ -224,11 +230,15 @@ func (gls *GoLinknameSet) Add(entries []GoLinkname) error {
 		gls.byReference = map[symbol.Name]GoLinkname{}
 	}
 	for _, e := range entries {
-		gls.byImplementation[e.Implementation] = append(gls.byImplementation[e.Implementation], e)
 		if prev, found := gls.byReference[e.Reference]; found {
+			if prev.Implementation == e.Implementation {
+				// Ignore the duplicate
+				continue
+			}
 			return fmt.Errorf("conflicting go:linkname directives: two implementations for %q: %q and %q",
 				e.Reference, prev.Implementation, e.Implementation)
 		}
+		gls.byImplementation[e.Implementation] = append(gls.byImplementation[e.Implementation], e)
 		gls.byReference[e.Reference] = e
 	}
 	return nil

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -23,3 +23,7 @@ func Test_ProxyMethod(t *testing.T) { runOutputTest(t, `testdata`, `proxyMethod`
 // to test that the package level type names do not conflict with function level
 // variable names when the code is minified.
 func Test_MinifyNaming(t *testing.T) { runOutputTest(t, `testdata`, `minifyNaming`, `-m`) }
+
+// Test_PushLinkname uses testdata/pushlinkname/main.go
+// to test that linknames can be pushed and pulled.
+func Test_PushLinkname(t *testing.T) { runOutputTest(t, `testdata`, `pushlinkname`) }

--- a/tests/testdata/pushlinkname/anotherPushLink/anotherPushLink.go
+++ b/tests/testdata/pushlinkname/anotherPushLink/anotherPushLink.go
@@ -1,0 +1,21 @@
+package anotherPushLink
+
+import (
+	_ "unsafe"
+
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/foo"
+)
+
+//go:linkname pushSetName
+func pushSetName(*foo.Foo, string)
+
+//go:linkname pushGetName
+func pushGetName(foo.Foo) string
+
+func Run() {
+	f := &foo.Foo{}
+	input := "Holland"
+	pushSetName(f, input)
+	name := pushGetName(*f)
+	println("Another Push Link: " + name)
+}

--- a/tests/testdata/pushlinkname/foo/foo.go
+++ b/tests/testdata/pushlinkname/foo/foo.go
@@ -1,0 +1,24 @@
+package foo
+
+import _ "unsafe"
+
+type Foo struct{ name string }
+
+func (f *Foo) String() string { return f.name }
+
+func setName1(f *Foo, name string) { f.name = name }
+
+func getName1(f Foo) string { return f.name }
+
+//go:linkname setName2 github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/pushLink.pushSetName
+func setName2(f *Foo, name string) { f.name = name }
+
+//go:linkname getName2 github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/pushLink.pushGetName
+func getName2(f Foo) string { return f.name }
+
+func setName3(f *Foo, name string) { f.name = name }
+
+func getName3(f Foo) string { return f.name }
+
+//go:linkname setName3 github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/anotherPushLink.pushSetName
+//go:linkname getName3 github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/anotherPushLink.pushGetName

--- a/tests/testdata/pushlinkname/main.go
+++ b/tests/testdata/pushlinkname/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/anotherPushLink"
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/pullLink"
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/pushLink"
+)
+
+func main() {
+	pullLink.Run()
+	pushLink.Run()
+	anotherPushLink.Run()
+}

--- a/tests/testdata/pushlinkname/main.out
+++ b/tests/testdata/pushlinkname/main.out
@@ -1,0 +1,3 @@
+Pull Link: Morse
+Push Link: Noodles
+Another Push Link: Holland

--- a/tests/testdata/pushlinkname/pullLink/pullLink.go
+++ b/tests/testdata/pushlinkname/pullLink/pullLink.go
@@ -1,0 +1,21 @@
+package pullLink
+
+import (
+	_ "unsafe"
+
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/foo"
+)
+
+//go:linkname pullSetName github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/foo.setName1
+func pullSetName(*foo.Foo, string)
+
+//go:linkname pullGetName github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/foo.getName1
+func pullGetName(foo.Foo) string
+
+func Run() {
+	f := &foo.Foo{}
+	input := "Morse"
+	pullSetName(f, input)
+	name := pullGetName(*f)
+	println("Pull Link: " + name)
+}

--- a/tests/testdata/pushlinkname/pushLink/pushLink.go
+++ b/tests/testdata/pushlinkname/pushLink/pushLink.go
@@ -1,0 +1,21 @@
+package pushLink
+
+import (
+	_ "unsafe"
+
+	"github.com/gopherjs/gopherjs/tests/testdata/pushlinkname/foo"
+)
+
+//go:linkname pushSetName
+func pushSetName(*foo.Foo, string)
+
+//go:linkname pushGetName
+func pushGetName(foo.Foo) string
+
+func Run() {
+	f := &foo.Foo{}
+	input := "Noodles"
+	pushSetName(f, input)
+	name := pushGetName(*f)
+	println("Push Link: " + name)
+}


### PR DESCRIPTION
Adding `//go:linkname` directives allowing pushing a link. We currently supported pulling a link, where a function stub can have a directive indicating which function declaration to link too. Now a function declaration can have a directive indicating which function stub should connect to it. This also allows handshakes where both links point at each other (the duplicate link is just ignored).

`https://github.com/golang/go/issues/67401` describes how the pull links are removed by go1.23. We've been adding a lot of native overrides to handle push links. As we get closer to go1.23, there will be more and more push links and less pull links. By adding push links we can remove the native overrides for linked functions. We will still have to have overrides for links to variables and constants for now since we don't handle linking in either direction for those.

I used an integration test for the test of the push since with the bump to go1.22 the STL is not ready to be used yet. The tests can be run with `go` to make sure we're linking correctly. To run the tests with `gopherjs`, first build `gopherjs` with these changes (e.g. `go install .`) then `cd tests/testdata/pushlinkname` and `gopherjs run main.go` to see the same results as in the `main.out` in the `pushlinkname` folder.

After fixing another block I found that I need to also update `TestParseGoLinknames` in `compiler/linkname/linkname_test.go` for this change, but I'll do that in a follow up ticket.

This work does not remove the native overrides from the STL yet. We can take care of those as we update towards go1.22.

related to https://github.com/gopherjs/gopherjs/issues/1334