### PR TITLE
[go1.22] Fix reflectlite

### DIFF
--- a/compiler/natives/src/internal/reflectlite/export_test.go
+++ b/compiler/natives/src/internal/reflectlite/export_test.go
@@ -3,9 +3,8 @@
 package reflectlite
 
 import (
-	"unsafe"
-
 	"internal/abi"
+	"unsafe"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -23,7 +22,7 @@ func Field(v Value, i int) Value {
 
 //gopherjs:new
 func (v Value) Field(i int) Value {
-	tt := v.typ.StructType()
+	tt := v.typ_.StructType()
 	if tt == nil {
 		panic(&ValueError{"reflect.Value.Field", v.kind()})
 	}
@@ -32,7 +31,7 @@ func (v Value) Field(i int) Value {
 		panic("reflect: Field index out of range")
 	}
 
-	prop := jsType(v.typ).Get("fields").Index(i).Get("prop").String()
+	prop := jsType(v.typ_).Get("fields").Index(i).Get("prop").String()
 	field := &tt.Fields[i]
 	typ := field.Typ
 
@@ -49,14 +48,14 @@ func (v Value) Field(i int) Value {
 		if jsTag := structTagGet(tag, `js`); jsTag != "" {
 			for {
 				v = v.Field(0)
-				if v.typ == abi.JsObjectPtr {
+				if v.typ_ == abi.JsObjectPtr {
 					o := v.object().Get("object")
 					return Value{typ, unsafe.Pointer(typ.JsPtrTo().New(
 						js.InternalObject(func() *js.Object { return js.Global.Call("$internalize", o.Get(jsTag), jsType(typ)) }),
 						js.InternalObject(func(x *js.Object) { o.Set(jsTag, js.Global.Call("$externalize", x, jsType(typ))) }),
 					).Unsafe()), fl}
 				}
-				if v.typ.Kind() == abi.Pointer {
+				if v.typ_.Kind() == abi.Pointer {
 					v = v.Elem()
 				}
 			}

--- a/compiler/natives/src/internal/reflectlite/reflectlite.go
+++ b/compiler/natives/src/internal/reflectlite/reflectlite.go
@@ -3,9 +3,8 @@
 package reflectlite
 
 import (
-	"unsafe"
-
 	"internal/abi"
+	"unsafe"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -89,8 +88,8 @@ func typedmemmove(t *abi.Type, dst, src unsafe.Pointer) {
 //gopherjs:new This is a simplified copy of the version in reflect.
 func methodReceiver(op string, v Value, i int) (fn unsafe.Pointer) {
 	var prop string
-	if v.typ.Kind() == abi.Interface {
-		tt := v.typ.InterfaceType()
+	if v.typ_.Kind() == abi.Interface {
+		tt := v.typ_.InterfaceType()
 		if i < 0 || i >= len(tt.Methods) {
 			panic("reflect: internal error: invalid method index")
 		}
@@ -100,19 +99,19 @@ func methodReceiver(op string, v Value, i int) (fn unsafe.Pointer) {
 		}
 		prop = tt.NameOff(m.Name).Name()
 	} else {
-		ms := v.typ.ExportedMethods()
+		ms := v.typ_.ExportedMethods()
 		if uint(i) >= uint(len(ms)) {
 			panic("reflect: internal error: invalid method index")
 		}
 		m := ms[i]
-		if !v.typ.NameOff(m.Name).IsExported() {
+		if !v.typ_.NameOff(m.Name).IsExported() {
 			panic("reflect: " + op + " of unexported method")
 		}
-		prop = js.Global.Call("$methodSet", jsType(v.typ)).Index(i).Get("prop").String()
+		prop = js.Global.Call("$methodSet", jsType(v.typ_)).Index(i).Get("prop").String()
 	}
 	rcvr := v.object()
-	if v.typ.IsWrapped() {
-		rcvr = jsType(v.typ).New(rcvr)
+	if v.typ_.IsWrapped() {
+		rcvr = jsType(v.typ_).New(rcvr)
 	}
 	fn = unsafe.Pointer(rcvr.Get(prop).Unsafe())
 	return
@@ -128,13 +127,13 @@ func valueInterface(v Value) any {
 		v = makeMethodValue("Interface", v)
 	}
 
-	if v.typ.IsWrapped() {
+	if v.typ_.IsWrapped() {
 		if v.flag&flagIndir != 0 && v.Kind() == abi.Struct {
-			cv := jsType(v.typ).Call("zero")
-			abi.CopyStruct(cv, v.object(), v.typ)
-			return any(unsafe.Pointer(jsType(v.typ).New(cv).Unsafe()))
+			cv := jsType(v.typ_).Call("zero")
+			abi.CopyStruct(cv, v.object(), v.typ_)
+			return any(unsafe.Pointer(jsType(v.typ_).New(cv).Unsafe()))
 		}
-		return any(unsafe.Pointer(jsType(v.typ).New(v.object()).Unsafe()))
+		return any(unsafe.Pointer(jsType(v.typ_).New(v.object()).Unsafe()))
 	}
 	return any(unsafe.Pointer(v.object().Unsafe()))
 }
@@ -161,8 +160,8 @@ func makeMethodValue(op string, v Value) Value {
 
 	fn := methodReceiver(op, v, int(v.flag)>>flagMethodShift)
 	rcvr := v.object()
-	if v.typ.IsWrapped() {
-		rcvr = jsType(v.typ).New(rcvr)
+	if v.typ_.IsWrapped() {
+		rcvr = jsType(v.typ_).New(rcvr)
 	}
 	fv := js.MakeFunc(func(this *js.Object, arguments []*js.Object) any {
 		return js.InternalObject(fn).Call("apply", rcvr, arguments)

--- a/compiler/natives/src/internal/reflectlite/value.go
+++ b/compiler/natives/src/internal/reflectlite/value.go
@@ -3,32 +3,35 @@
 package reflectlite
 
 import (
-	"unsafe"
-
 	"internal/abi"
+	"unsafe"
 
 	"github.com/gopherjs/gopherjs/js"
 )
 
+func (v Value) typ() *abi.Type {
+	return v.typ_
+}
+
 //gopherjs:new
 func (v Value) object() *js.Object {
-	if v.typ.Kind() == abi.Array || v.typ.Kind() == abi.Struct {
+	if v.typ_.Kind() == abi.Array || v.typ_.Kind() == abi.Struct {
 		return js.InternalObject(v.ptr)
 	}
 	if v.flag&flagIndir != 0 {
 		val := js.InternalObject(v.ptr).Call("$get")
-		if val != js.Global.Get("$ifaceNil") && val.Get("constructor") != jsType(v.typ) {
-			switch v.typ.Kind() {
+		if val != js.Global.Get("$ifaceNil") && val.Get("constructor") != jsType(v.typ_) {
+			switch v.typ_.Kind() {
 			case abi.Uint64, abi.Int64:
-				val = jsType(v.typ).New(val.Get("$high"), val.Get("$low"))
+				val = jsType(v.typ_).New(val.Get("$high"), val.Get("$low"))
 			case abi.Complex64, abi.Complex128:
-				val = jsType(v.typ).New(val.Get("$real"), val.Get("$imag"))
+				val = jsType(v.typ_).New(val.Get("$real"), val.Get("$imag"))
 			case abi.Slice:
 				if val == val.Get("constructor").Get("nil") {
-					val = jsType(v.typ).Get("nil")
+					val = jsType(v.typ_).Get("nil")
 					break
 				}
-				newVal := jsType(v.typ).New(val.Get("$array"))
+				newVal := jsType(v.typ_).New(val.Get("$array"))
 				newVal.Set("$offset", val.Get("$offset"))
 				newVal.Set("$length", val.Get("$length"))
 				newVal.Set("$capacity", val.Get("$capacity"))
@@ -46,14 +49,14 @@ func (v Value) assignTo(context string, dst *abi.Type, target unsafe.Pointer) Va
 		v = makeMethodValue(context, v)
 	}
 	switch {
-	case directlyAssignable(dst, v.typ):
+	case directlyAssignable(dst, v.typ_):
 		// Overwrite type so that they match.
 		// Same memory layout, so no harm done.
 		fl := v.flag&(flagAddr|flagIndir) | v.flag.ro()
 		fl |= flag(dst.Kind())
 		return Value{dst, v.ptr, fl}
 
-	case implements(dst, v.typ):
+	case implements(dst, v.typ_):
 		if target == nil {
 			target = unsafe_New(dst)
 		}
@@ -70,14 +73,14 @@ func (v Value) assignTo(context string, dst *abi.Type, target unsafe.Pointer) Va
 	}
 
 	// Failed.
-	panic(context + ": value of type " + v.typ.String() + " is not assignable to type " + dst.String())
+	panic(context + ": value of type " + v.typ_.String() + " is not assignable to type " + dst.String())
 }
 
 //gopherjs:replace
 func (v Value) IsNil() bool {
 	switch k := v.kind(); k {
 	case abi.Pointer, abi.Slice:
-		return v.object() == jsType(v.typ).Get("nil")
+		return v.object() == jsType(v.typ_).Get("nil")
 	case abi.Chan:
 		return v.object() == js.Global.Get("$chanNil")
 	case abi.Func:
@@ -113,15 +116,15 @@ func (v Value) Len() int {
 func (v Value) Set(x Value) {
 	v.mustBeAssignable()
 	x.mustBeExported()
-	x = x.assignTo("reflect.Set", v.typ, nil)
+	x = x.assignTo("reflect.Set", v.typ_, nil)
 	if v.flag&flagIndir != 0 {
-		switch v.typ.Kind() {
+		switch v.typ_.Kind() {
 		case abi.Array:
-			jsType(v.typ).Call("copy", js.InternalObject(v.ptr), js.InternalObject(x.ptr))
+			jsType(v.typ_).Call("copy", js.InternalObject(v.ptr), js.InternalObject(x.ptr))
 		case abi.Interface:
 			js.InternalObject(v.ptr).Call("$set", js.InternalObject(valueInterface(x)))
 		case abi.Struct:
-			abi.CopyStruct(js.InternalObject(v.ptr), js.InternalObject(x.ptr), v.typ)
+			abi.CopyStruct(js.InternalObject(v.ptr), js.InternalObject(x.ptr), v.typ_)
 		default:
 			js.InternalObject(v.ptr).Call("$set", x.object())
 		}
@@ -138,15 +141,15 @@ func (v Value) Elem() Value {
 		if val == js.Global.Get("$ifaceNil") {
 			return Value{}
 		}
-		typ := abi.ReflectType(val.Get("constructor"))
-		return makeValue(typ, val.Get("$val"), v.flag.ro())
+		typ_ := abi.ReflectType(val.Get("constructor"))
+		return makeValue(typ_, val.Get("$val"), v.flag.ro())
 
 	case abi.Pointer:
 		if v.IsNil() {
 			return Value{}
 		}
 		val := v.object()
-		tt := (*abi.PtrType)(unsafe.Pointer(v.typ))
+		tt := (*abi.PtrType)(unsafe.Pointer(v.typ_))
 		fl := v.flag&flagRO | flagIndir | flagAddr
 		fl |= flag(tt.Elem.Kind())
 		return Value{tt.Elem, unsafe.Pointer(abi.WrapJsObject(tt.Elem, val).Unsafe()), fl}
@@ -164,3 +167,6 @@ func unpackEface(i any) Value
 
 //gopherjs:purge Unused method for emptyInterface
 func packEface(v Value) any
+
+//gopherjs:purge Problematic without pointers
+func noescape(p unsafe.Pointer) unsafe.Pointer


### PR DESCRIPTION
The `reflectlite` package had some minor changes, mostly `typ` -> `typ_`. This change will unblock several other packages that have failures hidden by this change.

CI will not pass yet since this is part of the go1.22 update, however this will make the following pass
```bash
go install . && gopherjs test -v internal/reflectlite
```

related to #1334